### PR TITLE
feat: add platform package manager UI

### DIFF
--- a/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+++ b/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
@@ -280,6 +280,22 @@ function Show-PlatformPackageManager
             }
         }
 
+        function Write-PlatformPackageManagerResultTable
+        {
+            param(
+                [Parameter()]
+                [Object[]]$InputObject = @()
+            )
+
+            $records = @($InputObject | Where-Object { $null -ne $_ })
+            if ($records.Count -eq 0)
+            {
+                return
+            }
+
+            $records | Format-Table -AutoSize | Out-String | Write-Host
+        }
+
         function Invoke-PlatformPackageManagerInstalledBrowser
         {
             $includePackage = @(Read-PlatformPackageManagerList -Prompt 'Installed package filter (comma-separated, optional)')
@@ -290,7 +306,8 @@ function Show-PlatformPackageManager
             $parameters.ExcludePackage = $excludePackage
             Add-PlatformPackageManagerPickerParameters -Parameters $parameters
 
-            Show-InstalledPlatformPackage @parameters
+            $result = @(Show-InstalledPlatformPackage @parameters)
+            Write-PlatformPackageManagerResultTable -InputObject $result
         }
 
         function Invoke-PlatformPackageManagerSearch
@@ -310,7 +327,8 @@ function Show-PlatformPackageManager
             $parameters.Top = $Top
             Add-PlatformPackageManagerPickerParameters -Parameters $parameters
 
-            Find-PlatformPackage @parameters
+            $result = @(Find-PlatformPackage @parameters)
+            Write-PlatformPackageManagerResultTable -InputObject $result
         }
 
         function Invoke-PlatformPackageManagerDirectInstall
@@ -356,7 +374,8 @@ function Show-PlatformPackageManager
                 $parameters.NoSudo = $true
             }
 
-            Install-PlatformPackage @parameters
+            $result = @(Install-PlatformPackage @parameters)
+            Write-PlatformPackageManagerResultTable -InputObject $result
         }
 
         function Invoke-PlatformPackageManagerUpgrade
@@ -386,7 +405,8 @@ function Show-PlatformPackageManager
                 $parameters.NoSudo = $true
             }
 
-            Upgrade-PlatformPackage @parameters
+            $result = @(Upgrade-PlatformPackage @parameters)
+            Write-PlatformPackageManagerResultTable -InputObject $result
         }
 
         function Invoke-PlatformPackageManagerRemoval
@@ -415,7 +435,8 @@ function Show-PlatformPackageManager
                 $parameters.NoSudo = $true
             }
 
-            Remove-PlatformPackage @parameters
+            $result = @(Remove-PlatformPackage @parameters)
+            Write-PlatformPackageManagerResultTable -InputObject $result
         }
 
         function Invoke-PlatformPackageManagerDependencyView
@@ -442,8 +463,7 @@ function Show-PlatformPackageManager
                 return @()
             }
 
-            $records | Format-Table Package, Direction, Relationship, RelatedPackage, DependencyType, Installed -AutoSize | Out-String | Write-Host
-            return $records
+            Write-PlatformPackageManagerResultTable -InputObject $records
         }
 
         function Write-PlatformPackageManagerMenu

--- a/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+++ b/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
@@ -52,9 +52,8 @@ function Show-PlatformPackageManager
         Opens the menu and forwards SkipRefresh and NoSudo to workflows that support them.
 
     .OUTPUTS
-        System.Management.Automation.PSCustomObject
-        Returns summary objects emitted by the underlying install, upgrade, remove, or
-        dependency commands. Menu-only and cancelled interactive workflows return no output.
+        None. Results emitted by underlying package workflows are rendered inside the
+        manager UI as formatted tables.
 
     .NOTES
         Author: Jon LaBelle
@@ -65,7 +64,6 @@ function Show-PlatformPackageManager
         https://github.com/jonlabelle/pwsh-profile/blob/main/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
     #>
     [CmdletBinding()]
-    [OutputType([PSCustomObject], [PSCustomObject[]], [Object[]])]
     param(
         [Parameter()]
         [ValidateSet('Auto', 'winget', 'brew', 'apt', 'apk')]
@@ -280,7 +278,58 @@ function Show-PlatformPackageManager
             }
         }
 
-        function Write-PlatformPackageManagerResultTable
+        function Get-PlatformPackageManagerStatusText
+        {
+            $flags = @()
+            if ($NoSudo)
+            {
+                $flags += 'NoSudo'
+            }
+
+            if ($SkipRefresh)
+            {
+                $flags += 'SkipRefresh'
+            }
+
+            if ($UninstallPrevious)
+            {
+                $flags += 'UninstallPrevious'
+            }
+
+            if ($Purge)
+            {
+                $flags += 'Purge'
+            }
+
+            $flagText = if ($flags.Count -gt 0) { $flags -join ', ' } else { 'none' }
+            return "Manager: $PackageManager | Search limit: $Top | Flags: $flagText"
+        }
+
+        function Write-PlatformPackageManagerHeader
+        {
+            param(
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$Title,
+
+                [Parameter()]
+                [String]$Subtitle
+            )
+
+            $rule = '=' * 78
+            Write-Host $rule
+            Write-Host $Title
+            if (-not [String]::IsNullOrWhiteSpace($Subtitle))
+            {
+                Write-Host $Subtitle
+            }
+
+            Write-Host (Get-PlatformPackageManagerStatusText)
+            Write-Host $rule
+            Write-Host ''
+        }
+
+        function Format-PlatformPackageManagerResultTable
         {
             param(
                 [Parameter()]
@@ -290,10 +339,99 @@ function Show-PlatformPackageManager
             $records = @($InputObject | Where-Object { $null -ne $_ })
             if ($records.Count -eq 0)
             {
-                return
+                return ''
             }
 
-            $records | Format-Table -AutoSize | Out-String | Write-Host
+            return ($records | Format-Table -AutoSize | Out-String -Width 4096).TrimEnd()
+        }
+
+        function Get-PlatformPackageManagerActionResult
+        {
+            param(
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$Title,
+
+                [Parameter()]
+                [String]$Message,
+
+                [Parameter()]
+                [Object[]]$Records = @()
+            )
+
+            $recordList = @($Records | Where-Object { $null -ne $_ })
+            return [PSCustomObject]@{
+                PSTypeName = 'PlatformPackageManager.ActionResult'
+                Title = $Title
+                Message = $Message
+                Records = $recordList
+                RecordCount = $recordList.Count
+            }
+        }
+
+        function Read-PlatformPackageManagerNextAction
+        {
+            while ($true)
+            {
+                $value = (Read-PlatformPackageManagerInput -Prompt 'Next action').Trim()
+                if ([String]::IsNullOrWhiteSpace($value) -or $value.ToLowerInvariant() -in @('m', 'menu'))
+                {
+                    return [PSCustomObject]@{
+                        Command = 'Menu'
+                        Choice = ''
+                    }
+                }
+
+                if ($value.ToLowerInvariant() -in @('q', 'quit', 'exit'))
+                {
+                    return [PSCustomObject]@{
+                        Command = 'Quit'
+                        Choice = ''
+                    }
+                }
+
+                if ($value.ToLowerInvariant() -in @('1', '2', '3', '4', '5', '6', 'installed', 'browse', 'search', 'find', 'install', 'upgrade', 'update', 'remove', 'uninstall', 'deps', 'dependencies', 'dependency'))
+                {
+                    return [PSCustomObject]@{
+                        Command = 'Action'
+                        Choice = $value
+                    }
+                }
+
+                Write-Host 'Choose Enter/M for menu, 1-6 for another action, or Q to quit.'
+            }
+        }
+
+        function Show-PlatformPackageManagerResultScreen
+        {
+            param(
+                [Parameter(Mandatory)]
+                [PSCustomObject]$Result
+            )
+
+            Clear-Host
+
+            $recordSummary = if ($Result.RecordCount -eq 1) { '1 record' } else { "$($Result.RecordCount) records" }
+            Write-PlatformPackageManagerHeader -Title $Result.Title -Subtitle "Result: $recordSummary"
+
+            if (-not [String]::IsNullOrWhiteSpace($Result.Message))
+            {
+                Write-Host $Result.Message
+                Write-Host ''
+            }
+
+            if ($Result.RecordCount -gt 0)
+            {
+                $table = Format-PlatformPackageManagerResultTable -InputObject $Result.Records
+                if (-not [String]::IsNullOrWhiteSpace($table))
+                {
+                    Write-Host $table
+                    Write-Host ''
+                }
+            }
+
+            Write-Host 'Enter/M: menu  1-6: run another action  Q: quit'
+            return (Read-PlatformPackageManagerNextAction)
         }
 
         function Invoke-PlatformPackageManagerInstalledBrowser
@@ -307,7 +445,12 @@ function Show-PlatformPackageManager
             Add-PlatformPackageManagerPickerParameters -Parameters $parameters
 
             $result = @(Show-InstalledPlatformPackage @parameters)
-            Write-PlatformPackageManagerResultTable -InputObject $result
+            if ($result.Count -eq 0)
+            {
+                return (Get-PlatformPackageManagerActionResult -Title 'Installed Packages' -Message 'Installed package browser closed.')
+            }
+
+            return (Get-PlatformPackageManagerActionResult -Title 'Installed Packages' -Records $result)
         }
 
         function Invoke-PlatformPackageManagerSearch
@@ -315,8 +458,7 @@ function Show-PlatformPackageManager
             $query = (Read-PlatformPackageManagerInput -Prompt 'Search query').Trim()
             if ([String]::IsNullOrWhiteSpace($query))
             {
-                Write-Host 'Search cancelled; query is required.'
-                return
+                return (Get-PlatformPackageManagerActionResult -Title 'Search Packages' -Message 'Search cancelled; query is required.')
             }
 
             $excludePackage = @(Read-PlatformPackageManagerList -Prompt 'Exclude search results (comma-separated, optional)')
@@ -328,7 +470,12 @@ function Show-PlatformPackageManager
             Add-PlatformPackageManagerPickerParameters -Parameters $parameters
 
             $result = @(Find-PlatformPackage @parameters)
-            Write-PlatformPackageManagerResultTable -InputObject $result
+            if ($result.Count -eq 0)
+            {
+                return (Get-PlatformPackageManagerActionResult -Title 'Search Packages' -Message 'Search completed with no result records.')
+            }
+
+            return (Get-PlatformPackageManagerActionResult -Title 'Search Packages' -Records $result)
         }
 
         function Invoke-PlatformPackageManagerDirectInstall
@@ -355,8 +502,7 @@ function Show-PlatformPackageManager
             $targets = @(Read-PlatformPackageManagerList -Prompt $targetPrompt)
             if ($targets.Count -eq 0)
             {
-                Write-Host 'Install cancelled; at least one package is required.'
-                return
+                return (Get-PlatformPackageManagerActionResult -Title 'Install Packages' -Message 'Install cancelled; at least one package is required.')
             }
 
             $parameters = Get-PlatformPackageManagerCommonParameters
@@ -375,7 +521,12 @@ function Show-PlatformPackageManager
             }
 
             $result = @(Install-PlatformPackage @parameters)
-            Write-PlatformPackageManagerResultTable -InputObject $result
+            if ($result.Count -eq 0)
+            {
+                return (Get-PlatformPackageManagerActionResult -Title 'Install Packages' -Message 'Install completed with no result records.')
+            }
+
+            return (Get-PlatformPackageManagerActionResult -Title 'Install Packages' -Records $result)
         }
 
         function Invoke-PlatformPackageManagerUpgrade
@@ -406,7 +557,12 @@ function Show-PlatformPackageManager
             }
 
             $result = @(Upgrade-PlatformPackage @parameters)
-            Write-PlatformPackageManagerResultTable -InputObject $result
+            if ($result.Count -eq 0)
+            {
+                return (Get-PlatformPackageManagerActionResult -Title 'Upgrade Packages' -Message 'Upgrade completed with no result records.')
+            }
+
+            return (Get-PlatformPackageManagerActionResult -Title 'Upgrade Packages' -Records $result)
         }
 
         function Invoke-PlatformPackageManagerRemoval
@@ -436,7 +592,12 @@ function Show-PlatformPackageManager
             }
 
             $result = @(Remove-PlatformPackage @parameters)
-            Write-PlatformPackageManagerResultTable -InputObject $result
+            if ($result.Count -eq 0)
+            {
+                return (Get-PlatformPackageManagerActionResult -Title 'Remove Packages' -Message 'Removal completed with no result records.')
+            }
+
+            return (Get-PlatformPackageManagerActionResult -Title 'Remove Packages' -Records $result)
         }
 
         function Invoke-PlatformPackageManagerDependencyView
@@ -444,8 +605,7 @@ function Show-PlatformPackageManager
             $package = @(Read-PlatformPackageManagerList -Prompt 'Package name or id (comma-separated)')
             if ($package.Count -eq 0)
             {
-                Write-Host 'Dependency lookup cancelled; at least one package is required.'
-                return
+                return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Message 'Dependency lookup cancelled; at least one package is required.')
             }
 
             $direction = Read-PlatformPackageDependencyDirection
@@ -459,25 +619,25 @@ function Show-PlatformPackageManager
             $records = @(Get-PlatformPackageDependency @parameters)
             if ($records.Count -eq 0)
             {
-                Write-Host 'No dependency relationships were found.'
-                return @()
+                return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Message 'No dependency relationships were found.')
             }
 
-            Write-PlatformPackageManagerResultTable -InputObject $records
+            return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Records $records)
         }
 
         function Write-PlatformPackageManagerMenu
         {
             Clear-Host
-            Write-Host 'Show-PlatformPackageManager'
-            Write-Host ''
-            Write-Host '  1. Browse installed packages'
-            Write-Host '  2. Search packages and install from results'
-            Write-Host '  3. Install package by name or id'
-            Write-Host '  4. Upgrade packages'
-            Write-Host '  5. Remove packages'
-            Write-Host '  6. Inspect package dependencies'
-            Write-Host '  Q. Quit'
+            Write-PlatformPackageManagerHeader -Title 'Platform Package Manager' -Subtitle 'Unified native package management workflows'
+            Write-Host ('{0,-7} {1,-24} {2}' -f 'Action', 'Workflow', 'Purpose')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '------', '--------', '-------')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '[1]', 'Installed packages', 'Browse or filter installed package records')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '[2]', 'Search and install', 'Search the registry and optionally install results')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '[3]', 'Direct install', 'Install package names or ids directly')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '[4]', 'Upgrade packages', 'Review or upgrade outdated packages')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '[5]', 'Remove packages', 'Review or remove installed packages')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '[6]', 'Dependencies', 'Inspect dependency relationships')
+            Write-Host ('{0,-7} {1,-24} {2}' -f '[Q]', 'Quit', 'Exit the manager')
             Write-Host ''
         }
 
@@ -497,7 +657,7 @@ function Show-PlatformPackageManager
                 { $_ -in @('4', 'upgrade', 'update') } { Invoke-PlatformPackageManagerUpgrade; break }
                 { $_ -in @('5', 'remove', 'uninstall') } { Invoke-PlatformPackageManagerRemoval; break }
                 { $_ -in @('6', 'deps', 'dependencies', 'dependency') } { Invoke-PlatformPackageManagerDependencyView; break }
-                default { Write-Host 'Choose 1-6 or Q.' }
+                default { Get-PlatformPackageManagerActionResult -Title 'Platform Package Manager' -Message 'Choose 1-6 or Q.' }
             }
         }
 
@@ -533,10 +693,20 @@ function Show-PlatformPackageManager
 
     process
     {
+        $pendingChoice = ''
+
         while ($true)
         {
-            Write-PlatformPackageManagerMenu
-            $choice = (Read-PlatformPackageManagerInput -Prompt 'Select an action').Trim()
+            if ([String]::IsNullOrWhiteSpace($pendingChoice))
+            {
+                Write-PlatformPackageManagerMenu
+                $choice = (Read-PlatformPackageManagerInput -Prompt 'Select an action').Trim()
+            }
+            else
+            {
+                $choice = $pendingChoice
+                $pendingChoice = ''
+            }
 
             if ($choice.ToLowerInvariant() -in @('q', 'quit', 'exit'))
             {
@@ -548,7 +718,28 @@ function Show-PlatformPackageManager
                 continue
             }
 
-            Invoke-PlatformPackageManagerAction -Choice $choice
+            $actionResult = Invoke-PlatformPackageManagerAction -Choice $choice
+            if ($null -eq $actionResult)
+            {
+                continue
+            }
+
+            $nextAction = Show-PlatformPackageManagerResultScreen -Result $actionResult
+            switch ($nextAction.Command)
+            {
+                'Quit'
+                {
+                    return
+                }
+                'Action'
+                {
+                    $pendingChoice = $nextAction.Choice
+                }
+                default
+                {
+                    $pendingChoice = ''
+                }
+            }
         }
     }
 }

--- a/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+++ b/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
@@ -1,0 +1,534 @@
+function Show-PlatformPackageManager
+{
+    <#
+    .SYNOPSIS
+        Opens a unified console UI for native platform package management.
+
+    .DESCRIPTION
+        Provides one interactive entry point for the platform package management commands
+        backed by winget on Windows, Homebrew on macOS, and apt or apk on Linux.
+
+        The manager delegates to the existing package functions so their object output and
+        automation behavior remain available:
+        - Show-InstalledPlatformPackage for installed package browsing.
+        - Find-PlatformPackage for remote registry search and search-driven installs.
+        - Install-PlatformPackage for direct name or id installs.
+        - Upgrade-PlatformPackage for package upgrades.
+        - Remove-PlatformPackage for package removal.
+        - Get-PlatformPackageDependency for dependency inspection.
+
+    .PARAMETER PackageManager
+        Package manager to use. Auto detects the current platform package manager.
+
+    .PARAMETER Top
+        Maximum number of search results to retrieve for search-driven package actions.
+
+    .PARAMETER SkipRefresh
+        Skips registry refresh when launching the upgrade workflow.
+
+    .PARAMETER UninstallPrevious
+        Passes winget --uninstall-previous when launching the upgrade workflow.
+
+    .PARAMETER Purge
+        Requests package-manager-specific purge or zap behavior when launching removal.
+
+    .PARAMETER NoSudo
+        On Linux package managers that normally require elevated privileges, do not
+        automatically prefix install, upgrade, or removal commands with sudo.
+
+    .EXAMPLE
+        PS > Show-PlatformPackageManager
+
+        Opens the unified package management menu.
+
+    .EXAMPLE
+        PS > Show-PlatformPackageManager -PackageManager brew
+
+        Opens the unified package management menu using Homebrew.
+
+    .EXAMPLE
+        PS > Show-PlatformPackageManager -SkipRefresh -NoSudo
+
+        Opens the menu and forwards SkipRefresh and NoSudo to workflows that support them.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject
+        Returns summary objects emitted by the underlying install, upgrade, remove, or
+        dependency commands. Menu-only and cancelled interactive workflows return no output.
+
+    .NOTES
+        Author: Jon LaBelle
+        License: MIT
+        Source: https://github.com/jonlabelle/pwsh-profile/blob/main/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+
+    .LINK
+        https://github.com/jonlabelle/pwsh-profile/blob/main/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject], [PSCustomObject[]], [Object[]])]
+    param(
+        [Parameter()]
+        [ValidateSet('Auto', 'winget', 'brew', 'apt', 'apk')]
+        [String]$PackageManager = 'Auto',
+
+        [Parameter()]
+        [ValidateRange(0, 500)]
+        [Int32]$Top = 50,
+
+        [Parameter()]
+        [Switch]$SkipRefresh,
+
+        [Parameter()]
+        [Switch]$UninstallPrevious,
+
+        [Parameter()]
+        [Switch]$Purge,
+
+        [Parameter()]
+        [Switch]$NoSudo,
+
+        [Parameter(DontShow = $true)]
+        [ScriptBlock]$CommandRunner,
+
+        [Parameter(DontShow = $true)]
+        [ScriptBlock]$KeyReader,
+
+        [Parameter(DontShow = $true)]
+        [ScriptBlock]$PromptReader,
+
+        [Parameter(DontShow = $true)]
+        [ValidateRange(0, 500)]
+        [Int32]$PickerPageSize = 0
+    )
+
+    begin
+    {
+        function Get-PlatformPackageManagerDependencyPath
+        {
+            param(
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$FunctionName,
+
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$FileName
+            )
+
+            if (Get-Command -Name $FunctionName -ErrorAction SilentlyContinue)
+            {
+                Write-Verbose "$FunctionName is already loaded"
+                return $null
+            }
+
+            $dependencyPath = Join-Path -Path $PSScriptRoot -ChildPath $FileName
+            $dependencyPath = [System.IO.Path]::GetFullPath($dependencyPath)
+            if (-not (Test-Path -Path $dependencyPath -PathType Leaf))
+            {
+                throw "Required function '$FunctionName' could not be found. Expected location: $dependencyPath"
+            }
+
+            return $dependencyPath
+        }
+
+        function Read-PlatformPackageManagerInput
+        {
+            param(
+                [Parameter(Mandatory)]
+                [String]$Prompt
+            )
+
+            if ($PromptReader)
+            {
+                $value = & $PromptReader -Prompt $Prompt
+                if ($null -eq $value)
+                {
+                    return ''
+                }
+
+                return "$value"
+            }
+
+            try
+            {
+                if ([Console]::IsInputRedirected)
+                {
+                    throw 'Console input is redirected.'
+                }
+            }
+            catch
+            {
+                throw 'Interactive package management requires an attached console.'
+            }
+
+            return (Read-Host -Prompt $Prompt)
+        }
+
+        function ConvertFrom-PlatformPackageManagerListInput
+        {
+            param(
+                [Parameter()]
+                [String]$Value
+            )
+
+            if ([String]::IsNullOrWhiteSpace($Value))
+            {
+                return @()
+            }
+
+            return @(
+                $Value -split ',' |
+                ForEach-Object { "$_".Trim() } |
+                Where-Object { -not [String]::IsNullOrWhiteSpace($_) }
+            )
+        }
+
+        function Read-PlatformPackageManagerList
+        {
+            param(
+                [Parameter(Mandatory)]
+                [String]$Prompt
+            )
+
+            $value = Read-PlatformPackageManagerInput -Prompt $Prompt
+            return @(ConvertFrom-PlatformPackageManagerListInput -Value $value)
+        }
+
+        function Read-PlatformPackageManagerYesNo
+        {
+            param(
+                [Parameter(Mandatory)]
+                [String]$Prompt,
+
+                [Parameter()]
+                [Switch]$DefaultYes
+            )
+
+            $suffix = if ($DefaultYes) { 'Y/n' } else { 'y/N' }
+
+            while ($true)
+            {
+                $value = (Read-PlatformPackageManagerInput -Prompt "$Prompt [$suffix]").Trim()
+                if ([String]::IsNullOrWhiteSpace($value))
+                {
+                    return $DefaultYes.IsPresent
+                }
+
+                switch ($value.ToLowerInvariant())
+                {
+                    { $_ -in @('y', 'yes') } { return $true }
+                    { $_ -in @('n', 'no') } { return $false }
+                    default { Write-Host 'Enter y or n.' }
+                }
+            }
+        }
+
+        function Read-PlatformPackageDependencyDirection
+        {
+            while ($true)
+            {
+                Write-Host 'Dependency direction:'
+                Write-Host '  1. Depends on'
+                Write-Host '  2. Required by'
+                Write-Host '  3. Both'
+
+                $value = (Read-PlatformPackageManagerInput -Prompt 'Select direction [1]').Trim()
+                if ([String]::IsNullOrWhiteSpace($value))
+                {
+                    return 'DependsOn'
+                }
+
+                switch ($value.ToLowerInvariant())
+                {
+                    { $_ -in @('1', 'depends', 'dependson', 'depends on') } { return 'DependsOn' }
+                    { $_ -in @('2', 'requiredby', 'required by', 'uses') } { return 'RequiredBy' }
+                    { $_ -in @('3', 'both', 'all') } { return 'Both' }
+                    default { Write-Host 'Choose 1, 2, or 3.' }
+                }
+            }
+        }
+
+        function Get-PlatformPackageManagerCommonParameters
+        {
+            $parameters = @{
+                PackageManager = $PackageManager
+            }
+
+            if ($CommandRunner)
+            {
+                $parameters.CommandRunner = $CommandRunner
+            }
+
+            return $parameters
+        }
+
+        function Add-PlatformPackageManagerPickerParameters
+        {
+            param(
+                [Parameter(Mandatory)]
+                [Hashtable]$Parameters
+            )
+
+            if ($KeyReader)
+            {
+                $Parameters.KeyReader = $KeyReader
+            }
+
+            if ($PickerPageSize -gt 0)
+            {
+                $Parameters.PickerPageSize = $PickerPageSize
+            }
+        }
+
+        function Invoke-PlatformPackageManagerInstalledBrowser
+        {
+            $includePackage = @(Read-PlatformPackageManagerList -Prompt 'Installed package filter (comma-separated, optional)')
+            $excludePackage = @(Read-PlatformPackageManagerList -Prompt 'Exclude installed packages (comma-separated, optional)')
+
+            $parameters = Get-PlatformPackageManagerCommonParameters
+            $parameters.Name = $includePackage
+            $parameters.ExcludePackage = $excludePackage
+            Add-PlatformPackageManagerPickerParameters -Parameters $parameters
+
+            Show-InstalledPlatformPackage @parameters
+        }
+
+        function Invoke-PlatformPackageManagerSearch
+        {
+            $query = (Read-PlatformPackageManagerInput -Prompt 'Search query').Trim()
+            if ([String]::IsNullOrWhiteSpace($query))
+            {
+                Write-Host 'Search cancelled; query is required.'
+                return
+            }
+
+            $excludePackage = @(Read-PlatformPackageManagerList -Prompt 'Exclude search results (comma-separated, optional)')
+
+            $parameters = Get-PlatformPackageManagerCommonParameters
+            $parameters.Query = $query
+            $parameters.ExcludePackage = $excludePackage
+            $parameters.Top = $Top
+            Add-PlatformPackageManagerPickerParameters -Parameters $parameters
+
+            Find-PlatformPackage @parameters
+        }
+
+        function Invoke-PlatformPackageManagerDirectInstall
+        {
+            $installMode = ''
+            while ([String]::IsNullOrWhiteSpace($installMode))
+            {
+                $value = (Read-PlatformPackageManagerInput -Prompt 'Install by name or id? [name]').Trim()
+                if ([String]::IsNullOrWhiteSpace($value))
+                {
+                    $installMode = 'name'
+                    break
+                }
+
+                switch ($value.ToLowerInvariant())
+                {
+                    { $_ -in @('name', 'n') } { $installMode = 'name' }
+                    { $_ -in @('id', 'i') } { $installMode = 'id' }
+                    default { Write-Host 'Enter name or id.' }
+                }
+            }
+
+            $targetPrompt = if ($installMode -eq 'id') { 'Package id(s), comma-separated' } else { 'Package name(s), comma-separated' }
+            $targets = @(Read-PlatformPackageManagerList -Prompt $targetPrompt)
+            if ($targets.Count -eq 0)
+            {
+                Write-Host 'Install cancelled; at least one package is required.'
+                return
+            }
+
+            $parameters = Get-PlatformPackageManagerCommonParameters
+            if ($installMode -eq 'id')
+            {
+                $parameters.Id = $targets
+            }
+            else
+            {
+                $parameters.Name = $targets
+            }
+
+            if ($NoSudo)
+            {
+                $parameters.NoSudo = $true
+            }
+
+            Install-PlatformPackage @parameters
+        }
+
+        function Invoke-PlatformPackageManagerUpgrade
+        {
+            $includePackage = @(Read-PlatformPackageManagerList -Prompt 'Upgrade package filter (comma-separated, optional)')
+            $excludePackage = @(Read-PlatformPackageManagerList -Prompt 'Exclude upgrades (comma-separated, optional)')
+            $all = Read-PlatformPackageManagerYesNo -Prompt 'Upgrade all matching packages without the picker?'
+
+            $parameters = Get-PlatformPackageManagerCommonParameters
+            $parameters.IncludePackage = $includePackage
+            $parameters.ExcludePackage = $excludePackage
+            $parameters.All = $all
+            Add-PlatformPackageManagerPickerParameters -Parameters $parameters
+
+            if ($SkipRefresh)
+            {
+                $parameters.SkipRefresh = $true
+            }
+
+            if ($UninstallPrevious)
+            {
+                $parameters.UninstallPrevious = $true
+            }
+
+            if ($NoSudo)
+            {
+                $parameters.NoSudo = $true
+            }
+
+            Upgrade-PlatformPackage @parameters
+        }
+
+        function Invoke-PlatformPackageManagerRemoval
+        {
+            $includePackage = @(Read-PlatformPackageManagerList -Prompt 'Remove package filter (comma-separated, optional)')
+            $excludePackage = @(Read-PlatformPackageManagerList -Prompt 'Exclude removals (comma-separated, optional)')
+            $all = Read-PlatformPackageManagerYesNo -Prompt 'Remove all matching packages without the picker?'
+
+            if ($all -and $includePackage.Count -eq 0)
+            {
+                Write-Host 'Remove all requires an include filter; opening the picker instead.'
+                $all = $false
+            }
+
+            $usePurge = $Purge -or (Read-PlatformPackageManagerYesNo -Prompt 'Request purge/zap cleanup?')
+
+            $parameters = Get-PlatformPackageManagerCommonParameters
+            $parameters.IncludePackage = $includePackage
+            $parameters.ExcludePackage = $excludePackage
+            $parameters.All = $all
+            $parameters.Purge = $usePurge
+            Add-PlatformPackageManagerPickerParameters -Parameters $parameters
+
+            if ($NoSudo)
+            {
+                $parameters.NoSudo = $true
+            }
+
+            Remove-PlatformPackage @parameters
+        }
+
+        function Invoke-PlatformPackageManagerDependencyView
+        {
+            $package = @(Read-PlatformPackageManagerList -Prompt 'Package name or id (comma-separated)')
+            if ($package.Count -eq 0)
+            {
+                Write-Host 'Dependency lookup cancelled; at least one package is required.'
+                return
+            }
+
+            $direction = Read-PlatformPackageDependencyDirection
+            $installedOnly = Read-PlatformPackageManagerYesNo -Prompt 'Limit related packages to installed packages?'
+
+            $parameters = Get-PlatformPackageManagerCommonParameters
+            $parameters.Package = $package
+            $parameters.Direction = $direction
+            $parameters.InstalledOnly = $installedOnly
+
+            $records = @(Get-PlatformPackageDependency @parameters)
+            if ($records.Count -eq 0)
+            {
+                Write-Host 'No dependency relationships were found.'
+                return @()
+            }
+
+            $records | Format-Table Package, Direction, Relationship, RelatedPackage, DependencyType, Installed -AutoSize | Out-String | Write-Host
+            return $records
+        }
+
+        function Write-PlatformPackageManagerMenu
+        {
+            Clear-Host
+            Write-Host 'Show-PlatformPackageManager'
+            Write-Host ''
+            Write-Host '  1. Browse installed packages'
+            Write-Host '  2. Search packages and install from results'
+            Write-Host '  3. Install package by name or id'
+            Write-Host '  4. Upgrade packages'
+            Write-Host '  5. Remove packages'
+            Write-Host '  6. Inspect package dependencies'
+            Write-Host '  Q. Quit'
+            Write-Host ''
+        }
+
+        function Invoke-PlatformPackageManagerAction
+        {
+            param(
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$Choice
+            )
+
+            switch ($Choice.Trim().ToLowerInvariant())
+            {
+                { $_ -in @('1', 'installed', 'browse') } { Invoke-PlatformPackageManagerInstalledBrowser; break }
+                { $_ -in @('2', 'search', 'find') } { Invoke-PlatformPackageManagerSearch; break }
+                { $_ -in @('3', 'install') } { Invoke-PlatformPackageManagerDirectInstall; break }
+                { $_ -in @('4', 'upgrade', 'update') } { Invoke-PlatformPackageManagerUpgrade; break }
+                { $_ -in @('5', 'remove', 'uninstall') } { Invoke-PlatformPackageManagerRemoval; break }
+                { $_ -in @('6', 'deps', 'dependencies', 'dependency') } { Invoke-PlatformPackageManagerDependencyView; break }
+                default { Write-Host 'Choose 1-6 or Q.' }
+            }
+        }
+
+        $dependencyFiles = @(
+            @{ FunctionName = 'Get-PlatformPackage'; FileName = 'Get-PlatformPackage.ps1' }
+            @{ FunctionName = 'Find-PlatformPackage'; FileName = 'Find-PlatformPackage.ps1' }
+            @{ FunctionName = 'Install-PlatformPackage'; FileName = 'Install-PlatformPackage.ps1' }
+            @{ FunctionName = 'Upgrade-PlatformPackage'; FileName = 'Upgrade-PlatformPackage.ps1' }
+            @{ FunctionName = 'Remove-PlatformPackage'; FileName = 'Remove-PlatformPackage.ps1' }
+            @{ FunctionName = 'Get-PlatformPackageDependency'; FileName = 'Get-PlatformPackageDependency.ps1' }
+            @{ FunctionName = 'Show-InstalledPlatformPackage'; FileName = 'Show-InstalledPlatformPackage.ps1' }
+        )
+
+        foreach ($dependencyFile in $dependencyFiles)
+        {
+            $dependencyPath = Get-PlatformPackageManagerDependencyPath -FunctionName $dependencyFile.FunctionName -FileName $dependencyFile.FileName
+            if ([String]::IsNullOrWhiteSpace($dependencyPath))
+            {
+                continue
+            }
+
+            try
+            {
+                . $dependencyPath
+                Write-Verbose "Loaded $($dependencyFile.FunctionName) from: $dependencyPath"
+            }
+            catch
+            {
+                throw "Failed to load required dependency '$($dependencyFile.FunctionName)' from '$dependencyPath': $($_.Exception.Message)"
+            }
+        }
+    }
+
+    process
+    {
+        while ($true)
+        {
+            Write-PlatformPackageManagerMenu
+            $choice = (Read-PlatformPackageManagerInput -Prompt 'Select an action').Trim()
+
+            if ($choice.ToLowerInvariant() -in @('q', 'quit', 'exit'))
+            {
+                return
+            }
+
+            if ([String]::IsNullOrWhiteSpace($choice))
+            {
+                continue
+            }
+
+            Invoke-PlatformPackageManagerAction -Choice $choice
+        }
+    }
+}

--- a/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+++ b/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
@@ -11,8 +11,8 @@ function Show-PlatformPackageManager
         The manager delegates to the existing package functions so their object output and
         automation behavior remain available:
         - Show-InstalledPlatformPackage for installed package browsing.
-        - Find-PlatformPackage for remote registry search and search-driven installs.
-        - Install-PlatformPackage for direct name or id installs.
+        - Find-PlatformPackage for remote registry search.
+        - Install-PlatformPackage for search-driven and direct name or id installs.
         - Upgrade-PlatformPackage for package upgrades.
         - Remove-PlatformPackage for package removal.
         - Get-PlatformPackageDependency for dependency inspection.
@@ -458,7 +458,7 @@ function Show-PlatformPackageManager
             $query = (Read-PlatformPackageManagerInput -Prompt 'Search query').Trim()
             if ([String]::IsNullOrWhiteSpace($query))
             {
-                return (Get-PlatformPackageManagerActionResult -Title 'Search Packages' -Message 'Search cancelled; query is required.')
+                return (Get-PlatformPackageManagerActionResult -Title 'Search and Install Packages' -Message 'Search cancelled; query is required.')
             }
 
             $excludePackage = @(Read-PlatformPackageManagerList -Prompt 'Exclude search results (comma-separated, optional)')
@@ -469,13 +469,18 @@ function Show-PlatformPackageManager
             $parameters.Top = $Top
             Add-PlatformPackageManagerPickerParameters -Parameters $parameters
 
-            $result = @(Find-PlatformPackage @parameters)
-            if ($result.Count -eq 0)
+            if ($NoSudo)
             {
-                return (Get-PlatformPackageManagerActionResult -Title 'Search Packages' -Message 'Search completed with no result records.')
+                $parameters.NoSudo = $true
             }
 
-            return (Get-PlatformPackageManagerActionResult -Title 'Search Packages' -Records $result)
+            $result = @(Install-PlatformPackage @parameters)
+            if ($result.Count -eq 0)
+            {
+                return (Get-PlatformPackageManagerActionResult -Title 'Search and Install Packages' -Message 'Search completed with no result records.')
+            }
+
+            return (Get-PlatformPackageManagerActionResult -Title 'Search and Install Packages' -Records $result)
         }
 
         function Invoke-PlatformPackageManagerDirectInstall
@@ -611,18 +616,35 @@ function Show-PlatformPackageManager
             $direction = Read-PlatformPackageDependencyDirection
             $installedOnly = Read-PlatformPackageManagerYesNo -Prompt 'Limit related packages to installed packages?'
 
+            if ($PackageManager -eq 'winget' -and $direction -eq 'RequiredBy')
+            {
+                return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Message 'winget does not expose reverse dependency metadata, so RequiredBy dependency lookup is unavailable.')
+            }
+
             $parameters = Get-PlatformPackageManagerCommonParameters
             $parameters.Package = $package
             $parameters.Direction = $direction
             $parameters.InstalledOnly = $installedOnly
 
             $records = @(Get-PlatformPackageDependency @parameters)
-            if ($records.Count -eq 0)
+            $wingetReverseDependencyNote = ''
+            if ($PackageManager -eq 'winget' -and $direction -eq 'Both')
             {
-                return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Message 'No dependency relationships were found.')
+                $wingetReverseDependencyNote = 'winget does not expose reverse dependency metadata; RequiredBy results are unavailable.'
             }
 
-            return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Records $records)
+            if ($records.Count -eq 0)
+            {
+                $message = 'No dependency relationships were found.'
+                if (-not [String]::IsNullOrWhiteSpace($wingetReverseDependencyNote))
+                {
+                    $message = "$message $wingetReverseDependencyNote"
+                }
+
+                return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Message $message)
+            }
+
+            return (Get-PlatformPackageManagerActionResult -Title 'Package Dependencies' -Message $wingetReverseDependencyNote -Records $records)
         }
 
         function Write-PlatformPackageManagerMenu

--- a/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+++ b/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
@@ -36,6 +36,13 @@ function Show-PlatformPackageManager
         On Linux package managers that normally require elevated privileges, do not
         automatically prefix install, upgrade, or removal commands with sudo.
 
+    .PARAMETER WhatIf
+        Shows what install, upgrade, or removal commands would run without invoking the
+        platform package manager.
+
+    .PARAMETER Confirm
+        Prompts before delegated install, upgrade, or removal commands are invoked.
+
     .EXAMPLE
         PS > Show-PlatformPackageManager
 
@@ -63,7 +70,7 @@ function Show-PlatformPackageManager
     .LINK
         https://github.com/jonlabelle/pwsh-profile/blob/main/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     param(
         [Parameter()]
         [ValidateSet('Auto', 'winget', 'brew', 'apt', 'apk')]
@@ -127,6 +134,41 @@ function Show-PlatformPackageManager
             }
 
             return $dependencyPath
+        }
+
+        function Invoke-PlatformPackageManagerFunction
+        {
+            param(
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$FunctionName,
+
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$FileName,
+
+                [Parameter(Mandatory)]
+                [ScriptBlock]$Invocation,
+
+                [Parameter()]
+                [Hashtable]$Parameters = @{}
+            )
+
+            $dependencyPath = Get-PlatformPackageManagerDependencyPath -FunctionName $FunctionName -FileName $FileName
+            if (-not [String]::IsNullOrWhiteSpace($dependencyPath))
+            {
+                try
+                {
+                    . $dependencyPath
+                    Write-Verbose "Loaded $FunctionName from: $dependencyPath"
+                }
+                catch
+                {
+                    throw "Failed to load required dependency '$FunctionName' from '$dependencyPath': $($_.Exception.Message)"
+                }
+            }
+
+            & $Invocation $Parameters
         }
 
         function Read-PlatformPackageManagerInput
@@ -301,8 +343,79 @@ function Show-PlatformPackageManager
                 $flags += 'Purge'
             }
 
+            $managerText = if ($PackageManager -eq 'Auto')
+            {
+                "Auto -> $(Get-PlatformPackageManagerDetectedName)"
+            }
+            else
+            {
+                $PackageManager
+            }
+
             $flagText = if ($flags.Count -gt 0) { $flags -join ', ' } else { 'none' }
-            return "Manager: $PackageManager | Search limit: $Top | Flags: $flagText"
+            return "Manager: $managerText | Search limit: $Top | Flags: $flagText"
+        }
+
+        function Test-PlatformPackageManagerCommandAvailable
+        {
+            param(
+                [Parameter(Mandatory)]
+                [ValidateNotNullOrEmpty()]
+                [String]$Name
+            )
+
+            if ($CommandRunner)
+            {
+                return $PackageManager -ne 'Auto' -and $PackageManager -eq $Name
+            }
+
+            return $null -ne (Get-Command -Name $Name -CommandType Application -ErrorAction SilentlyContinue |
+                Select-Object -First 1)
+        }
+
+        function Get-PlatformPackageManagerDetectedName
+        {
+            if ($PackageManager -ne 'Auto')
+            {
+                return $PackageManager
+            }
+
+            $isWindowsPlatform = if ($PSVersionTable.PSVersion.Major -lt 6) { $true } else { [Bool]$IsWindows }
+            $isMacOSPlatform = if ($PSVersionTable.PSVersion.Major -lt 6) { $false } else { [Bool]$IsMacOS }
+            $isLinuxPlatform = if ($PSVersionTable.PSVersion.Major -lt 6) { $false } else { [Bool]$IsLinux }
+
+            if ($isWindowsPlatform -and (Test-PlatformPackageManagerCommandAvailable -Name 'winget'))
+            {
+                return 'winget'
+            }
+
+            if ($isMacOSPlatform -and (Test-PlatformPackageManagerCommandAvailable -Name 'brew'))
+            {
+                return 'brew'
+            }
+
+            if ($isLinuxPlatform)
+            {
+                if (Test-PlatformPackageManagerCommandAvailable -Name 'apt')
+                {
+                    return 'apt'
+                }
+
+                if (Test-PlatformPackageManagerCommandAvailable -Name 'apk')
+                {
+                    return 'apk'
+                }
+            }
+
+            foreach ($fallbackManager in @('brew', 'winget', 'apt', 'apk'))
+            {
+                if (Test-PlatformPackageManagerCommandAvailable -Name $fallbackManager)
+                {
+                    return $fallbackManager
+                }
+            }
+
+            return 'unresolved'
         }
 
         function Write-PlatformPackageManagerHeader
@@ -342,7 +455,39 @@ function Show-PlatformPackageManager
                 return ''
             }
 
-            return ($records | Format-Table -AutoSize | Out-String -Width 4096).TrimEnd()
+            $displayRecords = @(
+                foreach ($record in $records)
+                {
+                    if ($record.PSObject.Properties['Results'])
+                    {
+                        $record | Select-Object -Property * -ExcludeProperty Results
+                    }
+                    else
+                    {
+                        $record
+                    }
+                }
+            )
+
+            return ($displayRecords | Format-Table -AutoSize | Out-String -Width 4096).TrimEnd()
+        }
+
+        function Get-PlatformPackageManagerNestedResults
+        {
+            param(
+                [Parameter()]
+                [Object[]]$InputObject = @()
+            )
+
+            @(
+                foreach ($record in @($InputObject | Where-Object { $null -ne $_ }))
+                {
+                    if ($record.PSObject.Properties['Results'] -and $null -ne $record.Results)
+                    {
+                        @($record.Results | Where-Object { $null -ne $_ })
+                    }
+                }
+            )
         }
 
         function Get-PlatformPackageManagerActionResult
@@ -428,6 +573,19 @@ function Show-PlatformPackageManager
                     Write-Host $table
                     Write-Host ''
                 }
+
+                $detailRecords = @(Get-PlatformPackageManagerNestedResults -InputObject $Result.Records)
+                if ($detailRecords.Count -gt 0)
+                {
+                    Write-Host 'Details'
+                    Write-Host ('-' * 78)
+                    $detailTable = Format-PlatformPackageManagerResultTable -InputObject $detailRecords
+                    if (-not [String]::IsNullOrWhiteSpace($detailTable))
+                    {
+                        Write-Host $detailTable
+                        Write-Host ''
+                    }
+                }
             }
 
             Write-Host 'Enter/M: menu  1-6: run another action  Q: quit'
@@ -444,7 +602,10 @@ function Show-PlatformPackageManager
             $parameters.ExcludePackage = $excludePackage
             Add-PlatformPackageManagerPickerParameters -Parameters $parameters
 
-            $result = @(Show-InstalledPlatformPackage @parameters)
+            $result = @(Invoke-PlatformPackageManagerFunction -FunctionName 'Show-InstalledPlatformPackage' -FileName 'Show-InstalledPlatformPackage.ps1' -Parameters $parameters -Invocation {
+                    param([Hashtable]$InvocationParameters)
+                    Show-InstalledPlatformPackage @InvocationParameters
+                })
             if ($result.Count -eq 0)
             {
                 return (Get-PlatformPackageManagerActionResult -Title 'Installed Packages' -Message 'Installed package browser closed.')
@@ -474,7 +635,10 @@ function Show-PlatformPackageManager
                 $parameters.NoSudo = $true
             }
 
-            $result = @(Install-PlatformPackage @parameters)
+            $result = @(Invoke-PlatformPackageManagerFunction -FunctionName 'Install-PlatformPackage' -FileName 'Install-PlatformPackage.ps1' -Parameters $parameters -Invocation {
+                    param([Hashtable]$InvocationParameters)
+                    Install-PlatformPackage @InvocationParameters
+                })
             if ($result.Count -eq 0)
             {
                 return (Get-PlatformPackageManagerActionResult -Title 'Search and Install Packages' -Message 'Search completed with no result records.')
@@ -525,7 +689,10 @@ function Show-PlatformPackageManager
                 $parameters.NoSudo = $true
             }
 
-            $result = @(Install-PlatformPackage @parameters)
+            $result = @(Invoke-PlatformPackageManagerFunction -FunctionName 'Install-PlatformPackage' -FileName 'Install-PlatformPackage.ps1' -Parameters $parameters -Invocation {
+                    param([Hashtable]$InvocationParameters)
+                    Install-PlatformPackage @InvocationParameters
+                })
             if ($result.Count -eq 0)
             {
                 return (Get-PlatformPackageManagerActionResult -Title 'Install Packages' -Message 'Install completed with no result records.')
@@ -561,7 +728,10 @@ function Show-PlatformPackageManager
                 $parameters.NoSudo = $true
             }
 
-            $result = @(Upgrade-PlatformPackage @parameters)
+            $result = @(Invoke-PlatformPackageManagerFunction -FunctionName 'Upgrade-PlatformPackage' -FileName 'Upgrade-PlatformPackage.ps1' -Parameters $parameters -Invocation {
+                    param([Hashtable]$InvocationParameters)
+                    Upgrade-PlatformPackage @InvocationParameters
+                })
             if ($result.Count -eq 0)
             {
                 return (Get-PlatformPackageManagerActionResult -Title 'Upgrade Packages' -Message 'Upgrade completed with no result records.')
@@ -596,7 +766,10 @@ function Show-PlatformPackageManager
                 $parameters.NoSudo = $true
             }
 
-            $result = @(Remove-PlatformPackage @parameters)
+            $result = @(Invoke-PlatformPackageManagerFunction -FunctionName 'Remove-PlatformPackage' -FileName 'Remove-PlatformPackage.ps1' -Parameters $parameters -Invocation {
+                    param([Hashtable]$InvocationParameters)
+                    Remove-PlatformPackage @InvocationParameters
+                })
             if ($result.Count -eq 0)
             {
                 return (Get-PlatformPackageManagerActionResult -Title 'Remove Packages' -Message 'Removal completed with no result records.')
@@ -626,7 +799,10 @@ function Show-PlatformPackageManager
             $parameters.Direction = $direction
             $parameters.InstalledOnly = $installedOnly
 
-            $records = @(Get-PlatformPackageDependency @parameters)
+            $records = @(Invoke-PlatformPackageManagerFunction -FunctionName 'Get-PlatformPackageDependency' -FileName 'Get-PlatformPackageDependency.ps1' -Parameters $parameters -Invocation {
+                    param([Hashtable]$InvocationParameters)
+                    Get-PlatformPackageDependency @InvocationParameters
+                })
             $wingetReverseDependencyNote = ''
             if ($PackageManager -eq 'winget' -and $direction -eq 'Both')
             {
@@ -683,34 +859,6 @@ function Show-PlatformPackageManager
             }
         }
 
-        $dependencyFiles = @(
-            @{ FunctionName = 'Get-PlatformPackage'; FileName = 'Get-PlatformPackage.ps1' }
-            @{ FunctionName = 'Find-PlatformPackage'; FileName = 'Find-PlatformPackage.ps1' }
-            @{ FunctionName = 'Install-PlatformPackage'; FileName = 'Install-PlatformPackage.ps1' }
-            @{ FunctionName = 'Upgrade-PlatformPackage'; FileName = 'Upgrade-PlatformPackage.ps1' }
-            @{ FunctionName = 'Remove-PlatformPackage'; FileName = 'Remove-PlatformPackage.ps1' }
-            @{ FunctionName = 'Get-PlatformPackageDependency'; FileName = 'Get-PlatformPackageDependency.ps1' }
-            @{ FunctionName = 'Show-InstalledPlatformPackage'; FileName = 'Show-InstalledPlatformPackage.ps1' }
-        )
-
-        foreach ($dependencyFile in $dependencyFiles)
-        {
-            $dependencyPath = Get-PlatformPackageManagerDependencyPath -FunctionName $dependencyFile.FunctionName -FileName $dependencyFile.FileName
-            if ([String]::IsNullOrWhiteSpace($dependencyPath))
-            {
-                continue
-            }
-
-            try
-            {
-                . $dependencyPath
-                Write-Verbose "Loaded $($dependencyFile.FunctionName) from: $dependencyPath"
-            }
-            catch
-            {
-                throw "Failed to load required dependency '$($dependencyFile.FunctionName)' from '$dependencyPath': $($_.Exception.Message)"
-            }
-        }
     }
 
     process

--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ The profile includes utility functions organized by category:
 - **[`Get-SystemInfo`](Functions/SystemAdministration/Get-SystemInfo.ps1)** — Gets system information from local or remote computers
 - **[`Get-PlatformPackage`](Functions/SystemAdministration/Get-PlatformPackage.ps1)** — Gets installed platform packages from winget, brew, apt, or apk
 - **[`Get-PlatformPackageDependency`](Functions/SystemAdministration/Get-PlatformPackageDependency.ps1)** — Shows package deps relationships with winget, brew, apt, or apk
+- **[`Show-PlatformPackageManager`](Functions/SystemAdministration/Show-PlatformPackageManager.ps1)** — Opens a unified UI for platform package search, install, upgrade, removal, and dependency workflows
 - **[`Show-InstalledPlatformPackage`](Functions/SystemAdministration/Show-InstalledPlatformPackage.ps1)** — Displays installed platform packages in an interactive browser
 - **[`Find-PlatformPackage`](Functions/SystemAdministration/Find-PlatformPackage.ps1)** — Searches native platform package registries with winget, brew, apt, or apk
 - **[`Install-PlatformPackage`](Functions/SystemAdministration/Install-PlatformPackage.ps1)** — Installs platform packages by query, name, id, or piped search result

--- a/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     $Global:ProgressPreference = 'SilentlyContinue'
 
     . "$PSScriptRoot/../../../Functions/SystemAdministration/Show-PlatformPackageManager.ps1"
+    . "$PSScriptRoot/../../../Functions/SystemAdministration/Install-PlatformPackage.ps1"
 
     function Get-TestCommandResponse
     {
@@ -61,7 +62,7 @@ BeforeAll {
 
     $script:NewPromptReader = {
         param(
-            [Parameter(Mandatory)]
+            [Parameter()]
             [String[]]$Values
         )
 
@@ -135,6 +136,74 @@ Describe 'Show-PlatformPackageManager' {
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Insta\s*lled' } -Times 1
     }
 
+    It 'routes search installs through Install-PlatformPackage with NoSudo forwarded' {
+        Mock -CommandName Install-PlatformPackage -MockWith {
+            [PSCustomObject]@{
+                PackageManager = 'apt'
+                PackageManagerDisplayName = 'APT'
+                TotalMatched = 1
+                Selected = 1
+                NotSelected = 0
+                Installed = 1
+                Skipped = 0
+                Failed = 0
+                Results = @()
+            }
+        }
+        $promptReader = & $script:NewPromptReader @('2', 'git', '', 'q')
+
+        $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
+
+        $result.Count | Should -Be 0
+        Assert-MockCalled -CommandName Install-PlatformPackage -ParameterFilter {
+            $Query -eq 'git' -and
+            $PackageManager -eq 'apt' -and
+            $NoSudo -and
+            $Top -eq 50
+        } -Times 1
+    }
+
+    It 'routes upgrade options and forwards winget uninstall-previous' {
+        $runner = & $script:NewPackageCommandRunner @{
+            'winget upgrade --accept-source-agreements --output json' = Get-TestCommandResponse -ExitCode 1 -Output @('Unrecognized argument: --output')
+            'winget upgrade --accept-source-agreements' = Get-TestCommandResponse -Output @(
+                'Name               Id                          Version Available Source'
+                '-----------------------------------------------------------------------'
+                'Git                Git.Git                     2.43.0  2.44.0    winget'
+            )
+            'winget upgrade --id Git.Git --exact --accept-package-agreements --accept-source-agreements --uninstall-previous' = Get-TestCommandResponse -Output @('winget upgrade output')
+        }
+        $promptReader = & $script:NewPromptReader @('4', 'Git', '', 'y', 'q')
+
+        $result = @(Show-PlatformPackageManager -PackageManager winget -SkipRefresh -UninstallPrevious -CommandRunner $runner -PromptReader $promptReader)
+
+        $result.Count | Should -Be 0
+        ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --accept-package-agreements --accept-source-agreements --uninstall-previous' }).StreamOutput | Should -BeTrue
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget upgrade output' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded' } -Times 1
+    }
+
+    It 'routes remove options and forwards purge behavior' {
+        $runner = & $script:NewPackageCommandRunner @{
+            'brew list --formula --versions' = Get-TestCommandResponse -Output @()
+            'brew list --cask --versions' = Get-TestCommandResponse -Output @('visual-studio-code 1.89.0')
+            'brew uninstall --cask --zap visual-studio-code' = Get-TestCommandResponse -Output @('brew zap output')
+        }
+        $promptReader = & $script:NewPromptReader @('5', 'visual-studio-code', '', 'y', 'q')
+
+        $result = @(
+            & {
+                $ConfirmPreference = 'None'
+                Show-PlatformPackageManager -PackageManager brew -Purge -CommandRunner $runner -PromptReader $promptReader
+            }
+        )
+
+        $result.Count | Should -Be 0
+        ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall --cask --zap visual-studio-code' }).StreamOutput | Should -BeTrue
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Removed' } -Times 1
+    }
+
     It 'shows dependency records from the manager' {
         $runner = & $script:NewPackageCommandRunner @{
             'brew deps --direct git' = Get-TestCommandResponse -Output @('gettext')
@@ -146,6 +215,15 @@ Describe 'Show-PlatformPackageManager' {
         $result.Count | Should -Be 0
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Relationship*' } -Times 1
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
+    }
+
+    It 'explains that winget reverse dependency lookup is unavailable' {
+        $promptReader = & $script:NewPromptReader @('6', 'Git.Git', '2', 'n', 'q')
+
+        $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
+
+        $result.Count | Should -Be 0
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*winget does not expose reverse dependency metadata*' } -Times 1
     }
 
     It 'keeps action results on a dedicated screen until the next action is chosen' {

--- a/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
@@ -130,10 +130,10 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -CommandRunner $runner -PromptReader $promptReader)
 
-        $result.Count | Should -Be 1
-        $result[0].Installed | Should -Be 1
+        $result.Count | Should -Be 0
         ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
+        ($script:HostOutput -join "`n") | Should -Match 'Insta\s*lled'
     }
 
     It 'shows dependency records from the manager' {
@@ -144,9 +144,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
-        $result.Count | Should -Be 1
-        $result[0].Package | Should -Be 'git'
-        $result[0].RelatedPackage | Should -Be 'gettext'
+        $result.Count | Should -Be 0
+        ($script:HostOutput -join "`n") | Should -BeLike '*Relationship*'
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
     }
 }

--- a/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
@@ -87,8 +87,7 @@ BeforeAll {
 Describe 'Show-PlatformPackageManager' {
     BeforeEach {
         $script:Invocations = New-Object 'System.Collections.Generic.List[Object]'
-        $script:HostOutput = New-Object 'System.Collections.Generic.List[Object]'
-        Mock -CommandName Write-Host -MockWith { $script:HostOutput.Add($Object) }
+        Mock -CommandName Write-Host -MockWith {}
         Mock -CommandName Clear-Host -MockWith {}
     }
 
@@ -98,9 +97,9 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-PlatformPackageManager' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq '  1. Browse installed packages' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq '  6. Inspect package dependencies' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Installed packages*' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Dependencies*' } -Times 1
     }
 
     It 'routes installed package browsing through Show-InstalledPlatformPackage' {
@@ -133,7 +132,7 @@ Describe 'Show-PlatformPackageManager' {
         $result.Count | Should -Be 0
         ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
-        ($script:HostOutput -join "`n") | Should -Match 'Insta\s*lled'
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Insta\s*lled' } -Times 1
     }
 
     It 'shows dependency records from the manager' {
@@ -145,7 +144,21 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        ($script:HostOutput -join "`n") | Should -BeLike '*Relationship*'
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Relationship*' } -Times 1
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
+    }
+
+    It 'keeps action results on a dedicated screen until the next action is chosen' {
+        $runner = & $script:NewPackageCommandRunner @{
+            'brew deps --direct git' = Get-TestCommandResponse -Output @('gettext')
+        }
+        $promptReader = & $script:NewPromptReader @('6', 'git', '1', 'n', 'q')
+
+        $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
+
+        $result.Count | Should -Be 0
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Package Dependencies' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter/M: menu  1-6: run another action  Q: quit' } -Times 1
     }
 }

--- a/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
@@ -99,8 +99,16 @@ Describe 'Show-PlatformPackageManager' {
 
         $result.Count | Should -Be 0
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like 'Manager: Auto -> *' } -Times 1
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Installed packages*' } -Times 1
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Dependencies*' } -Times 1
+    }
+
+    It 'exposes ShouldProcess safety switches for delegated operations' {
+        $command = Get-Command -Name Show-PlatformPackageManager
+
+        $command.Parameters.Keys | Should -Contain 'WhatIf'
+        $command.Parameters.Keys | Should -Contain 'Confirm'
     }
 
     It 'routes installed package browsing through Show-InstalledPlatformPackage' {
@@ -134,6 +142,7 @@ Describe 'Show-PlatformPackageManager' {
         ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
         Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Insta\s*lled' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Details' } -Times 1
     }
 
     It 'routes search installs through Install-PlatformPackage with NoSudo forwarded' {

--- a/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
@@ -1,0 +1,152 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $Global:ProgressPreference = 'SilentlyContinue'
+
+    . "$PSScriptRoot/../../../Functions/SystemAdministration/Show-PlatformPackageManager.ps1"
+
+    function Get-TestCommandResponse
+    {
+        param(
+            [Parameter()]
+            [Int32]$ExitCode = 0,
+
+            [Parameter()]
+            [String[]]$Output = @()
+        )
+
+        [PSCustomObject]@{
+            ExitCode = $ExitCode
+            Output = @($Output)
+        }
+    }
+
+    $script:NewPackageCommandRunner = {
+        param(
+            [Parameter(Mandatory)]
+            [Hashtable]$Responses
+        )
+
+        $localResponses = $Responses
+        $localInvocations = $script:Invocations
+
+        return {
+            param(
+                [Parameter(Mandatory)]
+                [String]$Command,
+
+                [Parameter()]
+                [String[]]$Arguments = @(),
+
+                [Parameter()]
+                [Switch]$StreamOutput
+            )
+
+            $key = "$Command $($Arguments -join ' ')".Trim()
+            $localInvocations.Add([PSCustomObject]@{
+                    Command = $Command
+                    Arguments = @($Arguments)
+                    Key = $key
+                    StreamOutput = $StreamOutput.IsPresent
+                })
+
+            if ($localResponses.ContainsKey($key))
+            {
+                return $localResponses[$key]
+            }
+
+            return Get-TestCommandResponse -ExitCode 127 -Output @("Unexpected command: $key")
+        }.GetNewClosure()
+    }
+
+    $script:NewPromptReader = {
+        param(
+            [Parameter(Mandatory)]
+            [String[]]$Values
+        )
+
+        $queue = [System.Collections.Generic.Queue[String]]::new()
+        $Values | ForEach-Object { $queue.Enqueue($_) }
+
+        return {
+            param(
+                [Parameter()]
+                [String]$Prompt
+            )
+
+            if ($queue.Count -eq 0)
+            {
+                throw "Unexpected prompt: $Prompt"
+            }
+
+            return $queue.Dequeue()
+        }.GetNewClosure()
+    }
+}
+
+Describe 'Show-PlatformPackageManager' {
+    BeforeEach {
+        $script:Invocations = New-Object 'System.Collections.Generic.List[Object]'
+        $script:HostOutput = New-Object 'System.Collections.Generic.List[Object]'
+        Mock -CommandName Write-Host -MockWith { $script:HostOutput.Add($Object) }
+        Mock -CommandName Clear-Host -MockWith {}
+    }
+
+    It 'renders the unified menu and exits when quit is selected' {
+        $promptReader = & $script:NewPromptReader @('q')
+
+        $result = @(Show-PlatformPackageManager -PromptReader $promptReader)
+
+        $result.Count | Should -Be 0
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-PlatformPackageManager' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq '  1. Browse installed packages' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq '  6. Inspect package dependencies' } -Times 1
+    }
+
+    It 'routes installed package browsing through Show-InstalledPlatformPackage' {
+        $runner = & $script:NewPackageCommandRunner @{
+            'brew list --formula --versions' = Get-TestCommandResponse -Output @('git 2.44.0', 'gh 2.50.0')
+            'brew list --cask --versions' = Get-TestCommandResponse -Output @()
+        }
+        $promptReader = & $script:NewPromptReader @('1', 'g*', 'gh', 'q')
+        $keyReader = {
+            [System.ConsoleKeyInfo]::new([Char]3, [ConsoleKey]::C, $false, $false, $true)
+        }
+
+        $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
+
+        $result.Count | Should -Be 0
+        @($script:Invocations | Where-Object { $_.Key -eq 'brew list --formula --versions' }).Count | Should -Be 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage - Homebrew' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*git*' } -Times 1
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*gh*' } -Times 0
+    }
+
+    It 'installs a direct package id from the manager' {
+        $runner = & $script:NewPackageCommandRunner @{
+            'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' = Get-TestCommandResponse -Output @('winget install output')
+        }
+        $promptReader = & $script:NewPromptReader @('3', 'id', 'Git.Git', 'q')
+
+        $result = @(Show-PlatformPackageManager -PackageManager winget -CommandRunner $runner -PromptReader $promptReader)
+
+        $result.Count | Should -Be 1
+        $result[0].Installed | Should -Be 1
+        ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
+    }
+
+    It 'shows dependency records from the manager' {
+        $runner = & $script:NewPackageCommandRunner @{
+            'brew deps --direct git' = Get-TestCommandResponse -Output @('gettext')
+        }
+        $promptReader = & $script:NewPromptReader @('6', 'git', '1', 'n', 'q')
+
+        $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
+
+        $result.Count | Should -Be 1
+        $result[0].Package | Should -Be 'git'
+        $result[0].RelatedPackage | Should -Be 'gettext'
+        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
+    }
+}


### PR DESCRIPTION
## Summary
- add `Show-PlatformPackageManager` as a unified console menu for platform package browsing, search/install, direct install, upgrade, removal, and dependency inspection
- rework the manager around dedicated menu and result screens so returned records never fall through under the next menu render
- support delegated `-WhatIf`/`-Confirm`, lazy-load action dependencies, and show nested per-package result details
- route search installs through `Install-PlatformPackage -Query` so install flags such as `-NoSudo` are honored
- clarify unsupported winget reverse dependency lookups and show the detected backend when `-PackageManager Auto` is used
- render action result sets through `Format-Table -AutoSize` inside the manager UI, with an explicit footer for menu, next action, or quit
- keep existing PlatformPackage cmdlets as delegated workflows so scriptable object contracts remain intact
- document the new entry point and cover manager routing/result-screen behavior with unit tests

## Validation
- `Invoke-Pester` for PlatformPackage unit tests: 81 passed
- `Invoke-ScriptAnalyzer -Settings PSScriptAnalyzerSettings.psd1 -Path . -Recurse`
- Full unit suite was run earlier; one pre-existing DNS casing test failed in `Tests/Unit/NetworkAndDns/Test-DnsNameResolution.Tests.ps1` and reproduced when run alone