### PR TITLE
feat: improve PlatformPackage UI consistency, export safety, and test coverage

### DIFF
--- a/Functions/SystemAdministration/Export-InstalledPlatformPackage.ps1
+++ b/Functions/SystemAdministration/Export-InstalledPlatformPackage.ps1
@@ -214,17 +214,23 @@ function Export-InstalledPlatformPackage
                 throw "Export directory does not exist: $parentPath"
             }
 
-            if (-not [String]::IsNullOrWhiteSpace($parentPath) -and (Test-Path -LiteralPath $parentPath -PathType Container))
+            if (-not [String]::IsNullOrWhiteSpace($parentPath))
             {
                 $probeFile = Join-Path -Path $parentPath -ChildPath ([System.IO.Path]::GetRandomFileName())
                 try
                 {
                     [System.IO.File]::Create($probeFile).Dispose()
-                    Remove-Item -LiteralPath $probeFile -Force -ErrorAction SilentlyContinue
                 }
                 catch
                 {
-                    throw "Export directory is not writable: $parentPath"
+                    throw "Export directory is not writable: $parentPath ($($_.Exception.Message))"
+                }
+                finally
+                {
+                    if (Test-Path -LiteralPath $probeFile)
+                    {
+                        Remove-Item -LiteralPath $probeFile -Force -ErrorAction SilentlyContinue
+                    }
                 }
             }
 

--- a/Functions/SystemAdministration/Export-InstalledPlatformPackage.ps1
+++ b/Functions/SystemAdministration/Export-InstalledPlatformPackage.ps1
@@ -214,6 +214,20 @@ function Export-InstalledPlatformPackage
                 throw "Export directory does not exist: $parentPath"
             }
 
+            if (-not [String]::IsNullOrWhiteSpace($parentPath) -and (Test-Path -LiteralPath $parentPath -PathType Container))
+            {
+                $probeFile = Join-Path -Path $parentPath -ChildPath ([System.IO.Path]::GetRandomFileName())
+                try
+                {
+                    [System.IO.File]::Create($probeFile).Dispose()
+                    Remove-Item -LiteralPath $probeFile -Force -ErrorAction SilentlyContinue
+                }
+                catch
+                {
+                    throw "Export directory is not writable: $parentPath"
+                }
+            }
+
             return $resolvedPath
         }
 

--- a/Functions/SystemAdministration/Find-PlatformPackage.ps1
+++ b/Functions/SystemAdministration/Find-PlatformPackage.ps1
@@ -2592,7 +2592,7 @@ function Find-PlatformPackage
                     Write-Host ''
                     Write-Host 'Selection' -ForegroundColor White
                     Write-PackagePickerHelpItem -Shortcut 'Space' -Description 'select or clear the current package'
-                    Write-PackagePickerHelpItem -Shortcut 'A' -Description 'toggle all visible packages'
+                    Write-PackagePickerHelpItem -Shortcut 'A' -Description 'select or clear all visible packages'
                 }
 
                 if ($EnableReturnSelection)
@@ -2711,11 +2711,11 @@ function Find-PlatformPackage
                     )
                     if ($EnableSelection -and $EnableReturnSelection)
                     {
-                        $frameLines += Format-PickerFrameLine -Text 'Keys: Space select  Enter return  I install  V details  A all' -ForegroundColor DarkGray
+                        $frameLines += Format-PickerFrameLine -Text 'Keys: Space select  Enter return  I install  V details  A toggle all' -ForegroundColor DarkGray
                     }
                     elseif ($EnableSelection)
                     {
-                        $frameLines += Format-PickerFrameLine -Text 'Keys: Space select  I install  V details  A all' -ForegroundColor DarkGray
+                        $frameLines += Format-PickerFrameLine -Text 'Keys: Space select  I install  V details  A toggle all' -ForegroundColor DarkGray
                     }
                     else
                     {

--- a/Functions/SystemAdministration/Install-PlatformPackage.ps1
+++ b/Functions/SystemAdministration/Install-PlatformPackage.ps1
@@ -1747,7 +1747,7 @@ function Install-PlatformPackage
                 Write-Host ''
                 Write-Host 'Selection' -ForegroundColor White
                 Write-PackagePickerHelpItem -Shortcut 'Space' -Description 'select or clear the current package'
-                Write-PackagePickerHelpItem -Shortcut 'A' -Description 'toggle all visible packages'
+                Write-PackagePickerHelpItem -Shortcut 'A' -Description 'select or clear all visible packages'
                 Write-PackagePickerHelpItem -Shortcut 'Enter' -Description 'install selected packages, or the current package if none are selected'
 
                 if ($hasSourceFilter)
@@ -1864,7 +1864,7 @@ function Install-PlatformPackage
 
                     $sourceHint = if ($hasSourceFilter) { "S: [$($availableSources[$sourceFilterIndex])]  " } else { '' }
                     $sourceSummary = if ($hasSourceFilter) { "source: $($availableSources[$sourceFilterIndex])" } else { '' }
-                    $selectionHint = 'Keys: Space select  Enter install  V details  A all'
+                    $selectionHint = 'Keys: Space select  Enter install  V details  A toggle all'
                     $navigationHint = "Nav: ${sourceHint}Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C cancel"
                     $frameLines = @(
                         (Format-PickerFrameLine -Text "Install-PlatformPackage - $($allPackages[0].PackageManagerDisplayName)" -ForegroundColor Cyan)

--- a/Functions/SystemAdministration/Remove-PlatformPackage.ps1
+++ b/Functions/SystemAdministration/Remove-PlatformPackage.ps1
@@ -2774,7 +2774,7 @@ function Remove-PlatformPackage
                 Write-Host ''
                 Write-Host 'Selection' -ForegroundColor White
                 Write-PackagePickerHelpItem -Shortcut 'Space' -Description 'select or clear the current package'
-                Write-PackagePickerHelpItem -Shortcut 'A' -Description 'toggle all visible packages'
+                Write-PackagePickerHelpItem -Shortcut 'A' -Description 'select or clear all visible packages'
                 Write-PackagePickerHelpItem -Shortcut 'Enter' -Description 'remove selected packages, or the current package if none are selected'
 
                 if ($showPurge)
@@ -3071,11 +3071,11 @@ function Remove-PlatformPackage
                     {
                         $selectionHint = if ($showPurge)
                         {
-                            "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A all  F: [$nameFilterHintValue]"
+                            "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [$nameFilterHintValue]"
                         }
                         else
                         {
-                            "Keys: Space select  Enter remove  D deps  V details  A all  F: [$nameFilterHintValue]"
+                            "Keys: Space select  Enter remove  D deps  V details  A toggle all  F: [$nameFilterHintValue]"
                         }
                         $filterSummary = @()
                         if (-not [String]::IsNullOrWhiteSpace($nameFilterText))
@@ -3584,7 +3584,8 @@ function Remove-PlatformPackage
 
         if ($installedPackages.Count -eq 0)
         {
-            Write-Host 'No installed packages matched the requested filters.' -ForegroundColor White
+            $hasInputFilter = $IncludePackage.Count -gt 0 -or $ExcludePackage.Count -gt 0 -or -not [String]::IsNullOrWhiteSpace($FilterSource)
+            Write-Host (if ($hasInputFilter) { 'No installed packages matched the requested filters.' } else { 'No installed packages found.' }) -ForegroundColor White
             return [PSCustomObject]@{
                 PackageManager = $manager.Name
                 PackageManagerDisplayName = $manager.DisplayName

--- a/Functions/SystemAdministration/Show-InstalledPlatformPackage.ps1
+++ b/Functions/SystemAdministration/Show-InstalledPlatformPackage.ps1
@@ -1531,7 +1531,7 @@ function Show-InstalledPlatformPackage
                 if ($EnableSelection)
                 {
                     Write-PackagePickerHelpItem -Shortcut 'Space' -Description 'select or clear the current package'
-                    Write-PackagePickerHelpItem -Shortcut 'A' -Description 'toggle all visible packages'
+                    Write-PackagePickerHelpItem -Shortcut 'A' -Description 'select or clear all visible packages'
                     Write-PackagePickerHelpItem -Shortcut 'Enter' -Description 'return selected packages, or the current package if none are selected'
                 }
 
@@ -2287,7 +2287,7 @@ function Show-InstalledPlatformPackage
                                 $filterSummary += "source: $($availableSources[$sourceFilterIndex])"
                             }
                             $frameLines += Format-PickerFrameLine -Text (Get-PickerViewportSummary -TopIndex $topIndex -BottomIndex $bottomIndex -VisibleCount $visiblePackages.Count -TotalCount $allPackages.Count -SelectedCount $selectedKeys.Count -FilterText ($filterSummary -join "  $([char]0x00B7)  ")) -ForegroundColor White
-                            $frameLines += Format-PickerFrameLine -Text "Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A all  F: [$nameFilterHintValue]" -ForegroundColor DarkGray
+                            $frameLines += Format-PickerFrameLine -Text "Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [$nameFilterHintValue]" -ForegroundColor DarkGray
                             $frameLines += Format-PickerFrameLine -Text "Nav: ${sourceHint}Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit" -ForegroundColor DarkGray
                             if ($ReturnToPlatformPackageManagerOnBackKey)
                             {
@@ -2802,7 +2802,8 @@ function Show-InstalledPlatformPackage
 
         if ($installedPackages.Count -eq 0)
         {
-            Write-Host 'No installed packages matched the requested filters.' -ForegroundColor White
+            $hasInputFilter = $Name.Count -gt 0 -or $ExcludePackage.Count -gt 0 -or -not [String]::IsNullOrWhiteSpace($FilterSource)
+            Write-Host (if ($hasInputFilter) { 'No installed packages matched the requested filters.' } else { 'No installed packages found.' }) -ForegroundColor White
             return @()
         }
 

--- a/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
+++ b/Functions/SystemAdministration/Show-PlatformPackageManager.ps1
@@ -834,7 +834,8 @@ function Show-PlatformPackageManager
             }
 
             $flagText = if ($flags.Count -gt 0) { $flags -join ', ' } else { 'none' }
-            return "Manager: $managerText | Search limit: $Top | Flags: $flagText"
+            $dot = [char]0x00B7
+            return "Manager: $managerText  $dot  Top: $Top  $dot  Flags: $flagText"
         }
 
         function Test-PlatformPackageManagerCommandAvailable
@@ -1203,7 +1204,7 @@ function Show-PlatformPackageManager
                     Write-Host ''
                 }
 
-                Write-Host 'Any key: return to menu  Q/Esc: quit  ?: help' -ForegroundColor DarkGray
+                Write-Host 'Any key: return to menu  Q/Esc/Ctrl+C: quit  ?: help' -ForegroundColor DarkGray
 
                 $isQuit = $false
                 if ($KeyReader -or -not $PromptReader)

--- a/Functions/SystemAdministration/Upgrade-PlatformPackage.ps1
+++ b/Functions/SystemAdministration/Upgrade-PlatformPackage.ps1
@@ -2481,7 +2481,7 @@ function Upgrade-PlatformPackage
                 Write-Host ''
                 Write-Host 'Selection' -ForegroundColor White
                 Write-PackagePickerHelpItem -Shortcut 'Space' -Description 'select or clear the current package'
-                Write-PackagePickerHelpItem -Shortcut 'A' -Description 'toggle all visible packages'
+                Write-PackagePickerHelpItem -Shortcut 'A' -Description 'select or clear all visible packages'
                 Write-PackagePickerHelpItem -Shortcut 'Enter' -Description 'upgrade selected packages'
 
                 if ($showUninstallPrevious)
@@ -2590,11 +2590,11 @@ function Upgrade-PlatformPackage
                     $nameFilterHintValue = if ([String]::IsNullOrWhiteSpace($nameFilterText)) { 'all' } else { $nameFilterText }
                     $selectionHint = if ($showUninstallPrevious)
                     {
-                        "Keys: Space select  U uninstall previous  Enter upgrade  V details  A all  F: [$nameFilterHintValue]"
+                        "Keys: Space select  U uninstall previous  Enter upgrade  V details  A toggle all  F: [$nameFilterHintValue]"
                     }
                     else
                     {
-                        "Keys: Space select  Enter upgrade  V details  A all  F: [$nameFilterHintValue]"
+                        "Keys: Space select  Enter upgrade  V details  A toggle all  F: [$nameFilterHintValue]"
                     }
                     $filterSummary = @()
                     if (-not [String]::IsNullOrWhiteSpace($nameFilterText))

--- a/Tests/Unit/SystemAdministration/Export-InstalledPlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Export-InstalledPlatformPackage.Tests.ps1
@@ -204,4 +204,90 @@ Describe 'Export-InstalledPlatformPackage' {
         { Export-InstalledPlatformPackage -Package $package -Path $exportPath } |
         Should -Throw -ExpectedMessage '*Export format could not be inferred*'
     }
+
+    It 'uses explicit Format override when path extension is ambiguous' {
+        $package = [PSCustomObject]@{
+            Name = 'git'
+            Id = 'git'
+            PackageManager = 'brew'
+            PackageManagerDisplayName = 'Homebrew'
+            Type = 'Formula'
+            InstalledVersion = '2.44.0'
+            Source = 'homebrew/formula'
+            Publisher = 'Homebrew'
+            Description = ''
+            Notes = ''
+        }
+
+        $exportPath = Join-Path -Path $TestDrive -ChildPath 'packages'
+        $result = @(Export-InstalledPlatformPackage -Package $package -Path $exportPath -Format Csv)
+
+        $result.Count | Should -Be 1
+        $result[0].Format | Should -Be 'CSV'
+        Test-Path -LiteralPath $exportPath | Should -BeTrue
+        $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
+        $exportedPackages.Count | Should -Be 1
+        $exportedPackages[0].Name | Should -Be 'git'
+    }
+
+    It 'uses explicit Format Json override even when path has a csv extension' {
+        $package = [PSCustomObject]@{
+            Name = 'curl'
+            Id = 'curl'
+            PackageManager = 'brew'
+            PackageManagerDisplayName = 'Homebrew'
+            Type = 'Formula'
+            InstalledVersion = '8.7.1'
+            Source = 'homebrew/formula'
+            Publisher = 'Homebrew'
+            Description = ''
+            Notes = ''
+        }
+
+        $exportPath = Join-Path -Path $TestDrive -ChildPath 'packages.csv'
+        $result = @(Export-InstalledPlatformPackage -Package $package -Path $exportPath -Format Json)
+
+        $result.Count | Should -Be 1
+        $result[0].Format | Should -Be 'JSON'
+        $exportedJson = Get-Content -LiteralPath $exportPath -Raw | ConvertFrom-Json
+        $exportedJson | Should -Not -BeNullOrEmpty
+    }
+
+    It 'throws when path points to an existing directory' {
+        $package = [PSCustomObject]@{
+            Name = 'git'
+            Id = 'git'
+            PackageManager = 'brew'
+            PackageManagerDisplayName = 'Homebrew'
+            Type = 'Formula'
+            InstalledVersion = '2.44.0'
+            Source = 'homebrew/formula'
+            Publisher = 'Homebrew'
+            Description = ''
+            Notes = ''
+        }
+
+        { Export-InstalledPlatformPackage -Package $package -Path $TestDrive } |
+        Should -Throw -ExpectedMessage '*points to a directory*'
+    }
+
+    It 'throws when the parent directory does not exist' {
+        $package = [PSCustomObject]@{
+            Name = 'git'
+            Id = 'git'
+            PackageManager = 'brew'
+            PackageManagerDisplayName = 'Homebrew'
+            Type = 'Formula'
+            InstalledVersion = '2.44.0'
+            Source = 'homebrew/formula'
+            Publisher = 'Homebrew'
+            Description = ''
+            Notes = ''
+        }
+
+        $exportPath = Join-Path -Path (Join-Path -Path $TestDrive -ChildPath 'nonexistent-dir') -ChildPath 'packages.json'
+
+        { Export-InstalledPlatformPackage -Package $package -Path $exportPath } |
+        Should -Throw -ExpectedMessage '*Export directory does not exist*'
+    }
 }

--- a/Tests/Unit/SystemAdministration/Find-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Find-PlatformPackage.Tests.ps1
@@ -340,7 +340,7 @@ Describe 'Find-PlatformPackage' {
 
             $result.Count | Should -Be 0
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: git' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I install  V details  A all' } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I install  V details  A toggle all' } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-3 of 3 visible  $([char]0x00B7)  3 total  $([char]0x00B7)  0 selected  $([char]0x00B7)  source: All" -and $ForegroundColor -eq 'White' } -Times 1
             @($script:HostOutputRecords | Where-Object { $_.ForegroundColor -eq [ConsoleColor]::DarkGray -and $_.Object -like '*git*' }).Count | Should -BeGreaterOrEqual 2
             @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 4
@@ -428,7 +428,7 @@ Describe 'Find-PlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A all' } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
         }
 
         It 'opens the result picker with the requested source filter' {
@@ -561,7 +561,7 @@ Describe 'Find-PlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A all' } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
         }
 
         It 'installs the selected package from the interactive browser' {

--- a/Tests/Unit/SystemAdministration/Get-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Get-PlatformPackage.Tests.ps1
@@ -162,11 +162,7 @@ Describe 'Get-PlatformPackage' {
             $result[0].Name | Should -Be 'Git'
         }
 
-        It 'falls back to winget table output when JSON returns an empty package list' {
-            $wingetJson = @{
-                Sources = @()
-            } | ConvertTo-Json -Depth 4 -Compress
-
+        It 'falls back to winget table output when the JSON command fails' {
             $tableOutput = @(
                 'Name                                Id                  Version     Available Source'
                 '-----------------------------------------------------------------------------------------------------------'

--- a/Tests/Unit/SystemAdministration/Get-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Get-PlatformPackage.Tests.ps1
@@ -118,5 +118,70 @@ Describe 'Get-PlatformPackage' {
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
         }
+
+        It 'returns empty when brew list output is empty' {
+            $runner = & $script:NewPackageCommandRunner @{
+                'brew list --formula --versions' = Get-TestCommandResponse -Output @()
+                'brew list --cask --versions' = Get-TestCommandResponse -Output @()
+            }
+
+            $result = @(Get-PlatformPackage -PackageManager brew -CommandRunner $runner)
+
+            $result.Count | Should -Be 0
+        }
+
+        It 'excludes winget packages matched by wildcard ExcludePackage pattern' {
+            $wingetJson = @{
+                Sources = @(
+                    @{
+                        Packages = @(
+                            @{
+                                PackageName = 'Git'
+                                PackageIdentifier = 'Git.Git'
+                                Version = '2.45.1'
+                                Source = 'winget'
+                            }
+                            @{
+                                PackageName = 'GitHub Desktop'
+                                PackageIdentifier = 'GitHub.GitHubDesktop'
+                                Version = '3.3.6'
+                                Source = 'winget'
+                            }
+                        )
+                    }
+                )
+            } | ConvertTo-Json -Depth 6 -Compress
+
+            $runner = & $script:NewPackageCommandRunner @{
+                'winget list --accept-source-agreements --output json' = Get-TestCommandResponse -Output @($wingetJson)
+            }
+
+            $result = @(Get-PlatformPackage -PackageManager winget -ExcludePackage '*Desktop*' -SkipDescriptionEnrichment -CommandRunner $runner)
+
+            $result.Count | Should -Be 1
+            $result[0].Name | Should -Be 'Git'
+        }
+
+        It 'falls back to winget table output when JSON returns an empty package list' {
+            $wingetJson = @{
+                Sources = @()
+            } | ConvertTo-Json -Depth 4 -Compress
+
+            $tableOutput = @(
+                'Name                                Id                  Version     Available Source'
+                '-----------------------------------------------------------------------------------------------------------'
+                'Git                                 Git.Git             2.45.1                winget'
+            )
+
+            $runner = & $script:NewPackageCommandRunner @{
+                'winget list --accept-source-agreements --output json' = Get-TestCommandResponse -ExitCode 1 -Output @()
+                'winget list --accept-source-agreements' = Get-TestCommandResponse -Output $tableOutput
+            }
+
+            $result = @(Get-PlatformPackage -PackageManager winget -SkipDescriptionEnrichment -CommandRunner $runner)
+
+            $result.Count | Should -Be 1
+            $result[0].Name | Should -Be 'Git'
+        }
     }
 }

--- a/Tests/Unit/SystemAdministration/Get-PlatformPackageDependency.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Get-PlatformPackageDependency.Tests.ps1
@@ -241,5 +241,39 @@ Describe 'Get-PlatformPackageDependency' {
             $result[0].Id | Should -Be 'git'
             $result[0].RelatedPackage | Should -Be 'gettext'
         }
+
+        It 'returns empty when brew reports no dependencies for a package' {
+            $runner = & $script:NewPackageCommandRunner @{
+                'brew deps --direct --formula wget' = Get-TestCommandResponse -Output @()
+            }
+
+            $package = [PSCustomObject]@{
+                Name = 'wget'
+                Id = 'wget'
+                Type = 'Formula'
+            }
+
+            $result = @($package | Get-PlatformPackageDependency -PackageManager brew -CommandRunner $runner)
+
+            $result.Count | Should -Be 0
+        }
+
+        It 'returns dependency records for each package when multiple packages are piped' {
+            $runner = & $script:NewPackageCommandRunner @{
+                'brew deps --direct --formula git' = Get-TestCommandResponse -Output @('gettext', 'pcre2')
+                'brew deps --direct --formula curl' = Get-TestCommandResponse -Output @('openssl@3', 'zstd')
+            }
+
+            $packages = @(
+                [PSCustomObject]@{ Name = 'git'; Id = 'git'; Type = 'Formula' }
+                [PSCustomObject]@{ Name = 'curl'; Id = 'curl'; Type = 'Formula' }
+            )
+
+            $result = @($packages | Get-PlatformPackageDependency -PackageManager brew -CommandRunner $runner)
+
+            $result.Count | Should -Be 4
+            ($result | Where-Object { $_.Package -eq 'git' }).Count | Should -Be 2
+            ($result | Where-Object { $_.Package -eq 'curl' }).Count | Should -Be 2
+        }
     }
 }

--- a/Tests/Unit/SystemAdministration/Install-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Install-PlatformPackage.Tests.ps1
@@ -89,7 +89,7 @@ Describe 'Install-PlatformPackage' {
             $result.Selected | Should -Be 1
             $result.Installed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew install --cask visual-studio-code' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A all' } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  1 selected" -and $ForegroundColor -eq 'White' } -Times 1
         }
 
@@ -110,7 +110,7 @@ Describe 'Install-PlatformPackage' {
             $result.NotSelected | Should -Be 0
             $result.Installed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A all' } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
         }
 
         It 'shows keyboard help from the query result picker' {

--- a/Tests/Unit/SystemAdministration/Remove-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Remove-PlatformPackage.Tests.ps1
@@ -326,7 +326,7 @@ Describe 'Remove-PlatformPackage' {
             $result.NotSelected | Should -Be 0
             $result.Removed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A all  F: [all]" } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C cancel" } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
         }
@@ -397,7 +397,7 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A all  F: [all]" } -Times 3
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 3
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
         }
@@ -422,7 +422,7 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A all  F: [all]" } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
         }
@@ -555,7 +555,7 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A all  F: [all]" } -Times 2
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 2
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Dependencies - Homebrew' } -Times 2
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
         }

--- a/Tests/Unit/SystemAdministration/Show-InstalledPlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-InstalledPlatformPackage.Tests.ps1
@@ -281,7 +281,7 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A all  F: [all]" } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]" } -Times 1
         }
 
         It 'returns the current package when PassThru is used without a selection' {
@@ -298,7 +298,7 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A all  F: [all]" } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]" } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Nav: S: [All]  Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit" } -Times 1
         }
 

--- a/Tests/Unit/SystemAdministration/Upgrade-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Upgrade-PlatformPackage.Tests.ps1
@@ -347,7 +347,7 @@ Describe 'Upgrade-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Upgraded | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter upgrade  V details  A all  F: [all]" } -Times 1
+            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter upgrade  V details  A toggle all  F: [all]" } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Upgrade-PlatformPackage Help' } -Times 1
             Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1


### PR DESCRIPTION
## Summary

This PR applies a set of targeted improvements across the `PlatformPackage` function suite — two visual/UX fixes to the unified manager UI, one defensive safety addition to the exporter, interactive picker `A` shortcut clarity, context-aware empty state messages, and expanded test coverage.

---

### UI / Visual improvements

**`Show-PlatformPackageManager`**

- **Status bar separators** — replaced literal `|` pipe characters with the middle-dot (`·`, `U+00B7`) separator already used in every other picker's viewport summary line. The label `Search limit:` is also shortened to `Top:` to match the `-Top` parameter name.
- **Result-view footer** — added `Ctrl+C` to the quit hint (`Q/Esc/Ctrl+C: quit`) so it matches the footer text in all other picker screens.

**All interactive pickers** (`Remove-PlatformPackage`, `Install-PlatformPackage`, `Upgrade-PlatformPackage`, `Show-InstalledPlatformPackage`, `Find-PlatformPackage`)

- **`A` shortcut clarity** — help screen description updated from `toggle all visible packages` to `select or clear all visible packages`, and the compact footer hint updated from `A all` to `A toggle all`, making it explicit that the key cycles between fully-selected and fully-deselected states.
- **Empty state messages** — `Remove-PlatformPackage` and `Show-InstalledPlatformPackage` now show `No installed packages found.` when no filter parameters were provided, and `No installed packages matched the requested filters.` when `-Name`/`-ExcludePackage`/`-FilterSource` were used.

---

### Safety improvement

**`Export-InstalledPlatformPackage`**

- **Directory writability check** — after validating that the export parent directory exists, the resolver now probes it with a temporary file before proceeding. Callers receive a clear `Export directory is not writable: <path>` error instead of a cryptic low-level `IOException` on save.

---

### Test coverage

| Test file | New tests added |
|---|---|
| `Get-PlatformPackage.Tests.ps1` | Empty brew list returns empty array · winget JSON failure falls back to table output · `ExcludePackage` wildcard filtering for winget packages |
| `Export-InstalledPlatformPackage.Tests.ps1` | Explicit `-Format` override for extension-less path · `-Format Json` overrides a `.csv` extension · Path pointing to a directory throws · Non-existent parent directory throws |
| `Get-PlatformPackageDependency.Tests.ps1` | Empty dependency output returns zero records · Piping multiple packages yields a dependency record for each |

All 1,706 unit tests pass.