### PR TITLE
test: upgrade to pester6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install Pester module
         if: steps.cache-psmodules.outputs.cache-hit != 'true'
         shell: pwsh
-        run: Install-Module Pester -MinimumVersion '5.0.0' -MaximumVersion '5.99.99' -Force -SkipPublisherCheck -ErrorAction Stop
+        run: Install-Module Pester -MinimumVersion '6.0.0' -Force -SkipPublisherCheck -ErrorAction Stop
 
       - name: Run PSScriptAnalyzer
         shell: pwsh
@@ -184,7 +184,7 @@ jobs:
       - name: Install Pester module
         if: steps.cache-psmodules.outputs.cache-hit != 'true'
         shell: powershell
-        run: Install-Module Pester -MinimumVersion '5.0.0' -MaximumVersion '5.99.99' -Force -SkipPublisherCheck -ErrorAction Stop
+        run: Install-Module Pester -MinimumVersion '6.0.0' -Force -SkipPublisherCheck -ErrorAction Stop
 
       - name: Run PSScriptAnalyzer
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install Pester module
         if: steps.cache-psmodules.outputs.cache-hit != 'true'
         shell: pwsh
-        run: Install-Module Pester -MinimumVersion '6.0.0' -Force -SkipPublisherCheck -ErrorAction Stop
+        run: Install-Module Pester -MinimumVersion '6.0.0' -MaximumVersion '6.999.999' -Force -SkipPublisherCheck -ErrorAction Stop
 
       - name: Run PSScriptAnalyzer
         shell: pwsh
@@ -184,7 +184,7 @@ jobs:
       - name: Install Pester module
         if: steps.cache-psmodules.outputs.cache-hit != 'true'
         shell: powershell
-        run: Install-Module Pester -MinimumVersion '6.0.0' -Force -SkipPublisherCheck -ErrorAction Stop
+        run: Install-Module Pester -MinimumVersion '6.0.0' -MaximumVersion '6.999.999' -Force -SkipPublisherCheck -ErrorAction Stop
 
       - name: Run PSScriptAnalyzer
         shell: powershell

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - ".github/workflows/**"
   schedule:
-    - cron: "0 0 * * 1"  # Weekly on Monday at midnight UTC
+    - cron: "0 0 * * 1" # Weekly on Monday at midnight UTC
   workflow_dispatch:
 
 # Cancel any in-progress runs when a new commit is pushed
@@ -35,6 +35,8 @@ jobs:
         uses: github/codeql-action/init@main
         with:
           languages: actions
+          build-mode: none
+          queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@main

--- a/Invoke-Tests.ps1
+++ b/Invoke-Tests.ps1
@@ -77,7 +77,7 @@
 
 .NOTES
     Requires Pester 6.x to be installed:
-        Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck
+        Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force -SkipPublisherCheck
 #>
 
 [CmdletBinding()]
@@ -139,12 +139,12 @@ $TestTimingSummaryScriptPath = Join-Parts -BasePath $ScriptDirectory -PathSegmen
 # Import Pester if not already loaded
 if (-not (Get-Module Pester -ListAvailable))
 {
-    Write-Error 'Pester module is not installed. Please install Pester 6.x: Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck'
+    Write-Error 'Pester module is not installed. Please install Pester 6.x: Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force -SkipPublisherCheck'
     exit 1
 }
 
 $availablePesterModules = Get-Module Pester -ListAvailable | Sort-Object Version -Descending
-$compatiblePesterModules = $availablePesterModules | Where-Object { $_.Version.Major -ge 6 }
+$compatiblePesterModules = $availablePesterModules | Where-Object { $_.Version.Major -eq 6 }
 $selectedPesterModule = $compatiblePesterModules | Select-Object -First 1
 
 if (-not $selectedPesterModule)
@@ -155,7 +155,7 @@ No compatible Pester version is available.
 This test suite requires Pester 6.x.
 
 Please install Pester 6.x:
-    Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck
+    Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force -SkipPublisherCheck
 
 Available Pester versions:
 $($availablePesterModules | ForEach-Object { "  - $($_.Version.ToString()) at $($_.ModuleBase)" } | Out-String)
@@ -188,7 +188,7 @@ Write-Host "Running $TestType tests from: $($testPathsToRun -join ', ')" -Foregr
 # Verify the imported Pester version
 $installedPesterVersion = (Get-Module Pester).Version
 
-if ($installedPesterVersion -and $installedPesterVersion.Major -lt 6)
+if ($installedPesterVersion -and $installedPesterVersion.Major -ne 6)
 {
     Write-Error @"
 Pester version $($installedPesterVersion.ToString()) is not supported.
@@ -197,7 +197,7 @@ This test suite requires Pester 6.x.
 
 Please install Pester 6.x:
 
-    Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck
+    Install-Module -Name Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999 -Force -SkipPublisherCheck
 
 Current Pester installation: $($selectedPesterModule.ModuleBase)
 "@

--- a/Invoke-Tests.ps1
+++ b/Invoke-Tests.ps1
@@ -4,17 +4,14 @@
     Runs Pester tests for the PowerShell Profile project with cross-version compatibility.
 
 .DESCRIPTION
-    This script runs unit and integration tests using Pester, automatically detecting
-    the installed Pester version and using the appropriate syntax for compatibility
-    with Pester 4.x and 5.x.
+    This script runs unit and integration tests using Pester.
 
     Requirements:
-    - Pester 4.0 through 5.x (Pester 3.x and 6.x are not supported)
-    - Test files must be compatible with the installed Pester version
+    - Pester 6.x
+    - Test files must be compatible with Pester 6
 
     Features:
     - Cross-platform compatibility (Windows, macOS, Linux)
-    - Automatic Pester version detection and syntax adaptation
     - Support for unit and integration test separation
     - Configurable output verbosity
     - NUnit XML test results generation
@@ -32,7 +29,7 @@
     - 'Detailed': Comprehensive output including test names and timing (default)
     - 'Diagnostic': Maximum verbosity for debugging
 
-    Note: The actual available output formats depend on the Pester version installed.
+    Supported values: 'Normal', 'Detailed', 'Diagnostic'.
 
 .PARAMETER PassThru
     When specified, returns the Pester test results object for further processing
@@ -79,10 +76,8 @@
     Runs all tests and appends the timing summary to test-timing-summary.md.
 
 .NOTES
-    Requires Pester module to be installed. The script will automatically detect
-    the Pester version and use the appropriate syntax:
-    - Pester 5.x: Uses PesterConfiguration object
-    - Pester 4.x: Uses parameter-based syntax
+    Requires Pester 6.x to be installed:
+        Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck
 #>
 
 [CmdletBinding()]
@@ -144,14 +139,12 @@ $TestTimingSummaryScriptPath = Join-Parts -BasePath $ScriptDirectory -PathSegmen
 # Import Pester if not already loaded
 if (-not (Get-Module Pester -ListAvailable))
 {
-    Write-Error 'Pester module is not installed. Please install Pester 5.x first: Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99 -Force -SkipPublisherCheck'
+    Write-Error 'Pester module is not installed. Please install Pester 6.x: Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck'
     exit 1
 }
 
-# Pester 6 changed mock/assertion behavior used throughout the test suite, so stay
-# on the supported 4.x/5.x range until the tests are migrated intentionally.
 $availablePesterModules = Get-Module Pester -ListAvailable | Sort-Object Version -Descending
-$compatiblePesterModules = $availablePesterModules | Where-Object { $_.Version.Major -ge 4 -and $_.Version.Major -lt 6 }
+$compatiblePesterModules = $availablePesterModules | Where-Object { $_.Version.Major -ge 6 }
 $selectedPesterModule = $compatiblePesterModules | Select-Object -First 1
 
 if (-not $selectedPesterModule)
@@ -159,10 +152,10 @@ if (-not $selectedPesterModule)
     Write-Error @"
 No compatible Pester version is available.
 
-This test suite currently supports Pester 4.x and 5.x. Pester 6.x introduced mock/assertion behavior changes that are not compatible with these tests.
+This test suite requires Pester 6.x.
 
-Please install Pester 5.x:
-    Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99 -Force -SkipPublisherCheck
+Please install Pester 6.x:
+    Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck
 
 Available Pester versions:
 $($availablePesterModules | ForEach-Object { "  - $($_.Version.ToString()) at $($_.ModuleBase)" } | Out-String)
@@ -192,145 +185,62 @@ if (-not $testPathsToRun)
 
 Write-Host "Running $TestType tests from: $($testPathsToRun -join ', ')" -ForegroundColor Green
 
-# Check Pester version and configure accordingly
+# Verify the imported Pester version
 $installedPesterVersion = (Get-Module Pester).Version
-$isPesterVersion5 = $installedPesterVersion -and $installedPesterVersion.Major -eq 5
 
-# Check for unsupported Pester versions
-if ($installedPesterVersion -and ($installedPesterVersion.Major -lt 4 -or $installedPesterVersion.Major -ge 6))
+if ($installedPesterVersion -and $installedPesterVersion.Major -lt 6)
 {
     Write-Error @"
 Pester version $($installedPesterVersion.ToString()) is not supported.
 
-This test suite supports Pester 4.x and 5.x due to the following features and compatibility requirements:
+This test suite requires Pester 6.x.
 
-- BeforeAll/BeforeEach blocks (introduced in Pester 4.0)
-- Improved parameter validation
-- Better cross-platform support
-- Pester 4.x/5.x mock/assertion semantics used by the current tests
+Please install Pester 6.x:
 
-The script attempted to use the latest compatible available version, but an unsupported version was imported.
-
-Please install Pester 5.x:
-
-    Install-Module -Name Pester -MinimumVersion 5.0.0 -MaximumVersion 5.99.99 -Force -SkipPublisherCheck
+    Install-Module -Name Pester -MinimumVersion 6.0.0 -Force -SkipPublisherCheck
 
 Current Pester installation: $($selectedPesterModule.ModuleBase)
 "@
     exit 1
 }
 
-# Validate and map OutputFormat based on Pester version capabilities
-$ValidOutputFormats = if ($isPesterVersion5)
-{
-    @('Normal', 'Detailed', 'Diagnostic')
-}
-else
-{
-    @('Normal', 'Detailed')
-}
+# Validate OutputFormat
+$ValidOutputFormats = @('Normal', 'Detailed', 'Diagnostic')
 
 if ($OutputFormat -notin $ValidOutputFormats)
 {
-    Write-Error "Invalid OutputFormat '$OutputFormat'. Valid values for Pester $($installedPesterVersion.ToString()) are: $($ValidOutputFormats -join ', ')"
+    Write-Error "Invalid OutputFormat '$OutputFormat'. Valid values are: $($ValidOutputFormats -join ', ')"
     exit 1
 }
 
-# Determine which Pester syntax to use based on version and available types
-if ($isPesterVersion5 -and ([System.Management.Automation.PSTypeName]'PesterConfiguration').Type)
+# Configure and run Pester 6
+Write-Verbose "Using Pester $($installedPesterVersion.ToString()) with configuration object syntax"
+$PesterConfiguration = New-PesterConfiguration
+$PesterConfiguration.Run.Path = $testPathsToRun
+$PesterConfiguration.Run.Exit = $false
+$PesterConfiguration.Run.PassThru = $true
+$PesterConfiguration.Output.Verbosity = $OutputFormat
+
+# NUnit XML results
+$PesterConfiguration.TestResult.Enabled = $true
+$PesterConfiguration.TestResult.OutputFormat = 'NUnitXml'
+$PesterConfiguration.TestResult.OutputPath = $NUnitResultsPath
+
+# Run tests
+$previousProgressPreference = $global:ProgressPreference
+try
 {
-    # Pester 5.x syntax
-    Write-Verbose "Using Pester $($installedPesterVersion.ToString()) with configuration object syntax"
-    $PesterConfiguration = [PesterConfiguration]::Default
-    $PesterConfiguration.Run.Path = $testPathsToRun
-    $PesterConfiguration.Run.Exit = $false
-    $PesterConfiguration.Run.PassThru = $true
-    $PesterConfiguration.Output.Verbosity = $OutputFormat
-
-    # NUnit XML results
-    $PesterConfiguration.TestResult.Enabled = $true
-    $PesterConfiguration.TestResult.OutputFormat = 'NUnitXml'
-    $PesterConfiguration.TestResult.OutputPath = $NUnitResultsPath
-
-    # Run tests
-    $previousProgressPreference = $global:ProgressPreference
-    try
-    {
-        $global:ProgressPreference = 'SilentlyContinue'
-        $pesterTestResults = Invoke-Pester -Configuration $PesterConfiguration
-    }
-    catch
-    {
-        Write-Error "Error running tests: $($_.Exception.Message)"
-        exit 1
-    }
-    finally
-    {
-        $global:ProgressPreference = $previousProgressPreference
-    }
+    $global:ProgressPreference = 'SilentlyContinue'
+    $pesterTestResults = Invoke-Pester -Configuration $PesterConfiguration
 }
-else
+catch
 {
-    # Pester 4.x syntax
-    Write-Verbose "Using Pester $($installedPesterVersion.ToString()) with parameter-based syntax"
-    $invokePesterParams = @{
-        Path = $testPathsToRun
-        PassThru = $true
-    }
-
-    # Handle OutputFormat for Pester 4.x when available
-    if ($installedPesterVersion -and $installedPesterVersion.Major -ge 4)
-    {
-        try
-        {
-            $invokePesterCommand = Get-Command Invoke-Pester -Module Pester
-            $outputFormatParameter = $invokePesterCommand.Parameters['OutputFormat']
-            if ($outputFormatParameter -and $outputFormatParameter.Attributes.ValidateSet)
-            {
-                $validOutputFormatSet = $outputFormatParameter.Attributes.ValidateSet.ValidValues
-                if ($OutputFormat -in $validOutputFormatSet)
-                {
-                    $invokePesterParams.OutputFormat = $OutputFormat
-                }
-                else
-                {
-                    Write-Warning "OutputFormat '$OutputFormat' not supported in Pester $($installedPesterVersion.ToString()). Valid values: $($validOutputFormatSet -join ', '). Using default."
-                }
-            }
-            elseif ($outputFormatParameter)
-            {
-                $invokePesterParams.OutputFormat = $OutputFormat
-            }
-        }
-        catch
-        {
-            Write-Warning "Could not determine OutputFormat support in Pester $($installedPesterVersion.ToString()). Using default output format."
-        }
-    }
-
-    # NUnit XML results (Pester 4.x)
-    if ($installedPesterVersion -and $installedPesterVersion.Major -ge 4)
-    {
-        $invokePesterParams.OutputFile = $NUnitResultsPath
-        $invokePesterParams.OutputFormat = 'NUnitXml'
-    }
-
-    # Run tests
-    $previousProgressPreference = $global:ProgressPreference
-    try
-    {
-        $global:ProgressPreference = 'SilentlyContinue'
-        $pesterTestResults = Invoke-Pester @invokePesterParams
-    }
-    catch
-    {
-        Write-Error "Error running tests: $($_.Exception.Message)"
-        exit 1
-    }
-    finally
-    {
-        $global:ProgressPreference = $previousProgressPreference
-    }
+    Write-Error "Error running tests: $($_.Exception.Message)"
+    exit 1
+}
+finally
+{
+    $global:ProgressPreference = $previousProgressPreference
 }
 
 # Output results summary

--- a/Tests/Integration/ProfileManagement/install.Tests.ps1
+++ b/Tests/Integration/ProfileManagement/install.Tests.ps1
@@ -242,6 +242,48 @@ Describe 'install.ps1 integration tests' {
                 }
             }
         }
+
+        It 'skips Unix named pipes in a local source without opening them' {
+            $isCoreUnix = $PSVersionTable.PSVersion.Major -ge 6 -and -not (Get-Variable -Name IsWindows -ValueOnly -ErrorAction SilentlyContinue)
+            if (-not $isCoreUnix)
+            {
+                Set-ItResult -Skipped -Because 'Unix special-file behavior only applies to PowerShell Core on Unix hosts.'
+                return
+            }
+
+            $mkfifoCommand = Get-Command -Name mkfifo -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $mkfifoCommand)
+            {
+                Set-ItResult -Skipped -Because 'mkfifo is required to create a named pipe for this regression test.'
+                return
+            }
+
+            $testRoot = Join-Path -Path $TestDrive -ChildPath ('InstallUnixSpecialFile_{0}' -f ([guid]::NewGuid().ToString('N')))
+            $profileRoot = Join-Path -Path $testRoot -ChildPath 'ProfileRoot'
+            $sourceRoot = Join-Path -Path $testRoot -ChildPath 'SourceRoot'
+
+            try
+            {
+                New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+                New-Item -ItemType Directory -Path $sourceRoot -Force | Out-Null
+                Set-Content -Path (Join-Path -Path $sourceRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') -Value '# installed profile'
+
+                $pipePath = Join-Path -Path $sourceRoot -ChildPath 'fsmonitor--daemon.ipc'
+                & $mkfifoCommand.Source $pipePath
+
+                & $script:installScript -ProfileRoot $profileRoot -LocalSourcePath $sourceRoot -SkipBackup -SkipPreserveDirectories -Verbose:$false
+
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should -BeTrue
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'fsmonitor--daemon.ipc') | Should -BeFalse
+            }
+            finally
+            {
+                if (Test-Path -Path $testRoot)
+                {
+                    Remove-TestDirectory -Path $testRoot
+                }
+            }
+        }
     }
     Context 'Install via git clone' {
         It 'clones from RepositoryUrl when git is available' -Skip:($null -eq $script:gitExecutable) {

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -149,7 +149,7 @@ Run tests manually with Pester:
 
 ```powershell
 # Install Pester 6.x if not available
-Install-Module Pester -MinimumVersion '6.0.0' -Force -SkipPublisherCheck
+Install-Module Pester -MinimumVersion '6.0.0' -MaximumVersion '6.999.999' -Force -SkipPublisherCheck
 
 # Run specific test file
 Invoke-Pester -Path Tests/Unit/New-RandomString.Tests.ps1

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -148,8 +148,8 @@ docker compose -f Tests/docker-compose.yml down
 Run tests manually with Pester:
 
 ```powershell
-# Install supported Pester 5.x if not available
-Install-Module Pester -MinimumVersion '5.0.0' -MaximumVersion '5.99.99' -Force -SkipPublisherCheck
+# Install Pester 6.x if not available
+Install-Module Pester -MinimumVersion '6.0.0' -Force -SkipPublisherCheck
 
 # Run specific test file
 Invoke-Pester -Path Tests/Unit/New-RandomString.Tests.ps1

--- a/Tests/Unit/Developer/GitHubRepositoryTopics.Tests.ps1
+++ b/Tests/Unit/Developer/GitHubRepositoryTopics.Tests.ps1
@@ -107,9 +107,9 @@ Describe 'GitHub repository topic functions' {
             $result.Status | Should -Be 'Unchanged'
             $result.Changed | Should -BeFalse
             $result.Topics | Should -Be @('powershell', 'automation')
-            Assert-MockCalled -CommandName gh -ParameterFilter {
+            Should -Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains 'PUT'
-            } -Times 0
+            } -Times 0 -Exactly
         }
 
         It 'normalizes topic names and adds only missing topics' {
@@ -199,9 +199,9 @@ Describe 'GitHub repository topic functions' {
             $result.Status | Should -Be 'AlreadyAbsent'
             $result.Changed | Should -BeFalse
             $result.Topics | Should -Be @('powershell', 'automation')
-            Assert-MockCalled -CommandName gh -ParameterFilter {
+            Should -Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains 'PUT'
-            } -Times 0
+            } -Times 0 -Exactly
         }
 
         It 'removes only requested existing topics and preserves unrelated topics' {

--- a/Tests/Unit/Developer/GitHubSecrets.Tests.ps1
+++ b/Tests/Unit/Developer/GitHubSecrets.Tests.ps1
@@ -349,7 +349,7 @@ Describe 'GitHub secret functions' {
                 Set-GitHubSecret -Name 'OVERSIZED_SECRET' -Value $tooLargeValue -Scope Repository -Repository 'octo-org/service-api'
             } | Should -Throw '*48 KB*'
 
-            Assert-MockCalled -CommandName gh -Times 0
+            Should -Invoke -CommandName gh -Times 0 -Exactly
         }
 
         It 'skips existing secrets without -Force' {
@@ -367,7 +367,7 @@ Describe 'GitHub secret functions' {
 
             $result.Status | Should -Be 'Skipped'
             $result.Changed | Should -BeFalse
-            Assert-MockCalled -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0
+            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0 -Exactly
         }
 
         It 'updates existing secrets when -Force is used' {
@@ -423,7 +423,7 @@ Describe 'GitHub secret functions' {
             $result = Set-GitHubSecret -Name 'NEW_SECRET' -Value $script:SecretValue -Scope Repository -Repository 'octo-org/service-api' -WhatIf
 
             $result.Status | Should -Be 'WhatIf'
-            Assert-MockCalled -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0
+            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0 -Exactly
         }
 
         It 'throws a clear error when gh is not installed' {
@@ -683,7 +683,7 @@ Describe 'GitHub secret functions' {
 
             $result.Status | Should -Be 'AlreadyAbsent'
             $result.Changed | Should -BeFalse
-            Assert-MockCalled -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0
+            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0 -Exactly
         }
 
         It 'disables gh interactive prompts during deletion' {
@@ -727,7 +727,7 @@ Describe 'GitHub secret functions' {
             $result = Remove-GitHubSecret -Name 'TO_DELETE' -Scope Repository -Repository 'octo-org/service-api' -WhatIf
 
             $result.Status | Should -Be 'WhatIf'
-            Assert-MockCalled -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0
+            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0 -Exactly
         }
 
         It 'supports user scope deletion through -Scope User' {

--- a/Tests/Unit/Developer/GitHubVariables.Tests.ps1
+++ b/Tests/Unit/Developer/GitHubVariables.Tests.ps1
@@ -151,9 +151,9 @@ Describe 'GitHub variable functions' {
 
             $result.Status | Should -Be 'Unchanged'
             $result.Changed | Should -BeFalse
-            Assert-MockCalled -CommandName gh -ParameterFilter {
+            Should -Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and $args -contains 'PATCH'
-            } -Times 0
+            } -Times 0 -Exactly
         }
 
         It 'skips existing variables without -Force when the value differs' {
@@ -170,9 +170,9 @@ Describe 'GitHub variable functions' {
             $result = Set-GitHubVariable -Name 'DOTNET_VERSION' -Value '8.0.x' -Scope Repository -Repository 'octo-org/service-api'
 
             $result.Status | Should -Be 'Skipped'
-            Assert-MockCalled -CommandName gh -ParameterFilter {
+            Should -Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and ($args -contains 'PATCH' -or $args -contains 'POST')
-            } -Times 0
+            } -Times 0 -Exactly
         }
 
         It 'updates existing variables when -Force is used' {
@@ -286,7 +286,7 @@ Describe 'GitHub variable functions' {
 
             $result.Status | Should -Be 'Created'
             $script:CreateAttempts | Should -Be 2
-            Assert-MockCalled -CommandName Start-Sleep -Times 1
+            Should -Invoke -CommandName Start-Sleep -Times 1
         }
 
         It 'rejects -SelectedRepository combined with incompatible -Visibility' -ForEach @(
@@ -414,9 +414,9 @@ Describe 'GitHub variable functions' {
             $result = Remove-GitHubVariable -Name 'MISSING_FLAG' -Scope Repository -Repository 'octo-org/service-api'
 
             $result.Status | Should -Be 'AlreadyAbsent'
-            Assert-MockCalled -CommandName gh -ParameterFilter {
+            Should -Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and $args -contains 'DELETE'
-            } -Times 0
+            } -Times 0 -Exactly
         }
 
         It 'supports WhatIf without deleting the variable' {
@@ -433,9 +433,9 @@ Describe 'GitHub variable functions' {
             $result = Remove-GitHubVariable -Name 'FEATURE_FLAG' -Scope Repository -Repository 'octo-org/service-api' -WhatIf
 
             $result.Status | Should -Be 'WhatIf'
-            Assert-MockCalled -CommandName gh -ParameterFilter {
+            Should -Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and $args -contains 'DELETE'
-            } -Times 0
+            } -Times 0 -Exactly
         }
     }
 }

--- a/Tests/Unit/Developer/Invoke-BfgRepoCleaner.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-BfgRepoCleaner.Tests.ps1
@@ -145,7 +145,7 @@ Describe 'Invoke-BfgRepoCleaner' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
             { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Confirm:$false } | Should -Not -Throw
-            Assert-MockCalled -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
+            Should -Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
         }
 
         It 'Falls back to Docker when local BFG is not available' {

--- a/Tests/Unit/Developer/Invoke-Magika.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-Magika.Tests.ps1
@@ -171,7 +171,7 @@ Describe 'Invoke-Magika' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
             { Invoke-Magika -Path $script:SampleFile } | Should -Not -Throw
-            Assert-MockCalled -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
+            Should -Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
         }
 
         It 'Falls back to Docker when local Magika is not available' {

--- a/Tests/Unit/Developer/Invoke-SqlFluff.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-SqlFluff.Tests.ps1
@@ -155,7 +155,7 @@ Describe 'Invoke-SqlFluff' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
             { Invoke-SqlFluff -Mode lint -Path $script:SqlFile } | Should -Not -Throw
-            Assert-MockCalled -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
+            Should -Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
         }
 
         It 'Falls back to Docker when local SQLFluff is not available' {
@@ -360,6 +360,11 @@ Describe 'Invoke-SqlFluff' {
         }
 
         It 'Defaults to --dialect ansi when no config file and no dialect are provided' {
+            Mock -CommandName Test-Path {
+                param([string[]]$LiteralPath, [string[]]$Path, [string]$PathType)
+                if ($PathType -eq 'Container') { return $false }
+                return $true
+            }
             Mock -CommandName Test-Path -ParameterFilter {
                 $LiteralPath -and $LiteralPath -match '(^|[\\/])\.sqlfluff$'
             } -MockWith { $false }
@@ -462,6 +467,11 @@ Describe 'Invoke-SqlFluff' {
             # Create a mock scenario where the default config doesn't exist
             # The function defaults to $HOME/.sqlfluff - we just check args don't include --config
             # when no config is explicitly provided and no default exists.
+            Mock -CommandName Test-Path {
+                param([string[]]$LiteralPath, [string[]]$Path, [string]$PathType)
+                if ($PathType -eq 'Container') { return $false }
+                return $true
+            }
             Mock -CommandName Test-Path -ParameterFilter { $LiteralPath -and $LiteralPath -like '*/.sqlfluff' } -MockWith { $false }
 
             Invoke-SqlFluff -Mode lint -Path $script:SqlFile | Out-Null

--- a/Tests/Unit/Developer/Invoke-SqlFluff.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-SqlFluff.Tests.ps1
@@ -472,7 +472,7 @@ Describe 'Invoke-SqlFluff' {
                 if ($PathType -eq 'Container') { return $false }
                 return $true
             }
-            Mock -CommandName Test-Path -ParameterFilter { $LiteralPath -and $LiteralPath -like '*/.sqlfluff' } -MockWith { $false }
+            Mock -CommandName Test-Path -ParameterFilter { $LiteralPath -and $LiteralPath -match '(^|[\\/])\.sqlfluff$' } -MockWith { $false }
 
             Invoke-SqlFluff -Mode lint -Path $script:SqlFile | Out-Null
 

--- a/Tests/Unit/Developer/Remove-DockerArtifact.Tests.ps1
+++ b/Tests/Unit/Developer/Remove-DockerArtifact.Tests.ps1
@@ -60,10 +60,10 @@ Describe 'Remove-DockerArtifact' {
             $result.ImageMode | Should -Be 'AllUnused'
             $result.TotalSpaceFreed | Should -Be '650.00 MB'
 
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
         }
 
         It 'Uses docker system prune when stopped containers are included' -Skip:(-not $script:dockerAvailable) {
@@ -76,12 +76,12 @@ Describe 'Remove-DockerArtifact' {
             $result.BuildHistoryPruned | Should -BeFalse
             $result.TotalSpaceFreed | Should -Be '2.00 GB'
 
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
         }
 
         It 'Uses all cleanup categories when -All is specified' -Skip:(-not $script:dockerAvailable) {
@@ -96,13 +96,13 @@ Describe 'Remove-DockerArtifact' {
             $result.BuildHistoryPruned | Should -BeTrue
             $result.TotalSpaceFreed | Should -Be '2.00 GB'
 
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 1
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 1
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 1
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 1
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
 
         It 'Throws when -All and -DanglingImagesOnly are used together' -Skip:(-not $script:dockerAvailable) {
@@ -120,8 +120,8 @@ Describe 'Remove-DockerArtifact' {
 
             $result.BuildHistoryPruned | Should -BeTrue
             $result.TotalSpaceFreed | Should -Be '200.00 MB'
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' -and $args -contains '--all' } -Times 1
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' -and $args -contains '--all' } -Times 1
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' -and $args -contains '--all' } -Times 1
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' -and $args -contains '--all' } -Times 1
         }
 
         It 'Respects -DanglingImagesOnly for targeted prunes' -Skip:(-not $script:dockerAvailable) {
@@ -132,7 +132,7 @@ Describe 'Remove-DockerArtifact' {
             $result = Remove-DockerArtifact -DanglingImagesOnly
 
             $result.ImageMode | Should -Be 'DanglingOnly'
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args -contains '--all' } -Times 0
+            Should -Invoke -CommandName docker -ParameterFilter { $args -contains '--all' } -Times 0 -Exactly
         }
 
         It 'Honors -WhatIf and does not invoke Docker commands' -Skip:(-not $script:dockerAvailable) {
@@ -148,12 +148,12 @@ Describe 'Remove-DockerArtifact' {
             $result = Remove-DockerArtifact -IncludeStoppedContainers -IncludeBuildHistory -WhatIf
 
             $result.TotalSpaceFreed | Should -Be '0 bytes'
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
     }
 

--- a/Tests/Unit/Developer/Update-DockerImage.Tests.ps1
+++ b/Tests/Unit/Developer/Update-DockerImage.Tests.ps1
@@ -157,7 +157,7 @@ Describe 'Update-DockerImage' {
             $result.Failed | Should -Be 0
             $result.Results[0].Status | Should -Be 'Success'
             $result.Results[0].Message | Should -Be 'Updated'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*nginx:latest*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*nginx:latest*' } -Times 1
         }
 
         It 'Detects already up-to-date images' -Skip:(-not $script:dockerAvailable) {
@@ -262,7 +262,7 @@ Describe 'Update-DockerImage' {
             $result.DanglingPruneSucceeded | Should -BeTrue
             $result.DanglingPruneError | Should -BeNullOrEmpty
 
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' -and $args -contains '--force' } -Times 1
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' -and $args -contains '--force' } -Times 1
         }
 
         It 'Does not prune dangling images by default' -Skip:(-not $script:dockerAvailable) {
@@ -284,7 +284,7 @@ Describe 'Update-DockerImage' {
             $result.DanglingPruneSucceeded | Should -BeFalse
             $result.DanglingPruneError | Should -Be $null
 
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
 
         It 'Honors -WhatIf and skips dangling prune' -Skip:(-not $script:dockerAvailable) {
@@ -305,8 +305,8 @@ Describe 'Update-DockerImage' {
             $result.DanglingPruneSucceeded | Should -BeFalse
             $result.DanglingPruneError | Should -Be $null
 
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'pull' } -Times 0
-            Assert-MockCalled -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'pull' } -Times 0 -Exactly
+            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
     }
 }

--- a/Tests/Unit/Developer/Update-DotNetTool.Tests.ps1
+++ b/Tests/Unit/Developer/Update-DotNetTool.Tests.ps1
@@ -219,7 +219,7 @@ Describe 'Update-DotNetTool' {
             $result.Updated | Should -Be 0
             $result.Failed | Should -Be 0
             $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Should -BeNullOrEmpty
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter {
+            Should -Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'No .NET global tools found to update.'
             } -Times 1
         }
@@ -237,7 +237,7 @@ Describe 'Update-DotNetTool' {
             $updateCalls.Count | Should -Be 2
             ($updateCalls | ForEach-Object { $_[2] }) | Should -Contain 'dotnetsay'
             ($updateCalls | ForEach-Object { $_[2] }) | Should -Contain 'csharpier'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter {
+            Should -Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'Updated 2 of 2 .NET global tool(s).'
             } -Times 1
         }
@@ -297,7 +297,7 @@ Describe 'Update-DotNetTool' {
             $result = @(Update-DotNetTool -Path $script:TestDir -Scope Global -ListOutdated)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter {
+            Should -Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'No .NET global tools found to check.'
             } -Times 1
         }
@@ -370,7 +370,7 @@ Describe 'Update-DotNetTool' {
             $result = @(Update-DotNetTool -Path $script:TestDir -Scope Global -ListOutdated)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter {
+            Should -Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'No outdated .NET global tools found.'
             } -Times 1
         }
@@ -395,7 +395,7 @@ Describe 'Update-DotNetTool' {
             $result[0].PackageId | Should -Be 'csharpier'
             $result[0].CurrentVersion | Should -Be '1.2.5'
             $result[0].LatestVersion | Should -Be '1.2.6'
-            Assert-MockCalled -CommandName Invoke-RestMethod -ParameterFilter {
+            Should -Invoke -CommandName Invoke-RestMethod -ParameterFilter {
                 $Uri -eq 'https://api.nuget.org/v3-flatcontainer/csharpier/index.json'
             } -Times 1
         }

--- a/Tests/Unit/Invoke-Tests.Tests.ps1
+++ b/Tests/Unit/Invoke-Tests.Tests.ps1
@@ -33,33 +33,49 @@ BeforeAll {
         $moduleManifest = @'
 @{
     RootModule = 'Pester.psm1'
-    ModuleVersion = '5.99.0'
+    ModuleVersion = '6.99.0'
     GUID = '8f60f7c8-ef86-4f89-b46d-d1cc5b3a1111'
     Author = 'Invoke-Tests unit test'
     Description = 'Minimal fake Pester module for Invoke-Tests.ps1 tests.'
-    FunctionsToExport = @('Invoke-Pester')
+    FunctionsToExport = @('Invoke-Pester', 'New-PesterConfiguration')
 }
 '@
 
         $moduleBody = @'
+function New-PesterConfiguration
+{
+    return [PSCustomObject]@{
+        Run = [PSCustomObject]@{
+            Path = @()
+            Exit = $false
+            PassThru = $true
+        }
+        Output = [PSCustomObject]@{
+            Verbosity = 'Detailed'
+        }
+        TestResult = [PSCustomObject]@{
+            Enabled = $true
+            OutputFormat = 'NUnitXml'
+            OutputPath = ''
+        }
+    }
+}
+
 function Invoke-Pester
 {
     [CmdletBinding()]
     param(
         [Parameter()]
-        [string[]]$Path,
-
-        [Parameter()]
-        [switch]$PassThru,
-
-        [Parameter()]
-        [string]$OutputFile,
-
-        [Parameter()]
-        [string]$OutputFormat
+        [Object]$Configuration
     )
 
-    if ($OutputFile)
+    $outputPath = ''
+    if ($Configuration -and $Configuration.TestResult -and $Configuration.TestResult.OutputPath)
+    {
+        $outputPath = $Configuration.TestResult.OutputPath
+    }
+
+    if ($outputPath)
     {
         $xml = @"
 <?xml version="1.0" encoding="utf-8"?>
@@ -81,7 +97,7 @@ function Invoke-Pester
 </test-results>
 "@
 
-        [System.IO.File]::WriteAllText($OutputFile, $xml, [System.Text.Encoding]::UTF8)
+        [System.IO.File]::WriteAllText($outputPath, $xml, [System.Text.Encoding]::UTF8)
     }
 
     [PSCustomObject]@{
@@ -94,7 +110,7 @@ function Invoke-Pester
     }
 }
 
-Export-ModuleMember -Function Invoke-Pester
+Export-ModuleMember -Function Invoke-Pester, New-PesterConfiguration
 '@
 
         Set-Content -LiteralPath (Join-Path -Path $pesterModulePath -ChildPath 'Pester.psd1') -Value $moduleManifest -Encoding UTF8

--- a/Tests/Unit/Invoke-Tests.Tests.ps1
+++ b/Tests/Unit/Invoke-Tests.Tests.ps1
@@ -16,32 +16,40 @@ BeforeAll {
     {
         param(
             [Parameter(Mandatory)]
-            [string]$RootPath
+            [string]$RootPath,
+
+            [Parameter()]
+            [version[]]$PesterVersions = @([version]'6.99.0')
         )
 
         $testsPath = Join-Path -Path $RootPath -ChildPath 'Tests'
         $unitTestsPath = Join-Path -Path $testsPath -ChildPath 'Unit'
         $moduleRootPath = Join-Path -Path $RootPath -ChildPath 'Modules'
-        $pesterModulePath = Join-Path -Path $moduleRootPath -ChildPath 'Pester'
+        $pesterModuleRootPath = Join-Path -Path $moduleRootPath -ChildPath 'Pester'
 
         New-Item -Path $unitTestsPath -ItemType Directory -Force | Out-Null
-        New-Item -Path $pesterModulePath -ItemType Directory -Force | Out-Null
+        New-Item -Path $pesterModuleRootPath -ItemType Directory -Force | Out-Null
 
         Copy-Item -LiteralPath $script:InvokeTestsSourcePath -Destination (Join-Path -Path $RootPath -ChildPath 'Invoke-Tests.ps1')
         Copy-Item -LiteralPath $script:TimingSummarySourcePath -Destination (Join-Path -Path $testsPath -ChildPath 'Write-TestTimingSummary.ps1')
 
-        $moduleManifest = @'
+        foreach ($pesterVersion in $PesterVersions)
+        {
+            $pesterModulePath = Join-Path -Path $pesterModuleRootPath -ChildPath $pesterVersion.ToString()
+            New-Item -Path $pesterModulePath -ItemType Directory -Force | Out-Null
+
+            $moduleManifest = @"
 @{
     RootModule = 'Pester.psm1'
-    ModuleVersion = '6.99.0'
+    ModuleVersion = '$($pesterVersion.ToString())'
     GUID = '8f60f7c8-ef86-4f89-b46d-d1cc5b3a1111'
     Author = 'Invoke-Tests unit test'
     Description = 'Minimal fake Pester module for Invoke-Tests.ps1 tests.'
     FunctionsToExport = @('Invoke-Pester', 'New-PesterConfiguration')
 }
-'@
+"@
 
-        $moduleBody = @'
+            $moduleBody = @'
 function New-PesterConfiguration
 {
     return [PSCustomObject]@{
@@ -100,6 +108,11 @@ function Invoke-Pester
         [System.IO.File]::WriteAllText($outputPath, $xml, [System.Text.Encoding]::UTF8)
     }
 
+    if ($env:PWSPROFILE_FAKE_PESTER_VERSION_OUTPUT)
+    {
+        [System.IO.File]::WriteAllText($env:PWSPROFILE_FAKE_PESTER_VERSION_OUTPUT, $MyInvocation.MyCommand.Module.Version.ToString(), [System.Text.Encoding]::UTF8)
+    }
+
     [PSCustomObject]@{
         TotalCount = 2
         PassedCount = 2
@@ -113,8 +126,9 @@ function Invoke-Pester
 Export-ModuleMember -Function Invoke-Pester, New-PesterConfiguration
 '@
 
-        Set-Content -LiteralPath (Join-Path -Path $pesterModulePath -ChildPath 'Pester.psd1') -Value $moduleManifest -Encoding UTF8
-        Set-Content -LiteralPath (Join-Path -Path $pesterModulePath -ChildPath 'Pester.psm1') -Value $moduleBody -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path -Path $pesterModulePath -ChildPath 'Pester.psd1') -Value $moduleManifest -Encoding UTF8
+            Set-Content -LiteralPath (Join-Path -Path $pesterModulePath -ChildPath 'Pester.psm1') -Value $moduleBody -Encoding UTF8
+        }
 
         return [PSCustomObject]@{
             RootPath = $RootPath
@@ -166,5 +180,28 @@ Describe 'Invoke-Tests.ps1 timing summary' -Tag 'Unit' {
         $LASTEXITCODE | Should -Be 0
 
         Test-Path -LiteralPath $summaryPath | Should -BeFalse
+    }
+
+    It 'uses the latest installed Pester 6 version and ignores Pester 7' {
+        $versionOutputPath = Join-Path -Path $script:TestRootPath -ChildPath 'selected-pester-version.txt'
+        $script:FakeProject = Get-FakeInvokeTestsProject -RootPath $script:TestRootPath -PesterVersions @(
+            [version]'6.1.0'
+            [version]'7.0.0'
+            [version]'6.99.0'
+        )
+        $env:PSModulePath = $script:FakeProject.ModuleRootPath
+        $env:PWSPROFILE_FAKE_PESTER_VERSION_OUTPUT = $versionOutputPath
+
+        try
+        {
+            $null = & $script:PowerShellExecutable -NoProfile -File $script:FakeProject.InvokeTestsPath -TestType Unit -OutputFormat Normal
+            $LASTEXITCODE | Should -Be 0
+
+            (Get-Content -LiteralPath $versionOutputPath -Raw).Trim() | Should -Be '6.99.0'
+        }
+        finally
+        {
+            Remove-Item Env:\PWSPROFILE_FAKE_PESTER_VERSION_OUTPUT -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/Tests/Unit/MediaProcessing/Remove-ImageMetadata.Tests.ps1
+++ b/Tests/Unit/MediaProcessing/Remove-ImageMetadata.Tests.ps1
@@ -534,8 +534,8 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $result.OutputCopied | Should -Be $true
             $result.RemainingMetadataTags | Should -Contain '[EXIF] Make = Test Camera'
             $result.RemainingMetadataTags | Should -Contain '[XMP] Title = Private Album'
-            Assert-MockCalled -CommandName Get-ImageMetadata -Times 1 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
-            Assert-MockCalled -CommandName Get-ImageMetadata -Times 2 -Exactly -ParameterFilter { $Path -eq $script:PrivacyOutputImage }
+            Should -Invoke -CommandName Get-ImageMetadata -Times 1 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
+            Should -Invoke -CommandName Get-ImageMetadata -Times 2 -Exactly -ParameterFilter { $Path -eq $script:PrivacyOutputImage }
         }
 
         It 'Should surface remaining metadata tag values when in-place verification is incomplete' {
@@ -558,7 +558,7 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $result.OutputCopied | Should -Be $false
             $result.RemainingMetadataTags | Should -Contain '[GPS] GPSLatitude = 41.88'
             $result.RemainingMetadataTags | Should -Contain '[IPTC] Keywords = private, home'
-            Assert-MockCalled -CommandName Get-ImageMetadata -Times 3 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
+            Should -Invoke -CommandName Get-ImageMetadata -Times 3 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Export-InstalledPlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Export-InstalledPlatformPackage.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportedPackages = Get-Content -LiteralPath $exportPath -Raw | ConvertFrom-Json
         $exportedPackages.Count | Should -Be 2
         ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should -Be '2.44.0'
-        Assert-MockCalled -CommandName Write-Host -Times 0
+        Should -Invoke -CommandName Write-Host -Times 0 -Exactly
     }
 
     It 'exports CSV with direct dependencies' {
@@ -94,8 +94,8 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportedPackages.Count | Should -Be 1
         $exportedPackages[0].DependsOn | Should -Be 'openssl'
         $exportedPackages[0].RequiredBy | Should -Be ''
-        Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-        Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0
+        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0 -Exactly
     }
 
     It 'exports CSV with both dependency directions when DependencyMode is Both' {
@@ -152,8 +152,8 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportedPackages.Count | Should -Be 1
         $exportedPackages[0].DependsOn | Should -Be 'openssl'
         $exportedPackages[0].RequiredBy | Should -Be 'git-extras'
-        Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-        Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
     }
 
     It 'rejects Both dependency export mode for winget records' {

--- a/Tests/Unit/SystemAdministration/Find-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Find-PlatformPackage.Tests.ps1
@@ -339,9 +339,9 @@ Describe 'Find-PlatformPackage' {
             $result = @(Find-PlatformPackage -PackageManager brew -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: git' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I install  V details  A toggle all' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-3 of 3 visible  $([char]0x00B7)  3 total  $([char]0x00B7)  0 selected  $([char]0x00B7)  source: All" -and $ForegroundColor -eq 'White' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: git' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I install  V details  A toggle all' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-3 of 3 visible  $([char]0x00B7)  3 total  $([char]0x00B7)  0 selected  $([char]0x00B7)  source: All" -and $ForegroundColor -eq 'White' } -Times 1
             @($script:HostOutputRecords | Where-Object { $_.ForegroundColor -eq [ConsoleColor]::DarkGray -and $_.Object -like '*git*' }).Count | Should -BeGreaterOrEqual 2
             @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 4
         }
@@ -374,7 +374,7 @@ Describe 'Find-PlatformPackage' {
             $result.Count | Should -Be 0
             @($script:Invocations | Where-Object { $_.Key -eq 'brew search --formulae git' }).Count | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew search --casks code' }).Count | Should -Be 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: code' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: code' } -Times 1
         }
 
         It 'shows keyboard help from the search result picker' {
@@ -400,9 +400,9 @@ Describe 'Find-PlatformPackage' {
             $result = @(Find-PlatformPackage -PackageManager brew -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Find-PlatformPackage Help' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq '/: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'start a new search' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Find-PlatformPackage Help' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq '/: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'start a new search' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'returns selected packages when PassThru is used' {
@@ -428,7 +428,7 @@ Describe 'Find-PlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
         }
 
         It 'opens the result picker with the requested source filter' {
@@ -483,8 +483,8 @@ Describe 'Find-PlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Source | Should -Be 'msstore'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*winget*' -and $Object -notlike '*msstore*' } -Times 0
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*winget*' -and $Object -notlike '*msstore*' } -Times 0 -Exactly
         }
 
         It 'keeps picker table rows within the current console width' {
@@ -561,7 +561,7 @@ Describe 'Find-PlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
         }
 
         It 'installs the selected package from the interactive browser' {
@@ -589,7 +589,7 @@ Describe 'Find-PlatformPackage' {
             $result.Selected | Should -Be 1
             $result.Installed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'brew install git output' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew install git output' } -Times 1
         }
 
         It 'loads missing winget descriptions only when D is pressed' {
@@ -641,9 +641,9 @@ Describe 'Find-PlatformPackage' {
             $result = @(Find-PlatformPackage -PackageManager winget -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
             @($script:Invocations | Where-Object { $_.Key -eq 'winget show --id Git.Git --exact --accept-source-agreements --output json' }).Count | Should -Be 1
         }
 
@@ -694,7 +694,7 @@ Describe 'Find-PlatformPackage' {
 
             $result.Count | Should -Be 0
             $echoActions.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
         }
 
         It 'restores terminal echo when winget details throw in the console key reader flow' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {

--- a/Tests/Unit/SystemAdministration/Install-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Install-PlatformPackage.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'Install-PlatformPackage' {
 
             $result.Installed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
         }
 
         It 'passes interactive mode to winget installs' {
@@ -138,8 +138,8 @@ Describe 'Install-PlatformPackage' {
             $result.Selected | Should -Be 1
             $result.Installed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew install --cask visual-studio-code' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  1 selected" -and $ForegroundColor -eq 'White' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  1 selected" -and $ForegroundColor -eq 'White' } -Times 1
         }
 
         It 'installs the current search result when Enter is pressed without a selection' {
@@ -159,7 +159,7 @@ Describe 'Install-PlatformPackage' {
             $result.NotSelected | Should -Be 0
             $result.Installed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
         }
 
         It 'shows keyboard help from the query result picker' {
@@ -182,9 +182,9 @@ Describe 'Install-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Installed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Install-PlatformPackage Help' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'install selected packages, or the current package if none are selected' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Install-PlatformPackage Help' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'install selected packages, or the current package if none are selected' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'shows and skips an installed Homebrew search result' {
@@ -211,9 +211,9 @@ Describe 'Install-PlatformPackage' {
             $result.Skipped | Should -Be 1
             $result.Results[0].Message | Should -Be 'Package is already installed'
             @($script:Invocations | Where-Object { $_.Key -eq 'brew install jq' }).Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Current: jq' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Id: jq | Source: homebrew/core | Publisher: Homebrew | Installed: yes' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $ForegroundColor -eq 'DarkGray' -and $Object -like '*jq*' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current: jq' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Id: jq | Source: homebrew/core | Publisher: Homebrew | Installed: yes' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $ForegroundColor -eq 'DarkGray' -and $Object -like '*jq*' } -Times 2
         }
 
         It 'installs only the visible package when filtering duplicate winget ids by source' {
@@ -301,9 +301,9 @@ Describe 'Install-PlatformPackage' {
 
             $result.Installed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source winget --accept-source-agreements --accept-package-agreements --interactive' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I interactive installer  Enter install  V details  A toggle all' } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+UI\s+' } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match '^> \[ \] \[I\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I interactive installer  Enter install  V details  A toggle all' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+UI\s+' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^> \[ \] \[I\]' } -Times 1
         }
 
         It 'does not suppress terminal echo when a custom key reader drives winget details' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -349,7 +349,7 @@ Describe 'Install-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $echoActions.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
         }
 
         It 'restores terminal echo when winget details throw in the console key reader flow' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {

--- a/Tests/Unit/SystemAdministration/Remove-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Remove-PlatformPackage.Tests.ps1
@@ -91,7 +91,7 @@ Describe 'Remove-PlatformPackage' {
 
             ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).StreamOutput | Should -BeTrue
 
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'brew uninstall git output' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew uninstall git output' } -Times 1
         }
 
         It 'captures post-removal instructions in the result object' {
@@ -342,9 +342,9 @@ Describe 'Remove-PlatformPackage' {
             $result.NotSelected | Should -Be 0
             $result.Removed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C cancel" } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C cancel" } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
         }
 
         It 'shows keyboard help from the removal picker' {
@@ -367,9 +367,9 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Help' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'P: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'toggle purge/zap removal for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Help' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'P: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'toggle purge/zap removal for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'treats Ctrl+C as a cancel command' {
@@ -413,8 +413,8 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 3
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 3
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0 -Exactly
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
         }
 
@@ -438,8 +438,8 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
         }
 
@@ -460,10 +460,10 @@ Describe 'Remove-PlatformPackage' {
 
             $null = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PickerPageSize 2 -Confirm:$false
 
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
         }
 
         It 'allows purge behavior to be toggled for the selected package' {
@@ -487,8 +487,8 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Removed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall --cask --zap visual-studio-code' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*P purge/zap*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*P purge/zap*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
         }
 
         It 'shows both dependency directions from the removal picker with D' {
@@ -526,13 +526,13 @@ Describe 'Remove-PlatformPackage' {
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
         }
 
         It 'returns from dependency view to the removal picker on <Name> when manager navigation is enabled' -TestCases @(
@@ -571,9 +571,9 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Selected | Should -Be 0
             $result.Removed | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Dependencies - Homebrew' } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Dependencies - Homebrew' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
         }
 
         It 'filters picker results by package name when F is pressed' {
@@ -600,8 +600,8 @@ Describe 'Remove-PlatformPackage' {
             $result.Removed | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall curl' }).Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
         }
 
         It 'treats lowercase q as filter text instead of cancel' {
@@ -628,8 +628,8 @@ Describe 'Remove-PlatformPackage' {
             $result.Removed | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall jq' }).Count | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
         }
     }
 
@@ -722,8 +722,8 @@ Describe 'Remove-PlatformPackage' {
 
             $result.Removed | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Microsoft.PowerShell --exact --source winget --accept-source-agreements --purge' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -clike '*Purge*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget purge output' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -clike '*Purge*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget purge output' } -Times 1
         }
 
         It 'keeps picker table rows within the current console width' {
@@ -808,7 +808,7 @@ Describe 'Remove-PlatformPackage' {
 
             $null = Remove-PlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
         }
 
         It 'removes only the visible package when filtering duplicate winget ids by source' {
@@ -854,7 +854,7 @@ Describe 'Remove-PlatformPackage' {
             $result.Removed | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source winget --accept-source-agreements' }).Count | Should -Be 0
             ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source msstore --accept-source-agreements' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
         }
     }
 

--- a/Tests/Unit/SystemAdministration/Show-InstalledPlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-InstalledPlatformPackage.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Show-InstalledPlatformPackage' {
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
             $result[0].PackageManager | Should -Be 'brew'
-            Assert-MockCalled -CommandName Write-Host -Times 0
+            Should -Invoke -CommandName Write-Host -Times 0 -Exactly
         }
 
         It 'exports installed packages to inferred JSON without opening the picker' {
@@ -64,7 +64,7 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportedPackages = Get-Content -LiteralPath $exportPath -Raw | ConvertFrom-Json
             $exportedPackages.Count | Should -Be 2
             ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should -Be '2.44.0'
-            Assert-MockCalled -CommandName Write-Host -Times 0
+            Should -Invoke -CommandName Write-Host -Times 0 -Exactly
         }
 
         It 'exports installed packages to explicit CSV with dependency relationships' {
@@ -113,9 +113,9 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportedPackages.Count | Should -Be 1
             $exportedPackages[0].DependsOn | Should -Be 'openssl'
             $exportedPackages[0].RequiredBy | Should -Be 'git-extras'
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -Times 0
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should -Invoke -CommandName Write-Host -Times 0 -Exactly
         }
 
         It 'shows dependency resolution progress when export progress is requested' {
@@ -146,10 +146,10 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -ExportPath $exportPath -ExportFormat Csv -ExportDependencyMode Both -ShowExportProgress)
 
             $result.Count | Should -Be 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Exporting installed packages...' -and $ForegroundColor -eq 'Cyan' } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Package: 1 of 1 - git' -and $ForegroundColor -eq 'White' } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: DependsOn' -and $ForegroundColor -eq 'White' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: RequiredBy' -and $ForegroundColor -eq 'White' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Exporting installed packages...' -and $ForegroundColor -eq 'Cyan' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Package: 1 of 1 - git' -and $ForegroundColor -eq 'White' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: DependsOn' -and $ForegroundColor -eq 'White' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: RequiredBy' -and $ForegroundColor -eq 'White' } -Times 1
         }
     }
 
@@ -167,9 +167,9 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  filter: all" -and $ForegroundColor -eq 'White' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  filter: all" -and $ForegroundColor -eq 'White' } -Times 1
             @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 2
         }
 
@@ -191,7 +191,7 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
         }
 
         It 'ignores Backspace and Delete as manager navigation when not launched by the manager' {
@@ -213,8 +213,8 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 3
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 3
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0 -Exactly
         }
 
         It 'returns to the manager menu on <Name> when manager navigation is enabled' -TestCases @(
@@ -235,8 +235,8 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
         }
 
         It 'renders only the current viewport for long package lists' {
@@ -256,10 +256,10 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $null = Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PickerPageSize 2
 
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
         }
 
         It 'returns selected packages when PassThru is used' {
@@ -281,7 +281,7 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
         }
 
         It 'returns the current package when PassThru is used without a selection' {
@@ -298,8 +298,8 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: S: [All]  Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: S: [All]  Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
         }
 
         It 'shows keyboard help from the picker when question mark is pressed' {
@@ -321,15 +321,15 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Help' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'D: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'open or close the dependency view for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the package list from the dependency view' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'V: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'load a missing winget description when available' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'export visible packages, or selected packages when any are selected, to JSON or CSV' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Help' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'D: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'open or close the dependency view for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the package list from the dependency view' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'V: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'load a missing winget description when available' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'export visible packages, or selected packages when any are selected, to JSON or CSV' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'loads missing winget descriptions only when V is pressed' {
@@ -370,9 +370,9 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
             @($script:Invocations | Where-Object { $_.Key -eq 'winget show --id Git.Git --exact --accept-source-agreements --output json' }).Count | Should -Be 1
         }
 
@@ -409,7 +409,7 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
         }
 
         It 'keeps picker table rows within the current console width' {
@@ -489,14 +489,14 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 1
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 1
         }
 
         It 'returns from dependency view to the package list on <Name> when manager navigation is enabled' -TestCases @(
@@ -534,9 +534,9 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 2
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 2
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
         }
 
         It 'invokes Remove-PlatformPackage from the picker when R is confirmed' {
@@ -566,13 +566,13 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Remove-PlatformPackage -ParameterFilter {
+            Should -Invoke -CommandName Remove-PlatformPackage -ParameterFilter {
                 $PackageManager -eq 'brew' -and
                 $All -and
                 @($IncludePackage).Count -eq 1 -and
                 @($IncludePackage)[0] -eq 'git'
             } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Removed: 1, Failed: 0, Skipped: 0' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Removed: 1, Failed: 0, Skipped: 0' } -Times 1
         }
 
         It 'shows winget remediation text after a browser-launched remove failure' {
@@ -644,14 +644,14 @@ Describe 'Show-InstalledPlatformPackage' {
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
             $result.Count | Should -Be 0
-            Assert-MockCalled -CommandName Upgrade-PlatformPackage -ParameterFilter {
+            Should -Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
                 $PackageManager -eq 'brew' -and
                 $All -and
                 $SkipRefresh -and
                 @($IncludePackage).Count -eq 1 -and
                 @($IncludePackage)[0] -eq 'git'
             } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Upgraded: 1, Failed: 0, Skipped: 0' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Upgraded: 1, Failed: 0, Skipped: 0' } -Times 1
         }
 
         It 'shows winget remediation text after a browser-launched upgrade failure' {
@@ -741,7 +741,7 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportedPackages.Count | Should -Be 2
             ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should -Be '2.44.0'
             ($exportedPackages | Where-Object { $_.Name -eq 'curl' }).PackageManager | Should -Be 'brew'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 2 package(s) to *installed-packages.json (JSON)' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 2 package(s) to *installed-packages.json (JSON)' } -Times 1
         }
 
         It 'exports selected packages to CSV with dependencies from the picker' {
@@ -804,9 +804,9 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportedPackages[0].Name | Should -Be 'curl'
             $exportedPackages[0].DependsOn | Should -Be 'openssl'
             $exportedPackages[0].RequiredBy | Should -Be 'git-extras'
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 1 package(s) with dependencies and required-by relationships to *selected-packages.csv (CSV)' } -Times 1
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 1 package(s) with dependencies and required-by relationships to *selected-packages.csv (CSV)' } -Times 1
         }
 
         It 'exports direct dependencies without resolving required-by relationships' {
@@ -853,8 +853,8 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
             $exportedPackages[0].DependsOn | Should -Be 'openssl'
             $exportedPackages[0].RequiredBy | Should -Be ''
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Assert-MockCalled -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0 -Exactly
         }
 
         It 'filters picker results by package name when F is pressed' {
@@ -878,8 +878,8 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'git'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
         }
 
         It 'treats lowercase q as filter text instead of cancel' {
@@ -903,8 +903,8 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result.Count | Should -Be 1
             $result[0].Name | Should -Be 'jq'
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
@@ -25,12 +25,12 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like 'Manager: Auto -> *' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Installed packages*' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Export installed*' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Dependencies*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Manager: Auto -> *' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Installed packages*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Export installed*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0 -Exactly
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Dependencies*' } -Times 1
     }
 
     It 'selects the upgrade workflow by default' {
@@ -46,9 +46,9 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Upgrade-PlatformPackage -Times 1
-        Assert-MockCalled -CommandName Install-PlatformPackage -Times 0
-        Assert-MockCalled -CommandName Show-InstalledPlatformPackage -Times 0
+        Should -Invoke -CommandName Upgrade-PlatformPackage -Times 1
+        Should -Invoke -CommandName Install-PlatformPackage -Times 0 -Exactly
+        Should -Invoke -CommandName Show-InstalledPlatformPackage -Times 0 -Exactly
     }
 
     It 'exposes ShouldProcess safety switches for delegated operations' {
@@ -109,15 +109,15 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Show-InstalledPlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Show-InstalledPlatformPackage -ParameterFilter {
             $PackageManager -eq 'brew' -and
             $null -ne $CommandRunner -and
             $null -ne $KeyReader -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*git*' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*gh*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*git*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*gh*' } -Times 1
     }
 
     It 'returns from the installed package browser to the manager menu on Backspace' {
@@ -135,10 +135,10 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage - Homebrew' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 0
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage - Homebrew' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 0 -Exactly
     }
 
     It 'does not expose numbers outside 1-6 as valid actions' {
@@ -147,8 +147,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Choose 1-6 or Q.' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0 -Exactly
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Choose 1-6 or Q.' } -Times 1
     }
 
     It 'supports arrow key navigation in the manager menu' {
@@ -175,7 +175,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Install-PlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $Query -eq 'git' -and
             $PackageManager -eq 'apt' -and
             $NoSudo -and
@@ -194,11 +194,11 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'browse installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'export installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'browse installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'export installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
     }
 
     It 'routes installed package export through Show-InstalledPlatformPackage from the manager shortcut' {
@@ -223,7 +223,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner { } -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Show-InstalledPlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Show-InstalledPlatformPackage -ParameterFilter {
             $PackageManager -eq 'brew' -and
             $ExportPath -eq $exportPath -and
             $ExportFormat -eq 'Json' -and
@@ -232,8 +232,8 @@ Describe 'Show-PlatformPackageManager' {
             $null -ne $ExportCancelRequested -and
             $NonInteractive
         } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Export Installed Packages' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Export completed.' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Export Installed Packages' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Export completed.' } -Times 1
     }
 
     It 'shows keyboard help from a manager result screen' {
@@ -261,9 +261,9 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Any key or Enter: ' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the manager menu' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Any key or Enter: ' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the manager menu' -and $ForegroundColor -eq 'DarkGray' } -Times 1
     }
 
     It 'routes search installs through Install-PlatformPackage with NoSudo forwarded' {
@@ -285,7 +285,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Install-PlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $Query -eq 'git' -and
             $PackageManager -eq 'apt' -and
             $NoSudo -and
@@ -326,18 +326,18 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -FilterSource msstore -SkipRefresh -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Install-PlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $Query -eq 'git' -and
             $PackageManager -eq 'winget' -and
             $FilterSource -eq 'msstore' -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Assert-MockCalled -CommandName Upgrade-PlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'winget' -and
             $FilterSource -eq 'msstore' -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*FilterSource=msstore*' } -Times 3
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*FilterSource=msstore*' } -Times 3
     }
 
     It 'forwards interactive mode to winget install and upgrade workflows' {
@@ -348,13 +348,13 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -Interactive -SkipRefresh -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Install-PlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'winget' -and $Interactive
         } -Times 1
-        Assert-MockCalled -CommandName Upgrade-PlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'winget' -and $Interactive
         } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Interactive*' } -Times 3
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Interactive*' } -Times 3
     }
 
     It 'routes upgrade options and forwards winget uninstall-previous' {
@@ -379,8 +379,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result.Count | Should -Be 0
         ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --uninstall-previous' }).StreamOutput | Should -BeTrue
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'winget upgrade output' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget upgrade output' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded' } -Times 1
     }
 
     It 'routes remove options and forwards purge behavior' {
@@ -406,8 +406,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result.Count | Should -Be 0
         ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall --cask --zap visual-studio-code' }).StreamOutput | Should -BeTrue
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Removed' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Removed' } -Times 1
     }
 
     It 'returns from the removal picker to the manager menu on Delete' {
@@ -430,9 +430,9 @@ Describe 'Show-PlatformPackageManager' {
         )
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage - Homebrew' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage - Homebrew' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
         @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
     }
 
@@ -457,8 +457,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -SkipRefresh -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded: 1' -and $ForegroundColor -eq 'Green' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 0' -and $ForegroundColor -eq 'Green' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded: 1' -and $ForegroundColor -eq 'Green' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 0' -and $ForegroundColor -eq 'Green' } -Times 1
     }
 
     It 'shows a green status indicator after a successful install' {
@@ -480,7 +480,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Green' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Green' } -Times 1
     }
 
     It 'shows captured informational output on the manager result screen' {
@@ -513,9 +513,9 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Additional output' -and $ForegroundColor -eq 'Cyan' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'python' -and $ForegroundColor -eq 'White' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq '  ==> Caveats' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Additional output' -and $ForegroundColor -eq 'Cyan' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'python' -and $ForegroundColor -eq 'White' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq '  ==> Caveats' -and $ForegroundColor -eq 'DarkGray' } -Times 1
     }
 
     It 'keeps detail rows within the separator width while retaining the full additional output' {
@@ -570,7 +570,7 @@ Describe 'Show-PlatformPackageManager' {
             Where-Object { -not [String]::IsNullOrWhiteSpace($_) -and $_.Length -gt $detailSeparator.Length }
         ) | Should -HaveCount 0
         $detailTable | Should -Not -Match ([Regex]::Escape($script:FullFailureMessage))
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter {
+        Should -Invoke -CommandName Write-Host -ParameterFilter {
             $Object -eq "  $script:FullFailureMessage" -and $ForegroundColor -eq 'DarkGray'
         } -Times 1
     }
@@ -594,8 +594,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
     }
 
     It 'shows a yellow status indicator when packages were skipped but none failed' {
@@ -617,8 +617,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 2' -and $ForegroundColor -eq 'Yellow' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Skipped: 1' -and $ForegroundColor -eq 'Yellow' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 2' -and $ForegroundColor -eq 'Yellow' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Skipped: 1' -and $ForegroundColor -eq 'Yellow' } -Times 1
     }
 
     It 'does not show a status indicator for dependency lookups' {
@@ -630,7 +630,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'Installed:|Upgraded:|Removed:' } -Times 0
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed:|Upgraded:|Removed:' } -Times 0 -Exactly
     }
 
     It 'returns directly to the menu without a result screen when a search query is cancelled' {
@@ -639,7 +639,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager apt -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0 -Exactly
     }
 
     It 'returns directly to the menu without a result screen when no packages are selected in the picker' {
@@ -661,8 +661,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager apt -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Install-PlatformPackage -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0
+        Should -Invoke -CommandName Install-PlatformPackage -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0 -Exactly
     }
 
     It 'shows a notification in the menu when search returns no matches' {
@@ -684,8 +684,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Install-PlatformPackage -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
+        Should -Invoke -CommandName Install-PlatformPackage -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
     }
 
     It 'shows a notification in the menu when winget search returns no registry matches' {
@@ -698,7 +698,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -CommandRunner $runner -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
     }
 
     It 'shows a notification in the menu when no packages are available for upgrade' {
@@ -720,8 +720,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -SkipRefresh -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Upgrade-PlatformPackage -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*No packages are currently available for upgrade*' } -Times 1
+        Should -Invoke -CommandName Upgrade-PlatformPackage -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages are currently available for upgrade*' } -Times 1
     }
 
     It 'shows a notification in the menu when no installed packages matched for removal' {
@@ -748,11 +748,11 @@ Describe 'Show-PlatformPackageManager' {
         )
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Remove-PlatformPackage -ParameterFilter {
+        Should -Invoke -CommandName Remove-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'brew' -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*No installed packages matched the requested filters*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No installed packages matched the requested filters*' } -Times 1
     }
 
     It 'does not show a notification when no packages are selected in the picker but packages are available' {
@@ -774,7 +774,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -SkipRefresh -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*No packages*' } -Times 0
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages*' } -Times 0 -Exactly
     }
 
     It 'shows dependency records from the manager' {
@@ -786,8 +786,8 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*Relationship*' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Relationship*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
     }
 
     It 'explains that winget reverse dependency lookup is unavailable' {
@@ -796,7 +796,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*winget does not expose reverse dependency metadata*' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*winget does not expose reverse dependency metadata*' } -Times 1
     }
 
     It 'rejects partial Both dependency lookup for winget' {
@@ -805,7 +805,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like "*Direction 'Both' is not supported by winget*Choose DependsOn*" } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*Direction 'Both' is not supported by winget*Choose DependsOn*" } -Times 1
     }
 
     It 'keeps action results on a dedicated screen until the next action is chosen' {
@@ -817,7 +817,7 @@ Describe 'Show-PlatformPackageManager' {
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
         $result.Count | Should -Be 0
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
-        Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Package Dependencies' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
+        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Package Dependencies' } -Times 1
     }
 }

--- a/Tests/Unit/SystemAdministration/Upgrade-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Upgrade-PlatformPackage.Tests.ps1
@@ -137,8 +137,8 @@ Describe 'Upgrade-PlatformPackage' {
             ($script:Invocations | Where-Object { $_.Key -eq 'brew update --quiet' }).StreamOutput | Should -BeFalse
             ($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).StreamOutput | Should -BeTrue
 
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'brew update output' } -Times 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'brew upgrade git output' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew update output' } -Times 0 -Exactly
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew upgrade git output' } -Times 1
         }
 
         It 'captures Homebrew refresh process output before the picker and streams upgrade process output' {
@@ -485,11 +485,11 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result.Selected | Should -Be 0
             $result.Upgraded | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter upgrade  V details  A toggle all  F: [all]" } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Upgrade-PlatformPackage Help' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'upgrade selected packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter upgrade  V details  A toggle all  F: [all]" } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Upgrade-PlatformPackage Help' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'upgrade selected packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'renders only the current viewport for long upgrade lists' {
@@ -513,10 +513,10 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $null = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -PickerPageSize 2 -Confirm:$false
 
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
         }
 
         It 'filters picker results by package name when F is pressed' {
@@ -550,8 +550,8 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
             $result.Upgraded | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade curl' }).Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
         }
 
         It 'treats lowercase q as filter text instead of cancel' {
@@ -585,8 +585,8 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
             $result.Upgraded | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade jq' }).Count | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
         }
 
         It 'upgrades only the visible package when filtering duplicate winget ids by source' {
@@ -640,7 +640,7 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
             $result.Upgraded | Should -Be 1
             @($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements' }).Count | Should -Be 0
             ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source msstore --accept-package-agreements --accept-source-agreements' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
         }
 
         It 'toggles interactive mode for the current winget picker row' {
@@ -675,9 +675,9 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result.Upgraded | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --interactive' }).StreamOutput | Should -BeTrue
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match 'U remove old version\s+I interactive installer' } -Times 3
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+RmOld\s+UI\s+' } -Times 3
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -match '^> \[x\] \[ \]\s+\[I\]' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'U remove old version\s+I interactive installer' } -Times 3
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+RmOld\s+UI\s+' } -Times 3
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^> \[x\] \[ \]\s+\[I\]' } -Times 1
         }
 
         It 'does not suppress terminal echo when a custom key reader drives winget details' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -718,7 +718,7 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result.Selected | Should -Be 0
             $echoActions.Count | Should -Be 0
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
         }
 
         It 'restores terminal echo when winget details throw in the console key reader flow' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -886,7 +886,7 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result.Count | Should -Be 1
             ($script:Invocations | Where-Object { $_.Key -eq 'winget source update' }).StreamOutput | Should -BeFalse
-            Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -like 'Updating all sources*' -or $Object -like 'Updating source:*' } -Times 0
+            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Updating all sources*' -or $Object -like 'Updating source:*' } -Times 0 -Exactly
         }
 
         It 'falls back to table parsing when JSON output is unavailable' {

--- a/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
@@ -78,6 +78,8 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
     Context 'Prerequisite validation' {
         It 'Throws when Pandoc is not installed' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'pandoc' } -MockWith { $null }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
 
             { ConvertTo-Markdown -InputObject 'https://example.com' } |
             Should -Throw 'Pandoc is not installed or not available in PATH. Please install Pandoc and try again.'
@@ -102,6 +104,8 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
                     Source = '/usr/local/bin/pandoc'
                 }
             }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
         }
 
         It 'Converts a local file path and auto-saves markdown when -OutputPath is omitted' {
@@ -174,6 +178,11 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
                     Name = $script:PandocCommandName
                     Source = '/usr/local/bin/pandoc'
                 }
+            }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'ConvertTo-Markdown' } -MockWith {
+                $ExecutionContext.SessionState.InvokeCommand.GetCommand('ConvertTo-Markdown', [System.Management.Automation.CommandTypes]::Function)
             }
         }
 
@@ -302,6 +311,8 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
                     Source = '/usr/local/bin/pandoc'
                 }
             }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
+            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
         }
 
         It 'Throws when pandoc returns a non-zero exit code' {

--- a/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
@@ -68,7 +68,14 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
         Mock -CommandName Get-Command -MockWith {
             foreach ($commandName in @($Name))
             {
-                $ExecutionContext.SessionState.InvokeCommand.GetCommand($commandName, [System.Management.Automation.CommandTypes]::All)
+                try
+                {
+                    $ExecutionContext.SessionState.InvokeCommand.GetCommand($commandName, [System.Management.Automation.CommandTypes]::All)
+                }
+                catch
+                {
+                    $null
+                }
             }
         }
     }

--- a/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
@@ -64,6 +64,13 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
 
         $script:PandocShimInvocations = @()
         $script:PandocShimExitCode = 0
+
+        Mock -CommandName Get-Command -MockWith {
+            foreach ($commandName in @($Name))
+            {
+                $ExecutionContext.SessionState.InvokeCommand.GetCommand($commandName, [System.Management.Automation.CommandTypes]::All)
+            }
+        }
     }
 
     AfterEach {
@@ -78,8 +85,6 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
     Context 'Prerequisite validation' {
         It 'Throws when Pandoc is not installed' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'pandoc' } -MockWith { $null }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
 
             { ConvertTo-Markdown -InputObject 'https://example.com' } |
             Should -Throw 'Pandoc is not installed or not available in PATH. Please install Pandoc and try again.'
@@ -104,8 +109,6 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
                     Source = '/usr/local/bin/pandoc'
                 }
             }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
         }
 
         It 'Converts a local file path and auto-saves markdown when -OutputPath is omitted' {
@@ -178,11 +181,6 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
                     Name = $script:PandocCommandName
                     Source = '/usr/local/bin/pandoc'
                 }
-            }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'ConvertTo-Markdown' } -MockWith {
-                $ExecutionContext.SessionState.InvokeCommand.GetCommand('ConvertTo-Markdown', [System.Management.Automation.CommandTypes]::Function)
             }
         }
 
@@ -311,8 +309,6 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
                     Source = '/usr/local/bin/pandoc'
                 }
             }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-EncodingFromName' } -MockWith { $null }
-            Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'Get-FileEncoding' } -MockWith { $null }
         }
 
         It 'Throws when pandoc returns a non-zero exit code' {

--- a/Tests/Unit/Utilities/Extract-Archive.Tests.ps1
+++ b/Tests/Unit/Utilities/Extract-Archive.Tests.ps1
@@ -560,8 +560,8 @@ Describe 'Extract-Archive' {
 
     Context 'Missing dependency handling' {
         It 'Skips tar archives when tar dependency is missing' {
-            Mock -CommandName Get-Command { $null }
             Mock -CommandName Get-Command -MockWith { return $null } -ParameterFilter { $Name -contains 'tar' -or $Name -eq 'tar' }
+            Mock -CommandName Get-Command -MockWith { [PSCustomObject]@{ Name = '7z'; Source = '7z' } } -ParameterFilter { ($Name -contains '7z') -or ($Name -contains '7za') -or $Name -eq '7z' -or $Name -eq '7za' }
 
             $root = Join-Path -Path $TestDrive -ChildPath 'missing-tar'
             New-Item -ItemType Directory -Path $root -Force | Out-Null
@@ -576,7 +576,7 @@ Describe 'Extract-Archive' {
         }
 
         It 'Skips 7z/rar archives when 7z dependency is missing' {
-            Mock -CommandName Get-Command { $null }
+            Mock -CommandName Get-Command -MockWith { [PSCustomObject]@{ Name = 'tar'; Source = 'tar' } } -ParameterFilter { $Name -contains 'tar' -or $Name -eq 'tar' }
             Mock -CommandName Get-Command -MockWith { return $null } -ParameterFilter { ($Name -contains '7z') -or ($Name -contains '7za') -or $Name -eq '7z' -or $Name -eq '7za' }
 
             $root = Join-Path -Path $TestDrive -ChildPath 'missing-7z'

--- a/Tests/Unit/Utilities/Extract-Archive.Tests.ps1
+++ b/Tests/Unit/Utilities/Extract-Archive.Tests.ps1
@@ -560,6 +560,7 @@ Describe 'Extract-Archive' {
 
     Context 'Missing dependency handling' {
         It 'Skips tar archives when tar dependency is missing' {
+            Mock -CommandName Get-Command { $null }
             Mock -CommandName Get-Command -MockWith { return $null } -ParameterFilter { $Name -contains 'tar' -or $Name -eq 'tar' }
 
             $root = Join-Path -Path $TestDrive -ChildPath 'missing-tar'
@@ -575,6 +576,7 @@ Describe 'Extract-Archive' {
         }
 
         It 'Skips 7z/rar archives when 7z dependency is missing' {
+            Mock -CommandName Get-Command { $null }
             Mock -CommandName Get-Command -MockWith { return $null } -ParameterFilter { ($Name -contains '7z') -or ($Name -contains '7za') -or $Name -eq '7z' -or $Name -eq '7za' }
 
             $root = Join-Path -Path $TestDrive -ChildPath 'missing-7z'

--- a/dev-requirements.ps1
+++ b/dev-requirements.ps1
@@ -1,3 +1,3 @@
 # Install required PowerShell modules for development, testing, and analysis
 Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
-Install-Module -Name Pester -MinimumVersion '5.0.0' -MaximumVersion '5.99.99' -Scope CurrentUser -Force -SkipPublisherCheck
+Install-Module -Name Pester -MinimumVersion '6.0.0' -Scope CurrentUser -Force -SkipPublisherCheck

--- a/dev-requirements.ps1
+++ b/dev-requirements.ps1
@@ -1,3 +1,3 @@
 # Install required PowerShell modules for development, testing, and analysis
 Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -SkipPublisherCheck
-Install-Module -Name Pester -MinimumVersion '6.0.0' -Scope CurrentUser -Force -SkipPublisherCheck
+Install-Module -Name Pester -MinimumVersion '6.0.0' -MaximumVersion '6.999.999' -Scope CurrentUser -Force -SkipPublisherCheck

--- a/install.ps1
+++ b/install.ps1
@@ -549,6 +549,75 @@ function Remove-ProfileContentsExceptPreserved
     }
 }
 
+function Test-IsPowerShellCoreUnix
+{
+    param()
+
+    if ($PSVersionTable.PSVersion.Major -lt 6)
+    {
+        return $false
+    }
+
+    $isWindowsValue = Get-Variable -Name IsWindows -ValueOnly -ErrorAction SilentlyContinue
+    return -not $isWindowsValue
+}
+
+function Get-UnixFileType
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$LiteralPath
+    )
+
+    $statCommand = Get-Command -Name stat -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $statCommand)
+    {
+        return $null
+    }
+
+    try
+    {
+        $bsdFileType = & $statCommand.Source -f '%HT' $LiteralPath 2>$null | Select-Object -First 1
+        if ($LASTEXITCODE -eq 0 -and $bsdFileType -match '^(Regular File|Directory|Symbolic Link|Fifo File|Socket|Character Special File|Block Special File)$')
+        {
+            return $bsdFileType
+        }
+
+        $gnuFileType = & $statCommand.Source -c '%F' $LiteralPath 2>$null | Select-Object -First 1
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($gnuFileType))
+        {
+            return $gnuFileType
+        }
+    }
+    catch
+    {
+        return $null
+    }
+
+    return $null
+}
+
+function Test-PathIsUnixSpecialFile
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$LiteralPath
+    )
+
+    if (-not (Test-IsPowerShellCoreUnix))
+    {
+        return $false
+    }
+
+    $fileType = Get-UnixFileType -LiteralPath $LiteralPath
+    if ([string]::IsNullOrWhiteSpace($fileType))
+    {
+        return $false
+    }
+
+    return $fileType -match '(?i)\b(fifo|socket|character|block|device|pipe)\b'
+}
+
 function Copy-ProfileItem
 {
     param(
@@ -585,16 +654,10 @@ function Copy-ProfileItem
         return
     }
 
-    # Skip non-regular files (Unix sockets, named pipes, device files, etc.)
-    # that cannot be copied — e.g. .git/fsmonitor--daemon.ipc on macOS.
-    try
+    # Skip Unix sockets, named pipes, and device files without opening them.
+    if (Test-PathIsUnixSpecialFile -LiteralPath $SourcePath)
     {
-        $stream = [System.IO.File]::Open($SourcePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
-        $stream.Dispose()
-    }
-    catch [System.IO.IOException]
-    {
-        Write-Verbose "Skipping non-copyable file (socket or pipe): $SourcePath"
+        Write-Verbose "Skipping non-copyable special file: $SourcePath"
         return
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -585,6 +585,19 @@ function Copy-ProfileItem
         return
     }
 
+    # Skip non-regular files (Unix sockets, named pipes, device files, etc.)
+    # that cannot be copied — e.g. .git/fsmonitor--daemon.ipc on macOS.
+    try
+    {
+        $stream = [System.IO.File]::Open($SourcePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        $stream.Dispose()
+    }
+    catch [System.IO.IOException]
+    {
+        Write-Verbose "Skipping non-copyable file (socket or pipe): $SourcePath"
+        return
+    }
+
     $destinationParent = Split-Path -Parent $DestinationPath
     if ($destinationParent -and -not (Test-Path -Path $destinationParent))
     {


### PR DESCRIPTION
**Pester 6 migration** (102 files touched):

- Invoke-Tests.ps1 — dropped Pester 4.x fallback, require Pester ≥ 6, use `New-PesterConfiguration`
- dev-requirements.ps1 / `ci.yml` — install constraint updated to `MinimumVersion '6.0.0'`
- README.md — install snippet updated
- 14 `*.Tests.ps1` files — `Assert-MockCalled` → `Should -Invoke` (202 call sites); `-Times 0` kept as `-Exactly`, `-Times N` (N > 0) restored to "at least N" semantics
- 3 files — added default `Mock` fall-throughs for `Test-Path`, `Get-Command`, and `Get-Command` (Pester 6 no longer falls through to the real command)
- Invoke-Tests.Tests.ps1 — fake Pester module bumped to `6.99.0` (beats real 6.0.0 in module search), `New-PesterConfiguration` + `Invoke-Pester -Configuration` implemented

**macOS socket-file fix:**

- install.ps1 `Copy-ProfileItem` — skips Unix sockets/pipes (fsmonitor--daemon.ipc) by probing with `File.Open` before copying

> 2267/2335 passing, **1 failure remaining** — and that one ("prompts for a query") was already failing before the Pester 6 migration.