### PR TITLE
feat: pester6 Should migration

### DIFF
--- a/Tests/Integration/Developer/Import-DotEnv.Tests.ps1
+++ b/Tests/Integration/Developer/Import-DotEnv.Tests.ps1
@@ -191,32 +191,32 @@ Describe 'Import-DotEnv Integration Tests' {
             $result = Import-DotEnv -Path $envFile -PassThru
 
             # Verify application settings
-            $env:APP_NAME | Should -Be 'MyApp'
-            $env:APP_ENV | Should -Be 'development'
-            $env:APP_DEBUG | Should -Be 'true'
-            $env:APP_URL | Should -Be 'http://localhost:3000'
+            $env:APP_NAME | Should-Be 'MyApp'
+            $env:APP_ENV | Should-Be 'development'
+            $env:APP_DEBUG | Should-Be 'true'
+            $env:APP_URL | Should-Be 'http://localhost:3000'
 
             # Verify database settings
-            $env:DB_CONNECTION | Should -Be 'postgresql'
-            $env:DB_HOST | Should -Be 'localhost'
-            $env:DB_PORT | Should -Be '5432'
-            $env:DB_DATABASE | Should -Be 'myapp_dev'
-            $env:DB_USERNAME | Should -Be 'postgres'
-            $env:DB_PASSWORD | Should -Be 'secret123'
+            $env:DB_CONNECTION | Should-Be 'postgresql'
+            $env:DB_HOST | Should-Be 'localhost'
+            $env:DB_PORT | Should-Be '5432'
+            $env:DB_DATABASE | Should-Be 'myapp_dev'
+            $env:DB_USERNAME | Should-Be 'postgres'
+            $env:DB_PASSWORD | Should-Be 'secret123'
 
             # Verify cache settings
-            $env:CACHE_DRIVER | Should -Be 'redis'
-            $env:REDIS_HOST | Should -Be '127.0.0.1'
-            $env:REDIS_PORT | Should -Be '6379'
+            $env:CACHE_DRIVER | Should-Be 'redis'
+            $env:REDIS_HOST | Should-Be '127.0.0.1'
+            $env:REDIS_PORT | Should-Be '6379'
 
             # Verify mail settings
-            $env:MAIL_MAILER | Should -Be 'smtp'
-            $env:MAIL_HOST | Should -Be 'smtp.mailtrap.io'
-            $env:MAIL_PORT | Should -Be '2525'
+            $env:MAIL_MAILER | Should-Be 'smtp'
+            $env:MAIL_HOST | Should-Be 'smtp.mailtrap.io'
+            $env:MAIL_PORT | Should-Be '2525'
 
             # Verify PassThru result
-            $result.VariableCount | Should -BeGreaterThan 10
-            $result.FileName | Should -Be 'app.env'
+            $result.VariableCount | Should-BeGreaterThan 10
+            $result.FileName | Should-Be 'app.env'
 
             Remove-Item -Path $envFile -Force
         }
@@ -227,11 +227,11 @@ Describe 'Import-DotEnv Integration Tests' {
 
             Import-DotEnv -Path $envFile
 
-            $env:COMPOSE_PROJECT_NAME | Should -Be 'myproject'
-            $env:DOCKER_BUILDKIT | Should -Be '1'
-            $env:NODE_VERSION | Should -Be '18'
-            $env:POSTGRES_VERSION | Should -Be '15'
-            $env:WEB_PORT | Should -Be '8080'
+            $env:COMPOSE_PROJECT_NAME | Should-Be 'myproject'
+            $env:DOCKER_BUILDKIT | Should-Be '1'
+            $env:NODE_VERSION | Should-Be '18'
+            $env:POSTGRES_VERSION | Should-Be '15'
+            $env:WEB_PORT | Should-Be '8080'
 
             Remove-Item -Path $envFile -Force
         }
@@ -242,11 +242,11 @@ Describe 'Import-DotEnv Integration Tests' {
 
             Import-DotEnv -Path $envFile
 
-            $env:AWS_REGION | Should -Be 'us-east-1'
-            $env:AWS_ACCOUNT_ID | Should -Be '123456789012'
-            $env:AWS_ACCESS_KEY_ID | Should -Be 'AKIAIOSFODNN7EXAMPLE'
-            $env:AWS_SECRET_ACCESS_KEY | Should -Be 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-            $env:S3_BUCKET | Should -Be 'my-app-bucket'
+            $env:AWS_REGION | Should-Be 'us-east-1'
+            $env:AWS_ACCOUNT_ID | Should-Be '123456789012'
+            $env:AWS_ACCESS_KEY_ID | Should-Be 'AKIAIOSFODNN7EXAMPLE'
+            $env:AWS_SECRET_ACCESS_KEY | Should-Be 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+            $env:S3_BUCKET | Should-Be 'my-app-bucket'
 
             Remove-Item -Path $envFile -Force
         }
@@ -259,7 +259,7 @@ Describe 'Import-DotEnv Integration Tests' {
             $result = Import-DotEnv -Path $envDir -PassThru -WarningVariable warnings -WarningAction Continue
 
             $warnings | Should -Not -BeNullOrEmpty
-            ($warnings -join "`n") | Should -Match 'File not found.*dotenv-dir'
+            ($warnings -join "`n") | Should-MatchString 'File not found.*dotenv-dir'
             $env:APP_NAME | Should -BeNullOrEmpty
             $result | Should -BeNullOrEmpty
 
@@ -273,8 +273,8 @@ Describe 'Import-DotEnv Integration Tests' {
 
             $result = Import-DotEnv -Path $envFile -PassThru
 
-            $result.VariableCount | Should -Be 1
-            $env:BOM_VAR | Should -Be 'value_with_bom'
+            $result.VariableCount | Should-Be 1
+            $env:BOM_VAR | Should-Be 'value_with_bom'
 
             Remove-Item -Path $envFile -Force
         }
@@ -287,9 +287,9 @@ API_URL=https://first.example.com
 '@, [System.Text.Encoding]::UTF8)
 
             $initialResult = Import-DotEnv -Path $envFile -PassThru
-            $initialResult.VariableCount | Should -Be 2
-            $env:APP_NAME | Should -Be 'FirstLoad'
-            $env:API_URL | Should -Be 'https://first.example.com'
+            $initialResult.VariableCount | Should-Be 2
+            $env:APP_NAME | Should-Be 'FirstLoad'
+            $env:API_URL | Should-Be 'https://first.example.com'
 
             # Change the file values and load again without -Force; existing env vars should be preserved
             [System.IO.File]::WriteAllText($envFile, @'
@@ -299,11 +299,11 @@ API_URL=https://second.example.com
 
             $secondResult = Import-DotEnv -Path $envFile -PassThru
 
-            $env:APP_NAME | Should -Be 'FirstLoad'
-            $env:API_URL | Should -Be 'https://first.example.com'
-            $secondResult.VariableCount | Should -Be 0
-            $secondResult.Skipped | Should -Contain 'APP_NAME'
-            $secondResult.Skipped | Should -Contain 'API_URL'
+            $env:APP_NAME | Should-Be 'FirstLoad'
+            $env:API_URL | Should-Be 'https://first.example.com'
+            $secondResult.VariableCount | Should-Be 0
+            $secondResult.Skipped | Should-ContainCollection 'APP_NAME'
+            $secondResult.Skipped | Should-ContainCollection 'API_URL'
 
             Remove-Item -Path $envFile -Force
         }
@@ -331,17 +331,17 @@ LOCAL_SETTING=true
             # Load base first
             Import-DotEnv -Path $baseEnvFile
 
-            $env:APP_NAME | Should -Be 'BaseApp'
-            $env:APP_ENV | Should -Be 'production'
-            $env:DB_HOST | Should -Be 'prod-db.example.com'
+            $env:APP_NAME | Should-Be 'BaseApp'
+            $env:APP_ENV | Should-Be 'production'
+            $env:DB_HOST | Should-Be 'prod-db.example.com'
 
             # Load local overrides with Force
             Import-DotEnv -Path $localEnvFile -Force
 
-            $env:APP_NAME | Should -Be 'BaseApp'  # Not in local file
-            $env:APP_ENV | Should -Be 'development'  # Overridden
-            $env:DB_HOST | Should -Be 'localhost'  # Overridden
-            $env:LOCAL_SETTING | Should -Be 'true'  # New variable
+            $env:APP_NAME | Should-Be 'BaseApp'  # Not in local file
+            $env:APP_ENV | Should-Be 'development'  # Overridden
+            $env:DB_HOST | Should-Be 'localhost'  # Overridden
+            $env:LOCAL_SETTING | Should-Be 'true'  # New variable
 
             Remove-Item -Path $baseEnvFile, $localEnvFile -Force
         }
@@ -368,10 +368,10 @@ DB_PORT=5432'
             Import-DotEnv -Path (Join-Path -Path $script:TestDir -ChildPath '.env.development') -Force
             Import-DotEnv -Path (Join-Path -Path $script:TestDir -ChildPath '.env.local') -Force
 
-            $env:APP_NAME | Should -Be 'MyApp'
-            $env:APP_ENV | Should -Be 'development'
-            $env:DEBUG | Should -Be 'true'
-            $env:DB_HOST | Should -Be 'localhost'
+            $env:APP_NAME | Should-Be 'MyApp'
+            $env:APP_ENV | Should-Be 'development'
+            $env:DEBUG | Should-Be 'true'
+            $env:DB_HOST | Should-Be 'localhost'
 
             foreach ($fileName in $envFiles.Keys)
             {
@@ -387,11 +387,11 @@ DB_PORT=5432'
 
             Import-DotEnv -Path $envFile
 
-            $env:HOME_DIR | Should -Be '/home/user'
-            $env:PROJECT_ROOT | Should -Be '/home/user/projects/myapp'
-            $env:CONFIG_PATH | Should -Be '/home/user/projects/myapp/config'
-            $env:DATA_PATH | Should -Be '/home/user/projects/myapp/data'
-            $env:LOG_PATH | Should -Be '/home/user/projects/myapp/logs'
+            $env:HOME_DIR | Should-Be '/home/user'
+            $env:PROJECT_ROOT | Should-Be '/home/user/projects/myapp'
+            $env:CONFIG_PATH | Should-Be '/home/user/projects/myapp/config'
+            $env:DATA_PATH | Should-Be '/home/user/projects/myapp/data'
+            $env:LOG_PATH | Should-Be '/home/user/projects/myapp/logs'
 
             Remove-Item -Path $envFile -Force
         }
@@ -406,9 +406,9 @@ API_ENDPOINT="${API_BASE}/${API_VERSION}"
 
             Import-DotEnv -Path $envFile
 
-            $env:API_BASE | Should -Be 'https://api.example.com'
-            $env:API_VERSION | Should -Be 'v2'
-            $env:API_ENDPOINT | Should -Be 'https://api.example.com/v2'
+            $env:API_BASE | Should-Be 'https://api.example.com'
+            $env:API_VERSION | Should-Be 'v2'
+            $env:API_ENDPOINT | Should-Be 'https://api.example.com/v2'
 
             Remove-Item -Path $envFile -Force
         }
@@ -421,16 +421,16 @@ API_ENDPOINT="${API_BASE}/${API_VERSION}"
 
             Import-DotEnv -Path $envFile
 
-            $env:SIMPLE | Should -Be 'value'
-            $env:DOUBLE_QUOTED | Should -Be 'value with spaces'
-            $env:SINGLE_QUOTED | Should -Be 'value with spaces'
-            $env:SPECIAL | Should -Be '!@#$%^&*()'
-            $env:ESCAPED | Should -Match "Line 1`nLine 2"
-            $env:INLINE | Should -Be 'value'
-            $env:EXPORTED | Should -Be 'exported_value'
+            $env:SIMPLE | Should-Be 'value'
+            $env:DOUBLE_QUOTED | Should-Be 'value with spaces'
+            $env:SINGLE_QUOTED | Should-Be 'value with spaces'
+            $env:SPECIAL | Should-Be '!@#$%^&*()'
+            $env:ESCAPED | Should-MatchString "Line 1`nLine 2"
+            $env:INLINE | Should-Be 'value'
+            $env:EXPORTED | Should-Be 'exported_value'
             $env:EMPTY | Should -BeNullOrEmpty
-            $env:EQUALS | Should -Be 'key=value=another'
-            $env:EXPANDED | Should -Be 'base_expanded'
+            $env:EQUALS | Should-Be 'key=value=another'
+            $env:EXPANDED | Should-Be 'base_expanded'
 
             Remove-Item -Path $envFile -Force
         }
@@ -447,16 +447,16 @@ WORKFLOW_VAR3=value3
 
             # Load
             $loadResult = Import-DotEnv -Path $envFile -PassThru
-            $loadResult.VariableCount | Should -Be 3
+            $loadResult.VariableCount | Should-Be 3
 
             # Use
-            $env:WORKFLOW_VAR1 | Should -Be 'value1'
-            $env:WORKFLOW_VAR2 | Should -Be 'value2'
-            $env:WORKFLOW_VAR3 | Should -Be 'value3'
+            $env:WORKFLOW_VAR1 | Should-Be 'value1'
+            $env:WORKFLOW_VAR2 | Should-Be 'value2'
+            $env:WORKFLOW_VAR3 | Should-Be 'value3'
 
             # Unload
             $unloadResult = Import-DotEnv -Unload -PassThru
-            $unloadResult.VariableCount | Should -Be 3
+            $unloadResult.VariableCount | Should-Be 3
 
             # Verify cleanup
             $env:WORKFLOW_VAR1 | Should -BeNullOrEmpty
@@ -475,7 +475,7 @@ RELOAD_VAR=initial_value
 
             # First load
             Import-DotEnv -Path $envFile
-            $env:RELOAD_VAR | Should -Be 'initial_value'
+            $env:RELOAD_VAR | Should-Be 'initial_value'
 
             # Unload
             Import-DotEnv -Unload
@@ -487,7 +487,7 @@ RELOAD_VAR=new_value
 '@, [System.Text.Encoding]::UTF8)
 
             Import-DotEnv -Path $envFile
-            $env:RELOAD_VAR | Should -Be 'new_value'
+            $env:RELOAD_VAR | Should-Be 'new_value'
 
             Remove-Item -Path $envFile -Force
         }
@@ -504,7 +504,7 @@ RELOAD_VAR=new_value
             Import-DotEnv -Path @($validFile, $invalidFile) -WarningAction SilentlyContinue
 
             # Should still load the valid file
-            $env:VALID_VAR | Should -Be 'value'
+            $env:VALID_VAR | Should-Be 'value'
 
             Remove-Item -Path $validFile -Force
         }
@@ -517,8 +517,8 @@ RELOAD_VAR=new_value
             Import-DotEnv -Path $missingFile -WarningVariable warnings -WarningAction Continue
 
             $warnings | Should -Not -BeNullOrEmpty
-            ($warnings -join "`n") | Should -Match $escapedMissingFile
-            ($warnings -join "`n") | Should -Match 'File not found'
+            ($warnings -join "`n") | Should-MatchString $escapedMissingFile
+            ($warnings -join "`n") | Should-MatchString 'File not found'
         }
 
         It 'Should handle file read permissions gracefully' {
@@ -542,8 +542,8 @@ RELATIVE_PATH=./config/app.json
 
             Import-DotEnv -Path $envFile
 
-            $env:UNIX_PATH | Should -Be '/usr/local/bin'
-            $env:RELATIVE_PATH | Should -Be './config/app.json'
+            $env:UNIX_PATH | Should-Be '/usr/local/bin'
+            $env:RELATIVE_PATH | Should-Be './config/app.json'
 
             Remove-Item -Path $envFile -Force
         }
@@ -557,8 +557,8 @@ NETWORK_PATH="\\\\server\\share"
 
             Import-DotEnv -Path $envFile
 
-            $env:WIN_PATH | Should -Be 'C:\Program Files\MyApp'
-            $env:NETWORK_PATH | Should -Be '\\server\share'
+            $env:WIN_PATH | Should-Be 'C:\Program Files\MyApp'
+            $env:NETWORK_PATH | Should-Be '\\server\share'
 
             Remove-Item -Path $envFile -Force
         }
@@ -576,10 +576,10 @@ NETWORK_PATH="\\\\server\\share"
 
             $result = Import-DotEnv -Path $envFile -PassThru
 
-            $result.VariableCount | Should -Be 100
-            $env:VAR_1 | Should -Be 'value_1'
-            $env:VAR_50 | Should -Be 'value_50'
-            $env:VAR_100 | Should -Be 'value_100'
+            $result.VariableCount | Should-Be 100
+            $env:VAR_1 | Should-Be 'value_1'
+            $env:VAR_50 | Should-Be 'value_50'
+            $env:VAR_100 | Should-Be 'value_100'
 
             # Cleanup
             for ($i = 1; $i -le 100; $i++)
@@ -601,13 +601,13 @@ NETWORK_PATH="\\\\server\\share"
 
             # Verify we got results
             $result | Should -Not -BeNullOrEmpty
-            $result.Count | Should -BeGreaterThan 10
+            $result.Count | Should-BeGreaterThan 10
 
             # Check specific values
-            ($result | Where-Object { $_.Name -eq 'APP_NAME' }).Value | Should -Be 'MyApp'
-            ($result | Where-Object { $_.Name -eq 'APP_ENV' }).Value | Should -Be 'development'
-            ($result | Where-Object { $_.Name -eq 'DB_CONNECTION' }).Value | Should -Be 'postgresql'
-            ($result | Where-Object { $_.Name -eq 'DB_HOST' }).Value | Should -Be 'localhost'
+            ($result | Where-Object { $_.Name -eq 'APP_NAME' }).Value | Should-Be 'MyApp'
+            ($result | Where-Object { $_.Name -eq 'APP_ENV' }).Value | Should-Be 'development'
+            ($result | Where-Object { $_.Name -eq 'DB_CONNECTION' }).Value | Should-Be 'postgresql'
+            ($result | Where-Object { $_.Name -eq 'DB_HOST' }).Value | Should-Be 'localhost'
 
             Remove-Item -Path $envFile -Force
         }
@@ -634,11 +634,11 @@ DEBUG=true
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
             # Should show all variables with final values
-            $result.Count | Should -Be 4
-            ($result | Where-Object { $_.Name -eq 'APP_NAME' }).Value | Should -Be 'BaseApp'
-            ($result | Where-Object { $_.Name -eq 'APP_ENV' }).Value | Should -Be 'development'
-            ($result | Where-Object { $_.Name -eq 'DB_HOST' }).Value | Should -Be 'localhost'
-            ($result | Where-Object { $_.Name -eq 'DEBUG' }).Value | Should -Be 'true'
+            $result.Count | Should-Be 4
+            ($result | Where-Object { $_.Name -eq 'APP_NAME' }).Value | Should-Be 'BaseApp'
+            ($result | Where-Object { $_.Name -eq 'APP_ENV' }).Value | Should-Be 'development'
+            ($result | Where-Object { $_.Name -eq 'DB_HOST' }).Value | Should-Be 'localhost'
+            ($result | Where-Object { $_.Name -eq 'DEBUG' }).Value | Should-Be 'true'
 
             Remove-Item -Path $file1, $file2 -Force
         }
@@ -655,9 +655,9 @@ CONFIG_PATH="${PROJECT_PATH}/config"
 
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
-            ($result | Where-Object { $_.Name -eq 'BASE_PATH' }).Value | Should -Be '/home/user'
-            ($result | Where-Object { $_.Name -eq 'PROJECT_PATH' }).Value | Should -Be '/home/user/projects'
-            ($result | Where-Object { $_.Name -eq 'CONFIG_PATH' }).Value | Should -Be '/home/user/projects/config'
+            ($result | Where-Object { $_.Name -eq 'BASE_PATH' }).Value | Should-Be '/home/user'
+            ($result | Where-Object { $_.Name -eq 'PROJECT_PATH' }).Value | Should-Be '/home/user/projects'
+            ($result | Where-Object { $_.Name -eq 'CONFIG_PATH' }).Value | Should-Be '/home/user/projects/config'
 
             Remove-Item -Path $envFile -Force
         }
@@ -680,9 +680,9 @@ TIMEOUT=30
             # Show values should reflect current state
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
-            ($result | Where-Object { $_.Name -eq 'CONFIG_MODE' }).Value | Should -Be 'modified'
-            ($result | Where-Object { $_.Name -eq 'API_ENDPOINT' }).Value | Should -Be 'https://api.example.com'
-            ($result | Where-Object { $_.Name -eq 'TIMEOUT' }).Value | Should -Be '60'
+            ($result | Where-Object { $_.Name -eq 'CONFIG_MODE' }).Value | Should-Be 'modified'
+            ($result | Where-Object { $_.Name -eq 'API_ENDPOINT' }).Value | Should-Be 'https://api.example.com'
+            ($result | Where-Object { $_.Name -eq 'TIMEOUT' }).Value | Should-Be '60'
 
             Remove-Item -Path $envFile -Force
         }

--- a/Tests/Integration/Developer/Invoke-GitPull.Tests.ps1
+++ b/Tests/Integration/Developer/Invoke-GitPull.Tests.ps1
@@ -153,9 +153,9 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath
 
-            $result.RepositoriesProcessed | Should -Be 1
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.RepositoriesFailed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 1
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.RepositoriesFailed | Should-Be 0
         }
 
         It 'Should report already up to date' {
@@ -163,8 +163,8 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath
 
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.Results[0].Message | Should -Match 'up to date|Updated successfully'
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.Results[0].Message | Should-MatchString 'up to date|Updated successfully'
         }
 
         It 'Should skip non-Git directory' {
@@ -173,8 +173,8 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $nonGitDir
 
-            $result.RepositoriesSkipped | Should -Be 1
-            $result.RepositoriesProcessed | Should -Be 0
+            $result.RepositoriesSkipped | Should-Be 1
+            $result.RepositoriesProcessed | Should-Be 0
         }
 
         It 'Should skip repository without remote origin configured' {
@@ -182,9 +182,9 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -WarningAction SilentlyContinue
 
-            $result.RepositoriesProcessed | Should -Be 0
-            $result.RepositoriesSkipped | Should -Be 1
-            $result.RepositoriesFailed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 0
+            $result.RepositoriesSkipped | Should-Be 1
+            $result.RepositoriesFailed | Should-Be 0
         }
 
         It 'Should respect -WhatIf and not make changes' {
@@ -197,7 +197,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             # HEAD should be unchanged (use 2>$null for PS 5.1 compatibility)
             $headAfter = & git -C $repos.RepoPath rev-parse HEAD 2>$null
-            $headAfter | Should -Be $headBefore
+            $headAfter | Should-Be $headBefore
         }
 
         It 'Should use rebase by default' {
@@ -206,7 +206,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
             # The command should succeed (rebase is default)
             $result = Invoke-GitPull -Path $repos.RepoPath
 
-            $result.RepositoriesUpdated | Should -Be 1
+            $result.RepositoriesUpdated | Should-Be 1
         }
 
         It 'Should support -NoRebase option' {
@@ -214,7 +214,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -NoRebase
 
-            $result.RepositoriesUpdated | Should -Be 1
+            $result.RepositoriesUpdated | Should-Be 1
         }
 
         It 'Should support -Prune option' {
@@ -222,7 +222,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -Prune
 
-            $result.RepositoriesUpdated | Should -Be 1
+            $result.RepositoriesUpdated | Should-Be 1
         }
     }
 
@@ -245,8 +245,8 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path @($repos1.RepoPath, $repos2.RepoPath)
 
-            $result.RepositoriesProcessed | Should -Be 2
-            $result.RepositoriesUpdated | Should -Be 2
+            $result.RepositoriesProcessed | Should-Be 2
+            $result.RepositoriesUpdated | Should-Be 2
         }
 
         It 'Should accept paths from pipeline' {
@@ -255,8 +255,8 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = @($repos1.RepoPath, $repos2.RepoPath) | Invoke-GitPull
 
-            $result.RepositoriesProcessed | Should -Be 2
-            $result.RepositoriesUpdated | Should -Be 2
+            $result.RepositoriesProcessed | Should-Be 2
+            $result.RepositoriesUpdated | Should-Be 2
         }
 
         It 'Should skip repository without remote and continue processing remaining' {
@@ -265,10 +265,10 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path @($repos1.RepoPath, $repos2.RepoPath) -WarningAction SilentlyContinue
 
-            $result.RepositoriesProcessed | Should -Be 1
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.RepositoriesSkipped | Should -Be 1
-            $result.RepositoriesFailed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 1
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.RepositoriesSkipped | Should-Be 1
+            $result.RepositoriesFailed | Should-Be 0
         }
     }
 
@@ -295,8 +295,8 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $script:TestWorkspace -Recurse
 
-            $result.RepositoriesProcessed | Should -Be 2
-            $result.RepositoriesUpdated | Should -Be 2
+            $result.RepositoriesProcessed | Should-Be 2
+            $result.RepositoriesUpdated | Should-Be 2
         }
 
         It 'Should respect -Depth parameter' {
@@ -312,7 +312,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
             # With depth 1, should only find level 1 repo
             $result = Invoke-GitPull -Path $script:TestWorkspace -Recurse -Depth 1
 
-            $result.RepositoriesProcessed | Should -Be 1
+            $result.RepositoriesProcessed | Should-Be 1
         }
 
         It 'Should handle empty directory with -Recurse' {
@@ -321,7 +321,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $emptyDir -Recurse
 
-            $result.RepositoriesProcessed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 0
         }
 
         It 'Should find repository when path is the repository itself with -Recurse' {
@@ -329,8 +329,8 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -Recurse
 
-            $result.RepositoriesProcessed | Should -Be 1
-            $result.RepositoriesUpdated | Should -Be 1
+            $result.RepositoriesProcessed | Should-Be 1
+            $result.RepositoriesUpdated | Should-Be 1
         }
     }
 
@@ -352,10 +352,10 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath
 
-            $result.Results | Should -HaveCount 1
-            $result.Results[0].Path | Should -Be $repos.RepoPath
-            $result.Results[0].Name | Should -Be 'detail-repo'
-            $result.Results[0].Success | Should -BeTrue
+            $result.Results | Should-BeCollection -Count 1
+            $result.Results[0].Path | Should-Be $repos.RepoPath
+            $result.Results[0].Name | Should-Be 'detail-repo'
+            $result.Results[0].Success | Should-BeTruthy
             $result.Results[0].Message | Should -Not -BeNullOrEmpty
         }
 
@@ -365,7 +365,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
             # Pulling a non-existent branch forces a real failure with an error message
             $result = Invoke-GitPull -Path $repos.RepoPath -Branch 'branch-does-not-exist' -Force -ErrorAction SilentlyContinue
 
-            $result.Results[0].Success | Should -BeFalse
+            $result.Results[0].Success | Should-BeFalsy
             $result.Results[0].Message | Should -Not -BeNullOrEmpty
         }
     }
@@ -390,7 +390,7 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath
 
-            $result.RepositoriesUpdated | Should -Be 1
+            $result.RepositoriesUpdated | Should-Be 1
         }
 
         It 'Should handle mixed valid and invalid paths' {
@@ -399,8 +399,8 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path @($repos.RepoPath, $invalidPath) -WarningAction SilentlyContinue
 
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.RepositoriesSkipped | Should -Be 1
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.RepositoriesSkipped | Should-Be 1
         }
     }
 
@@ -422,9 +422,9 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -Branch $repos.BranchName
 
-            $result.RepositoriesProcessed | Should -Be 1
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.RepositoriesFailed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 1
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.RepositoriesFailed | Should-Be 0
         }
 
         It 'Should auto-detect the default branch with -DefaultBranch' {
@@ -435,9 +435,9 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -DefaultBranch
 
-            $result.RepositoriesProcessed | Should -Be 1
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.RepositoriesFailed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 1
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.RepositoriesFailed | Should-Be 0
         }
 
         It 'Should auto-detect default branch for each repository in recursive mode' {
@@ -449,16 +449,16 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $script:TestWorkspace -Recurse -DefaultBranch
 
-            $result.RepositoriesProcessed | Should -Be 2
-            $result.RepositoriesUpdated | Should -Be 2
+            $result.RepositoriesProcessed | Should-Be 2
+            $result.RepositoriesUpdated | Should-Be 2
         }
 
         It 'Should throw when -Branch and -DefaultBranch are both specified' {
-            { Invoke-GitPull -Branch 'main' -DefaultBranch } | Should -Throw '*Cannot use*'
+            { Invoke-GitPull -Branch 'main' -DefaultBranch } | Should-Throw '*Cannot use*'
         }
 
         It 'Should throw when -Checkout is used without -Branch or -DefaultBranch' {
-            { Invoke-GitPull -Checkout } | Should -Throw '*Checkout*requires*'
+            { Invoke-GitPull -Checkout } | Should-Throw '*Checkout*requires*'
         }
 
         It 'Should switch to the specified branch before pulling with -Checkout' {
@@ -469,13 +469,13 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -Branch $repos.BranchName -Checkout
 
-            $result.RepositoriesProcessed | Should -Be 1
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.RepositoriesFailed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 1
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.RepositoriesFailed | Should-Be 0
 
             # Verify we are now on the target branch
             $currentBranch = Invoke-GitWithOutput -WorkingDirectory $repos.RepoPath -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
-            $currentBranch | Should -Be $repos.BranchName
+            $currentBranch | Should-Be $repos.BranchName
         }
 
         It 'Should switch to the auto-detected default branch with -DefaultBranch -Checkout' {
@@ -487,13 +487,13 @@ Describe 'Invoke-GitPull Integration Tests' -Tag 'Integration' {
 
             $result = Invoke-GitPull -Path $repos.RepoPath -DefaultBranch -Checkout
 
-            $result.RepositoriesProcessed | Should -Be 1
-            $result.RepositoriesUpdated | Should -Be 1
-            $result.RepositoriesFailed | Should -Be 0
+            $result.RepositoriesProcessed | Should-Be 1
+            $result.RepositoriesUpdated | Should-Be 1
+            $result.RepositoriesFailed | Should-Be 0
 
             # Verify we are now on the default branch
             $currentBranch = Invoke-GitWithOutput -WorkingDirectory $repos.RepoPath -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
-            $currentBranch | Should -Be $repos.BranchName
+            $currentBranch | Should-Be $repos.BranchName
         }
     }
 }

--- a/Tests/Integration/Developer/Remove-DotNetBuildArtifact.Tests.ps1
+++ b/Tests/Integration/Developer/Remove-DotNetBuildArtifact.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     # Suppress progress bars to prevent freezing in non-interactive environments
     $Global:ProgressPreference = 'SilentlyContinue'
 
@@ -53,10 +53,10 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath -Recurse
 
             # Verify folders are removed
-            Test-Path $BinPath | Should -BeFalse
-            Test-Path $ObjPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 2
-            $Result.TotalProjectsFound | Should -Be 1
+            Test-Path $BinPath | Should-BeFalsy
+            Test-Path $ObjPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 2
+            $Result.TotalProjectsFound | Should-Be 1
         }
 
         It 'Should remove bin and obj folders from VB.NET projects' {
@@ -72,8 +72,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath -Recurse
 
             # Verify
-            Test-Path $BinPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path $BinPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 1
         }
 
         It 'Should remove bin and obj folders from F# projects' {
@@ -89,8 +89,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath -Recurse
 
             # Verify
-            Test-Path $ObjPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path $ObjPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 1
         }
 
         It 'Should remove bin and obj folders from SQL projects' {
@@ -106,8 +106,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath -Recurse
 
             # Verify
-            Test-Path $BinPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path $BinPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 1
         }
 
         It 'Should not remove bin/obj folders without project file' {
@@ -121,10 +121,10 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath
 
             # Verify folders still exist (no project file found)
-            Test-Path $BinPath | Should -BeTrue
-            Test-Path $ObjPath | Should -BeTrue
-            $Result.FoldersRemoved | Should -Be 0
-            $Result.TotalProjectsFound | Should -Be 0
+            Test-Path $BinPath | Should-BeTruthy
+            Test-Path $ObjPath | Should-BeTruthy
+            $Result.FoldersRemoved | Should-Be 0
+            $Result.TotalProjectsFound | Should-Be 0
         }
 
         It 'Should respect -WhatIf parameter' {
@@ -137,7 +137,7 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $null = Remove-DotNetBuildArtifact -Path $script:ProjectPath -WhatIf
 
             # Verify folder still exists
-            Test-Path $BinPath | Should -BeTrue
+            Test-Path $BinPath | Should-BeTruthy
         }
 
         It 'Should calculate space freed' {
@@ -153,8 +153,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath
 
             # Verify space calculation
-            $Result.TotalSpaceFreed | Should -Not -Match 'Not calculated'
-            $Result.TotalSpaceFreed | Should -Not -Be '0 bytes'
+            $Result.TotalSpaceFreed | Should-NotMatchString 'Not calculated'
+            $Result.TotalSpaceFreed | Should-NotBe '0 bytes'
         }
 
         It 'Should skip size calculation with -NoSizeCalculation' {
@@ -170,8 +170,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath -NoSizeCalculation
 
             # Verify
-            $Result.TotalSpaceFreed | Should -Match 'Not calculated'
-            $Result.FoldersRemoved | Should -Be 1
+            $Result.TotalSpaceFreed | Should-MatchString 'Not calculated'
+            $Result.FoldersRemoved | Should-Be 1
         }
     }
 
@@ -213,15 +213,15 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:WorkspacePath -Recurse
 
             # Verify all artifacts removed
-            Test-Path (Join-Path -Path $Project1 -ChildPath 'bin') | Should -BeFalse
-            Test-Path (Join-Path -Path $Project1 -ChildPath 'obj') | Should -BeFalse
-            Test-Path (Join-Path -Path $Project2 -ChildPath 'bin') | Should -BeFalse
-            Test-Path (Join-Path -Path $Project2 -ChildPath 'obj') | Should -BeFalse
-            Test-Path (Join-Path -Path $Project3 -ChildPath 'bin') | Should -BeFalse
-            Test-Path (Join-Path -Path $Project3 -ChildPath 'obj') | Should -BeFalse
+            Test-Path (Join-Path -Path $Project1 -ChildPath 'bin') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Project1 -ChildPath 'obj') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Project2 -ChildPath 'bin') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Project2 -ChildPath 'obj') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Project3 -ChildPath 'bin') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Project3 -ChildPath 'obj') | Should-BeFalsy
 
-            $Result.TotalProjectsFound | Should -Be 3
-            $Result.FoldersRemoved | Should -Be 6
+            $Result.TotalProjectsFound | Should-Be 3
+            $Result.FoldersRemoved | Should-Be 6
         }
 
         It 'Should limit scope without Recurse' {
@@ -238,11 +238,11 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
 
             $Result = Remove-DotNetBuildArtifact -Path $rootProject
 
-            Test-Path (Join-Path -Path $rootProject -ChildPath 'bin') | Should -BeFalse
-            Test-Path (Join-Path -Path $rootProject -ChildPath 'obj') | Should -BeFalse
-            Test-Path (Join-Path -Path $nestedProject -ChildPath 'bin') | Should -BeTrue
-            Test-Path (Join-Path -Path $nestedProject -ChildPath 'obj') | Should -BeTrue
-            $Result.FoldersRemoved | Should -Be 2
+            Test-Path (Join-Path -Path $rootProject -ChildPath 'bin') | Should-BeFalsy
+            Test-Path (Join-Path -Path $rootProject -ChildPath 'obj') | Should-BeFalsy
+            Test-Path (Join-Path -Path $nestedProject -ChildPath 'bin') | Should-BeTruthy
+            Test-Path (Join-Path -Path $nestedProject -ChildPath 'obj') | Should-BeTruthy
+            $Result.FoldersRemoved | Should-Be 2
         }
 
         It 'Should handle projects with only bin or only obj' {
@@ -264,10 +264,10 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:WorkspacePath -Recurse
 
             # Verify
-            Test-Path $BinPath | Should -BeFalse
-            Test-Path $ObjPath | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 2
-            $Result.FoldersRemoved | Should -Be 2
+            Test-Path $BinPath | Should-BeFalsy
+            Test-Path $ObjPath | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 2
+            $Result.FoldersRemoved | Should-Be 2
         }
 
         It 'Should handle nested bin/obj directories' {
@@ -289,8 +289,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:WorkspacePath -Recurse
 
             # Verify entire bin directory is removed
-            Test-Path $BinPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path $BinPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 1
         }
     }
 
@@ -327,9 +327,9 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:WorkspacePath -Recurse
 
             # Verify .git project was excluded
-            Test-Path $BinPath | Should -BeTrue
-            Test-Path $NormalBin | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 1
+            Test-Path $BinPath | Should-BeTruthy
+            Test-Path $NormalBin | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 1
         }
 
         It 'Should exclude node_modules directories by default' {
@@ -345,8 +345,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:WorkspacePath
 
             # Verify node_modules project was excluded
-            Test-Path $BinPath | Should -BeTrue
-            $Result.TotalProjectsFound | Should -Be 0
+            Test-Path $BinPath | Should-BeTruthy
+            $Result.TotalProjectsFound | Should-Be 0
         }
 
         It 'Should respect custom ExcludeDirectory parameter' {
@@ -369,9 +369,9 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:WorkspacePath -ExcludeDirectory @('.git', 'node_modules', 'vendor') -Recurse
 
             # Verify vendor was excluded, normal was cleaned
-            Test-Path $VendorBin | Should -BeTrue
-            Test-Path $NormalBin | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 1
+            Test-Path $VendorBin | Should-BeTruthy
+            Test-Path $NormalBin | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 1
         }
     }
 
@@ -399,7 +399,7 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
                 $RelativePath = Split-Path $script:ProjectPath -Leaf
                 $Result = Remove-DotNetBuildArtifact -Path $RelativePath
 
-                $Result.FoldersRemoved | Should -Be 1
+                $Result.FoldersRemoved | Should-Be 1
             }
             finally
             {
@@ -413,7 +413,7 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             {
                 $Result = Remove-DotNetBuildArtifact
 
-                $Result.FoldersRemoved | Should -Be 1
+                $Result.FoldersRemoved | Should-Be 1
             }
             finally
             {
@@ -426,7 +426,7 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
         It 'Should handle invalid path' {
             $InvalidPath = Join-Path -Path $script:TestRoot -ChildPath 'nonexistent-path'
 
-            { Remove-DotNetBuildArtifact -Path $InvalidPath -ErrorAction Stop } | Should -Throw
+            { Remove-DotNetBuildArtifact -Path $InvalidPath -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should handle path that is not a directory' {
@@ -435,7 +435,7 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
 
             try
             {
-                { Remove-DotNetBuildArtifact -Path $FilePath -ErrorAction Stop } | Should -Throw
+                { Remove-DotNetBuildArtifact -Path $FilePath -ErrorAction Stop } | Should-Throw
             }
             finally
             {
@@ -451,8 +451,8 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             {
                 $Result = Remove-DotNetBuildArtifact -Path $EmptyPath
 
-                $Result.PSObject.Properties.Name | Should -Contain 'Errors'
-                $Result.Errors | Should -BeOfType [int]
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'Errors'
+                $Result.Errors | Should-HaveType ([int])
             }
             finally
             {
@@ -482,9 +482,9 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath
 
             # Should complete successfully
-            $Result.TotalProjectsFound | Should -Be 1
-            $Result.FoldersRemoved | Should -Be 0
-            $Result.Errors | Should -Be 0
+            $Result.TotalProjectsFound | Should-Be 1
+            $Result.FoldersRemoved | Should-Be 0
+            $Result.Errors | Should-Be 0
         }
 
         It 'Should handle empty directory' {
@@ -492,9 +492,9 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath
 
             # Should complete without errors
-            $Result.TotalProjectsFound | Should -Be 0
-            $Result.FoldersRemoved | Should -Be 0
-            $Result.Errors | Should -Be 0
+            $Result.TotalProjectsFound | Should-Be 0
+            $Result.FoldersRemoved | Should-Be 0
+            $Result.Errors | Should-Be 0
         }
 
         It 'Should handle mixed project types' {
@@ -514,10 +514,10 @@ Describe 'Remove-DotNetBuildArtifact Integration Tests' -Tag 'Integration' {
             $Result = Remove-DotNetBuildArtifact -Path $script:ProjectPath -Recurse
 
             # Verify both projects cleaned
-            Test-Path $BinPath1 | Should -BeFalse
-            Test-Path $ObjPath | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 2
-            $Result.FoldersRemoved | Should -Be 2
+            Test-Path $BinPath1 | Should-BeFalsy
+            Test-Path $ObjPath | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 2
+            $Result.FoldersRemoved | Should-Be 2
         }
     }
 }

--- a/Tests/Integration/Developer/Remove-GitIgnoredFile.Tests.ps1
+++ b/Tests/Integration/Developer/Remove-GitIgnoredFile.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     # Suppress progress bars to prevent freezing in non-interactive environments
     $Global:ProgressPreference = 'SilentlyContinue'
 
@@ -67,9 +67,9 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:RepoPath
 
             # Verify files are removed
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should -BeFalse
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.tmp') | Should -BeFalse
-            $Result.FilesRemoved | Should -Be 2
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should-BeFalsy
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.tmp') | Should-BeFalsy
+            $Result.FilesRemoved | Should-Be 2
         }
 
         It 'Should remove ignored directories' {
@@ -82,8 +82,8 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:RepoPath
 
             # Verify directory is removed
-            Test-Path $BuildDir | Should -BeFalse
-            $Result.DirectoriesRemoved | Should -Be 1
+            Test-Path $BuildDir | Should-BeFalsy
+            $Result.DirectoriesRemoved | Should-Be 1
         }
 
         It 'Should not remove tracked files' {
@@ -99,8 +99,8 @@ temp/
             $null = Remove-GitIgnoredFile -Path $script:RepoPath
 
             # Verify tracked file still exists
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'README.md') | Should -BeTrue
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should -BeFalse
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'README.md') | Should-BeTruthy
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should-BeFalsy
         }
 
         It 'Should not remove untracked files by default' {
@@ -114,8 +114,8 @@ temp/
             $null = Remove-GitIgnoredFile -Path $script:RepoPath
 
             # Verify untracked file still exists, ignored file removed
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'untracked.txt') | Should -BeTrue
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should -BeFalse
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'untracked.txt') | Should-BeTruthy
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should-BeFalsy
         }
 
         It 'Should remove untracked files with -IncludeUntracked' {
@@ -129,9 +129,9 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:RepoPath -IncludeUntracked
 
             # Verify both files are removed
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'untracked.txt') | Should -BeFalse
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should -BeFalse
-            $Result.FilesRemoved | Should -Be 2
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'untracked.txt') | Should-BeFalsy
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should-BeFalsy
+            $Result.FilesRemoved | Should-Be 2
         }
 
         It 'Should respect -WhatIf parameter' {
@@ -142,7 +142,7 @@ temp/
             $null = Remove-GitIgnoredFile -Path $script:RepoPath -WhatIf
 
             # Verify file still exists
-            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should -BeTrue
+            Test-Path (Join-Path -Path $script:RepoPath -ChildPath 'test.log') | Should-BeTruthy
         }
 
         It 'Should handle repository with no ignored files' {
@@ -150,9 +150,9 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:RepoPath
 
             # Should complete successfully with no removals
-            $Result.FilesRemoved | Should -Be 0
-            $Result.DirectoriesRemoved | Should -Be 0
-            $Result.Errors | Should -Be 0
+            $Result.FilesRemoved | Should-Be 0
+            $Result.DirectoriesRemoved | Should-Be 0
+            $Result.Errors | Should-Be 0
         }
 
         It 'Should calculate space freed' {
@@ -164,8 +164,8 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:RepoPath
 
             # Verify space was calculated (not "Not calculated")
-            $Result.TotalSpaceFreed | Should -Not -Match 'Not calculated'
-            $Result.TotalSpaceFreed | Should -Not -Be '0 bytes'
+            $Result.TotalSpaceFreed | Should-NotMatchString 'Not calculated'
+            $Result.TotalSpaceFreed | Should-NotBe '0 bytes'
         }
 
         It 'Should skip size calculation with -NoSizeCalculation' {
@@ -176,8 +176,8 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:RepoPath -NoSizeCalculation
 
             # Verify size calculation was skipped
-            $Result.TotalSpaceFreed | Should -Match 'Not calculated'
-            $Result.FilesRemoved | Should -Be 1
+            $Result.TotalSpaceFreed | Should-MatchString 'Not calculated'
+            $Result.FilesRemoved | Should-Be 1
         }
 
         It 'Should error when path is not a Git repository' {
@@ -187,7 +187,7 @@ temp/
             try
             {
                 # Should throw an error
-                { Remove-GitIgnoredFile -Path $NonGitPath -ErrorAction Stop } | Should -Throw '*git repository*'
+                { Remove-GitIgnoredFile -Path $NonGitPath -ErrorAction Stop } | Should-Throw '*git repository*'
             }
             finally
             {
@@ -240,11 +240,11 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:WorkspacePath -Recurse
 
             # Verify all files are removed
-            Test-Path (Join-Path -Path $script:Repo1 -ChildPath 'test.log') | Should -BeFalse
-            Test-Path (Join-Path -Path $script:Repo2 -ChildPath 'test.log') | Should -BeFalse
-            Test-Path (Join-Path -Path $script:Repo3 -ChildPath 'test.log') | Should -BeFalse
-            $Result.RepositoriesProcessed | Should -Be 3
-            $Result.FilesRemoved | Should -Be 3
+            Test-Path (Join-Path -Path $script:Repo1 -ChildPath 'test.log') | Should-BeFalsy
+            Test-Path (Join-Path -Path $script:Repo2 -ChildPath 'test.log') | Should-BeFalsy
+            Test-Path (Join-Path -Path $script:Repo3 -ChildPath 'test.log') | Should-BeFalsy
+            $Result.RepositoriesProcessed | Should-Be 3
+            $Result.FilesRemoved | Should-Be 3
         }
 
         It 'Should handle repositories with no ignored files' {
@@ -255,8 +255,8 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:WorkspacePath -Recurse
 
             # Verify correct statistics
-            $Result.RepositoriesProcessed | Should -Be 1
-            $Result.FilesRemoved | Should -Be 1
+            $Result.RepositoriesProcessed | Should-Be 1
+            $Result.FilesRemoved | Should-Be 1
         }
 
         It 'Should respect -WhatIf in recursive mode' {
@@ -268,8 +268,8 @@ temp/
             $null = Remove-GitIgnoredFile -Path $script:WorkspacePath -Recurse -WhatIf
 
             # Verify files still exist
-            Test-Path (Join-Path -Path $script:Repo1 -ChildPath 'test.log') | Should -BeTrue
-            Test-Path (Join-Path -Path $script:Repo2 -ChildPath 'test.log') | Should -BeTrue
+            Test-Path (Join-Path -Path $script:Repo1 -ChildPath 'test.log') | Should-BeTruthy
+            Test-Path (Join-Path -Path $script:Repo2 -ChildPath 'test.log') | Should-BeTruthy
         }
 
         It 'Should handle workspace with no repositories' {
@@ -282,9 +282,9 @@ temp/
                 # Should complete without errors but report no repositories
                 $Result = Remove-GitIgnoredFile -Path $EmptyWorkspace -Recurse
 
-                $Result.RepositoriesProcessed | Should -Be 0
-                $Result.FilesRemoved | Should -Be 0
-                $Result.Errors | Should -Be 0
+                $Result.RepositoriesProcessed | Should-Be 0
+                $Result.FilesRemoved | Should-Be 0
+                $Result.Errors | Should-Be 0
             }
             finally
             {
@@ -301,9 +301,9 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:WorkspacePath -Recurse
 
             # Verify cumulative space calculation
-            $Result.TotalSpaceFreed | Should -Not -Match 'Not calculated'
-            $Result.TotalSpaceFreed | Should -Not -Be '0 bytes'
-            $Result.RepositoriesProcessed | Should -Be 2
+            $Result.TotalSpaceFreed | Should-NotMatchString 'Not calculated'
+            $Result.TotalSpaceFreed | Should-NotBe '0 bytes'
+            $Result.RepositoriesProcessed | Should-Be 2
         }
     }
 
@@ -341,7 +341,7 @@ temp/
                 $RelativePath = Split-Path $script:RepoPath -Leaf
                 $Result = Remove-GitIgnoredFile -Path $RelativePath
 
-                $Result.FilesRemoved | Should -Be 1
+                $Result.FilesRemoved | Should-Be 1
             }
             finally
             {
@@ -360,7 +360,7 @@ temp/
                 # Run without specifying path (should use current directory)
                 $Result = Remove-GitIgnoredFile
 
-                $Result.FilesRemoved | Should -Be 1
+                $Result.FilesRemoved | Should-Be 1
             }
             finally
             {
@@ -374,7 +374,7 @@ temp/
             $InvalidPath = Join-Path -Path $script:TestRoot -ChildPath 'nonexistent-path'
 
             # Should handle gracefully
-            { Remove-GitIgnoredFile -Path $InvalidPath -ErrorAction Stop } | Should -Throw
+            { Remove-GitIgnoredFile -Path $InvalidPath -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should return error count when issues occur' {
@@ -382,8 +382,8 @@ temp/
             $Result = Remove-GitIgnoredFile -Path $script:TestRoot -Recurse
 
             # Result should have Errors property
-            $Result.PSObject.Properties.Name | Should -Contain 'Errors'
-            $Result.Errors | Should -BeOfType [int]
+            $Result.PSObject.Properties.Name | Should-ContainCollection 'Errors'
+            $Result.Errors | Should-HaveType ([int])
         }
     }
 }

--- a/Tests/Integration/Developer/Remove-NodeModules.Tests.ps1
+++ b/Tests/Integration/Developer/Remove-NodeModules.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     # Suppress progress bars to prevent freezing in non-interactive environments
     $Global:ProgressPreference = 'SilentlyContinue'
 
@@ -51,9 +51,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath -Recurse
 
             # Verify folder is removed
-            Test-Path $NodeModulesPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 1
-            $Result.TotalProjectsFound | Should -Be 1
+            Test-Path $NodeModulesPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 1
+            $Result.TotalProjectsFound | Should-Be 1
         }
 
         It 'Should not remove node_modules without package.json' {
@@ -66,9 +66,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath -Recurse
 
             # Verify folder still exists (no package.json found)
-            Test-Path $NodeModulesPath | Should -BeTrue
-            $Result.FoldersRemoved | Should -Be 0
-            $Result.TotalProjectsFound | Should -Be 0
+            Test-Path $NodeModulesPath | Should-BeTruthy
+            $Result.FoldersRemoved | Should-Be 0
+            $Result.TotalProjectsFound | Should-Be 0
         }
 
         It 'Should respect -WhatIf parameter' {
@@ -81,7 +81,7 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $null = Remove-NodeModules -Path $script:ProjectPath -WhatIf
 
             # Verify folder still exists
-            Test-Path $NodeModulesPath | Should -BeTrue
+            Test-Path $NodeModulesPath | Should-BeTruthy
         }
 
         It 'Should calculate space freed' {
@@ -97,8 +97,8 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath
 
             # Verify space calculation
-            $Result.TotalSpaceFreed | Should -Not -Match 'Not calculated'
-            $Result.TotalSpaceFreed | Should -Not -Be '0 bytes'
+            $Result.TotalSpaceFreed | Should-NotMatchString 'Not calculated'
+            $Result.TotalSpaceFreed | Should-NotBe '0 bytes'
         }
 
         It 'Should skip size calculation with -NoSizeCalculation' {
@@ -114,8 +114,8 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath -NoSizeCalculation
 
             # Verify
-            $Result.TotalSpaceFreed | Should -Match 'Not calculated'
-            $Result.FoldersRemoved | Should -Be 1
+            $Result.TotalSpaceFreed | Should-MatchString 'Not calculated'
+            $Result.FoldersRemoved | Should-Be 1
         }
 
         It 'Should handle nested node_modules directories' {
@@ -139,8 +139,8 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath
 
             # Verify entire node_modules is removed (including nested)
-            Test-Path $NodeModulesPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path $NodeModulesPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 1
         }
     }
 
@@ -180,12 +180,12 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:WorkspacePath -Recurse
 
             # Verify all node_modules removed
-            Test-Path (Join-Path -Path $Project1 -ChildPath 'node_modules') | Should -BeFalse
-            Test-Path (Join-Path -Path $Project2 -ChildPath 'node_modules') | Should -BeFalse
-            Test-Path (Join-Path -Path $Project3 -ChildPath 'node_modules') | Should -BeFalse
+            Test-Path (Join-Path -Path $Project1 -ChildPath 'node_modules') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Project2 -ChildPath 'node_modules') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Project3 -ChildPath 'node_modules') | Should-BeFalsy
 
-            $Result.TotalProjectsFound | Should -Be 3
-            $Result.FoldersRemoved | Should -Be 3
+            $Result.TotalProjectsFound | Should-Be 3
+            $Result.FoldersRemoved | Should-Be 3
         }
 
         It 'Should limit scope without Recurse' {
@@ -201,9 +201,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
 
             $Result = Remove-NodeModules -Path $rootProject
 
-            Test-Path (Join-Path -Path $rootProject -ChildPath 'node_modules') | Should -BeFalse
-            Test-Path (Join-Path -Path $nestedProject -ChildPath 'node_modules') | Should -BeTrue
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path (Join-Path -Path $rootProject -ChildPath 'node_modules') | Should-BeFalsy
+            Test-Path (Join-Path -Path $nestedProject -ChildPath 'node_modules') | Should-BeTruthy
+            $Result.FoldersRemoved | Should-Be 1
         }
 
         It 'Should handle projects without node_modules' {
@@ -224,9 +224,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:WorkspacePath -Recurse
 
             # Verify
-            Test-Path $NodeModulesPath | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 2
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path $NodeModulesPath | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 2
+            $Result.FoldersRemoved | Should-Be 1
         }
 
         It 'Should handle monorepo structure' {
@@ -253,12 +253,12 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:WorkspacePath -Recurse
 
             # Verify all node_modules removed (root + packages)
-            Test-Path $RootNodeModules | Should -BeFalse
-            Test-Path (Join-Path -Path $Package1 -ChildPath 'node_modules') | Should -BeFalse
-            Test-Path (Join-Path -Path $Package2 -ChildPath 'node_modules') | Should -BeFalse
+            Test-Path $RootNodeModules | Should-BeFalsy
+            Test-Path (Join-Path -Path $Package1 -ChildPath 'node_modules') | Should-BeFalsy
+            Test-Path (Join-Path -Path $Package2 -ChildPath 'node_modules') | Should-BeFalsy
 
-            $Result.TotalProjectsFound | Should -Be 3
-            $Result.FoldersRemoved | Should -Be 3
+            $Result.TotalProjectsFound | Should-Be 3
+            $Result.FoldersRemoved | Should-Be 3
         }
     }
 
@@ -295,9 +295,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:WorkspacePath -Recurse
 
             # Verify .git project was excluded
-            Test-Path $GitNodeModules | Should -BeTrue
-            Test-Path $NormalNodeModules | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 1
+            Test-Path $GitNodeModules | Should-BeTruthy
+            Test-Path $NormalNodeModules | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 1
         }
 
         It 'Should respect custom ExcludeDirectory parameter' {
@@ -320,9 +320,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:WorkspacePath -ExcludeDirectory @('.git', 'vendor') -Recurse
 
             # Verify vendor was excluded, normal was cleaned
-            Test-Path $VendorNodeModules | Should -BeTrue
-            Test-Path $NormalNodeModules | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 1
+            Test-Path $VendorNodeModules | Should-BeTruthy
+            Test-Path $NormalNodeModules | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 1
         }
 
         It 'Should handle multiple excluded directories' {
@@ -354,12 +354,12 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             # Verify all excluded projects still have node_modules
             foreach ($path in $Paths)
             {
-                Test-Path (Join-Path -Path $path -ChildPath 'node_modules') | Should -BeTrue
+                Test-Path (Join-Path -Path $path -ChildPath 'node_modules') | Should-BeTruthy
             }
 
             # Normal project should be cleaned
-            Test-Path $NormalNodeModules | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 1
+            Test-Path $NormalNodeModules | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 1
         }
     }
 
@@ -387,7 +387,7 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
                 $RelativePath = Split-Path $script:ProjectPath -Leaf
                 $Result = Remove-NodeModules -Path $RelativePath
 
-                $Result.FoldersRemoved | Should -Be 1
+                $Result.FoldersRemoved | Should-Be 1
             }
             finally
             {
@@ -401,7 +401,7 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             {
                 $Result = Remove-NodeModules
 
-                $Result.FoldersRemoved | Should -Be 1
+                $Result.FoldersRemoved | Should-Be 1
             }
             finally
             {
@@ -414,7 +414,7 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
         It 'Should handle invalid path' {
             $InvalidPath = Join-Path -Path $script:TestRoot -ChildPath 'nonexistent-path'
 
-            { Remove-NodeModules -Path $InvalidPath -ErrorAction Stop } | Should -Throw
+            { Remove-NodeModules -Path $InvalidPath -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should handle path that is not a directory' {
@@ -423,7 +423,7 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
 
             try
             {
-                { Remove-NodeModules -Path $FilePath -ErrorAction Stop } | Should -Throw
+                { Remove-NodeModules -Path $FilePath -ErrorAction Stop } | Should-Throw
             }
             finally
             {
@@ -439,8 +439,8 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             {
                 $Result = Remove-NodeModules -Path $EmptyPath
 
-                $Result.PSObject.Properties.Name | Should -Contain 'Errors'
-                $Result.Errors | Should -BeOfType [int]
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'Errors'
+                $Result.Errors | Should-HaveType ([int])
             }
             finally
             {
@@ -470,9 +470,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath -Recurse
 
             # Should complete successfully
-            $Result.TotalProjectsFound | Should -Be 1
-            $Result.FoldersRemoved | Should -Be 0
-            $Result.Errors | Should -Be 0
+            $Result.TotalProjectsFound | Should-Be 1
+            $Result.FoldersRemoved | Should-Be 0
+            $Result.Errors | Should-Be 0
         }
 
         It 'Should handle empty directory' {
@@ -480,9 +480,9 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath
 
             # Should complete without errors
-            $Result.TotalProjectsFound | Should -Be 0
-            $Result.FoldersRemoved | Should -Be 0
-            $Result.Errors | Should -Be 0
+            $Result.TotalProjectsFound | Should-Be 0
+            $Result.FoldersRemoved | Should-Be 0
+            $Result.Errors | Should-Be 0
         }
 
         It 'Should handle package.json in subdirectories' {
@@ -502,10 +502,10 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath -Recurse
 
             # Verify both removed
-            Test-Path $RootNodeModules | Should -BeFalse
-            Test-Path $SubNodeModules | Should -BeFalse
-            $Result.TotalProjectsFound | Should -Be 2
-            $Result.FoldersRemoved | Should -Be 2
+            Test-Path $RootNodeModules | Should-BeFalsy
+            Test-Path $SubNodeModules | Should-BeFalsy
+            $Result.TotalProjectsFound | Should-Be 2
+            $Result.FoldersRemoved | Should-Be 2
         }
 
         It 'Should handle large node_modules with many files' {
@@ -526,8 +526,8 @@ Describe 'Remove-NodeModules Integration Tests' -Tag 'Integration' {
             $Result = Remove-NodeModules -Path $script:ProjectPath
 
             # Verify removed
-            Test-Path $NodeModulesPath | Should -BeFalse
-            $Result.FoldersRemoved | Should -Be 1
+            Test-Path $NodeModulesPath | Should-BeFalsy
+            $Result.FoldersRemoved | Should-Be 1
         }
     }
 }

--- a/Tests/Integration/MediaProcessing/MediaProcessing.Tests.ps1
+++ b/Tests/Integration/MediaProcessing/MediaProcessing.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             foreach ($funcName in $functions)
             {
                 $command = Get-Command $funcName
-                $command.Parameters.ContainsKey('Recurse') | Should -Be $true -Because "$funcName should have Recurse parameter"
+                $command.Parameters.ContainsKey('Recurse') | Should-Be $true -Because "$funcName should have Recurse parameter"
             }
         }
 
@@ -35,7 +35,7 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             foreach ($funcName in $functions)
             {
                 $command = Get-Command $funcName
-                $command.Parameters.ContainsKey('NoRecursion') | Should -Be $false -Because "$funcName should not have NoRecursion parameter"
+                $command.Parameters.ContainsKey('NoRecursion') | Should-Be $false -Because "$funcName should not have NoRecursion parameter"
             }
         }
 
@@ -45,7 +45,7 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             foreach ($funcName in $functions)
             {
                 $command = Get-Command $funcName
-                $command.Parameters.ContainsKey('Exclude') | Should -Be $true -Because "$funcName should have Exclude parameter"
+                $command.Parameters.ContainsKey('Exclude') | Should-Be $true -Because "$funcName should have Exclude parameter"
             }
         }
     }
@@ -58,7 +58,7 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             {
                 $command = Get-Command $funcName
                 $recurseParam = $command.Parameters['Recurse']
-                $recurseParam.ParameterType.Name | Should -Be 'SwitchParameter' -Because "$funcName Recurse parameter should be Switch type"
+                $recurseParam.ParameterType.Name | Should-Be 'SwitchParameter' -Because "$funcName Recurse parameter should be Switch type"
             }
         }
 
@@ -69,7 +69,7 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             {
                 $command = Get-Command $funcName
                 $excludeParam = $command.Parameters['Exclude']
-                $excludeParam.ParameterType.Name | Should -Be 'String[]' -Because "$funcName Exclude parameter should be String array type"
+                $excludeParam.ParameterType.Name | Should-Be 'String[]' -Because "$funcName Exclude parameter should be String array type"
             }
         }
     }
@@ -81,7 +81,7 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             foreach ($funcName in $functions)
             {
                 $command = Get-Command $funcName
-                $command.Parameters.ContainsKey('Filter') | Should -Be $true -Because "$funcName should have Filter parameter"
+                $command.Parameters.ContainsKey('Filter') | Should-Be $true -Because "$funcName should have Filter parameter"
             }
         }
 
@@ -92,7 +92,7 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             {
                 $command = Get-Command $funcName
                 $filterParam = $command.Parameters['Filter']
-                $filterParam.ParameterType.Name | Should -Be 'String[]' -Because "$funcName Filter parameter should be String array type"
+                $filterParam.ParameterType.Name | Should-Be 'String[]' -Because "$funcName Filter parameter should be String array type"
             }
         }
     }
@@ -148,21 +148,21 @@ Describe 'MediaProcessing Functions Integration' -Tag 'Integration' {
             $global:LASTEXITCODE = 0
             $metadataWriteOutput = @(& $exifToolPath -overwrite_original '-Comment=Private integration comment' $sampleImage 2>&1)
             $metadataWriteExitCode = $LASTEXITCODE
-            $metadataWriteExitCode | Should -Be 0 -Because "ExifTool should stage the test metadata. Output: $($metadataWriteOutput -join ' ')"
+            $metadataWriteExitCode | Should-Be 0 -Because "ExifTool should stage the test metadata. Output: $($metadataWriteOutput -join ' ')"
 
             $beforeCleanup = Get-ImageMetadata -Path $sampleImage -ExifToolPath $exifToolPath -Tag 'Comment' -NoEmptyProperties
-            $beforeCleanup.Metadata['File:Comment'] | Should -Be 'Private integration comment'
+            $beforeCleanup.Metadata['File:Comment'] | Should-Be 'Private integration comment'
 
             $cleanupResult = Remove-ImageMetadata -Path $sampleImage -ExifToolPath $exifToolPath -Verify -PassThru
 
-            $cleanupResult.MetadataRemoved | Should -Be $true
-            $cleanupResult.RemovedMetadataTagCount | Should -BeGreaterThan 0
-            $cleanupResult.RemovedMetadataTags | Should -Contain 'File:Comment'
-            $cleanupResult.Verified | Should -Be $true
+            $cleanupResult.MetadataRemoved | Should-Be $true
+            $cleanupResult.RemovedMetadataTagCount | Should-BeGreaterThan 0
+            $cleanupResult.RemovedMetadataTags | Should-ContainCollection 'File:Comment'
+            $cleanupResult.Verified | Should-Be $true
             $cleanupResult.RemainingMetadataTags | Should -BeNullOrEmpty
 
             $afterCleanup = Get-ImageMetadata -Path $sampleImage -ExifToolPath $exifToolPath -Tag 'Comment' -NoEmptyProperties
-            $afterCleanup.Metadata.Contains('File:Comment') | Should -Be $false
+            $afterCleanup.Metadata.Contains('File:Comment') | Should-Be $false
         }
     }
 }

--- a/Tests/Integration/NetworkAndDns/Test-TlsProtocol.Tests.ps1
+++ b/Tests/Integration/NetworkAndDns/Test-TlsProtocol.Tests.ps1
@@ -33,12 +33,12 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName 'bing.com' -Protocol Tls12 -Timeout 10000
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Server | Should -Be 'bing.com'
-            $result.Port | Should -Be 443
-            $result.Protocol | Should -Be 'Tls12'
-            $result.Supported | Should -Be $true
-            $result.Status | Should -Be 'Success'
-            $result.ResponseTime | Should -BeGreaterThan ([TimeSpan]::Zero)
+            $result.Server | Should-Be 'bing.com'
+            $result.Port | Should-Be 443
+            $result.Protocol | Should-Be 'Tls12'
+            $result.Supported | Should-Be $true
+            $result.Status | Should-Be 'Success'
+            $result.ResponseTime | Should-BeGreaterThan ([TimeSpan]::Zero)
         }
 
         It 'Should successfully test TLS 1.3 on a modern HTTPS endpoint' {
@@ -46,10 +46,10 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName 'www.cloudflare.com' -Protocol Tls13 -Timeout 10000
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Server | Should -Be 'www.cloudflare.com'
-            $result.Protocol | Should -Be 'Tls13'
+            $result.Server | Should-Be 'www.cloudflare.com'
+            $result.Protocol | Should-Be 'Tls13'
             # TLS 1.3 may or may not be supported depending on the .NET version
-            $result.Supported | Should -BeOfType [Boolean]
+            $result.Supported | Should-HaveType ([Boolean])
             $result.Status | Should -Not -BeNullOrEmpty
         }
 
@@ -58,11 +58,11 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName 'bing.com' -Protocol Tls, Tls11 -Timeout 10000
 
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 2
+            $result | Should-BeCollection -Count 2
 
             # Verify protocols were tested
-            $result[0].Protocol | Should -Be 'Tls'
-            $result[1].Protocol | Should -Be 'Tls11'
+            $result[0].Protocol | Should-Be 'Tls'
+            $result[1].Protocol | Should-Be 'Tls11'
 
             # Each result should have a status
             $result[0].Status | Should -Not -BeNullOrEmpty
@@ -78,18 +78,18 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName 'www.github.com' -Timeout 10000
 
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 4
+            $result | Should-BeCollection -Count 4
 
             # Verify all protocols were tested
             $protocols = $result | Select-Object -ExpandProperty Protocol
-            $protocols | Should -Contain 'Tls'
-            $protocols | Should -Contain 'Tls11'
-            $protocols | Should -Contain 'Tls12'
-            $protocols | Should -Contain 'Tls13'
+            $protocols | Should-ContainCollection 'Tls'
+            $protocols | Should-ContainCollection 'Tls11'
+            $protocols | Should-ContainCollection 'Tls12'
+            $protocols | Should-ContainCollection 'Tls13'
 
             # GitHub should support at least TLS 1.2
             $tls12Result = $result | Where-Object { $_.Protocol -eq 'Tls12' }
-            $tls12Result.Supported | Should -Be $true
+            $tls12Result.Supported | Should-Be $true
         }
     }
 
@@ -98,8 +98,8 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName 'this-host-absolutely-does-not-exist-12345.invalid' -Protocol Tls12 -Timeout 3000
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Supported | Should -Be $false
-            $result.Status | Should -Not -Be 'Success'
+            $result.Supported | Should-Be $false
+            $result.Status | Should-NotBe 'Success'
         }
 
         It 'Should handle connection timeout to unreachable hosts' {
@@ -107,8 +107,8 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName '192.0.2.1' -Protocol Tls12 -Timeout 2000
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Supported | Should -Be $false
-            $result.Status | Should -Match 'timeout|failed'
+            $result.Supported | Should-Be $false
+            $result.Status | Should-MatchString 'timeout|failed'
         }
 
         It 'Should handle non-HTTPS ports gracefully' {
@@ -117,7 +117,7 @@ Describe 'Test-TlsProtocol Integration Tests' {
 
             $result | Should -Not -BeNullOrEmpty
             # Connection might succeed but TLS handshake should fail
-            $result.Supported | Should -Be $false
+            $result.Supported | Should-Be $false
         }
     }
 
@@ -128,8 +128,8 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $stopwatch.Stop()
 
             # Should complete within timeout plus overhead (15 seconds total)
-            $stopwatch.Elapsed.TotalSeconds | Should -BeLessThan 15
-            $result.ResponseTime.TotalSeconds | Should -BeLessThan 10
+            $stopwatch.Elapsed.TotalSeconds | Should-BeLessThan 15
+            $result.ResponseTime.TotalSeconds | Should-BeLessThan 10
         }
 
         It 'Should test multiple protocols efficiently' {
@@ -137,9 +137,9 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName 'www.cloudflare.com' -Protocol Tls12, Tls13 -Timeout 10000
             $stopwatch.Stop()
 
-            $result | Should -HaveCount 2
+            $result | Should-BeCollection -Count 2
             # Testing 2 protocols should complete in reasonable time (30 seconds with overhead)
-            $stopwatch.Elapsed.TotalSeconds | Should -BeLessThan 30
+            $stopwatch.Elapsed.TotalSeconds | Should-BeLessThan 30
         }
     }
 
@@ -149,14 +149,14 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = $servers | Test-TlsProtocol -Protocol Tls12 -Timeout 10000
 
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 2
-            $result[0].Server | Should -Be 'bing.com'
-            $result[1].Server | Should -Be 'www.github.com'
+            $result | Should-BeCollection -Count 2
+            $result[0].Server | Should-Be 'bing.com'
+            $result[1].Server | Should-Be 'www.github.com'
 
             # Both should support TLS 1.2
             $result | ForEach-Object {
-                $_.Protocol | Should -Be 'Tls12'
-                $_.Supported | Should -Be $true
+                $_.Protocol | Should-Be 'Tls12'
+                $_.Supported | Should-Be $true
             }
         }
     }
@@ -167,8 +167,8 @@ Describe 'Test-TlsProtocol Integration Tests' {
             $result = Test-TlsProtocol -ComputerName 'bing.com' -Port 443 -Protocol Tls12 -Timeout 10000
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Port | Should -Be 443
-            $result.Supported | Should -Be $true
+            $result.Port | Should-Be 443
+            $result.Supported | Should-Be $true
         }
     }
 }

--- a/Tests/Integration/ProfileManagement/install.Tests.ps1
+++ b/Tests/Integration/ProfileManagement/install.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules Pester
+#Requires -Modules Pester
 
 BeforeAll {
     # Suppress progress bars to prevent freezing in non-interactive environments
@@ -25,26 +25,26 @@ Describe 'install.ps1 integration tests' {
             {
                 & $script:installScript -ProfileRoot $profileRoot -RepositoryUrl $script:repoRoot -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should -BeTrue
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should-BeTruthy
                 $gitConfigPath = Join-Path -Path $profileRoot -ChildPath '.git/config'
-                Test-Path $gitConfigPath | Should -BeTrue
+                Test-Path $gitConfigPath | Should-BeTruthy
                 $gitConfigContent = Get-Content $gitConfigPath -Raw
                 $originMatch = [regex]::Match(
                     $gitConfigContent,
                     '^\s*url\s*=\s*(.+)$',
                     [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [System.Text.RegularExpressions.RegexOptions]::Multiline
                 )
-                $originMatch.Success | Should -BeTrue -Because 'git clone should record the remote origin URL'
+                $originMatch.Success | Should-BeTruthy -Because 'git clone should record the remote origin URL'
 
                 $originUrl = [regex]::Unescape($originMatch.Groups[1].Value.Trim())
                 $resolvedOrigin = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($originUrl)
                 $resolvedRepoRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($script:repoRoot)
-                $resolvedOrigin | Should -Be $resolvedRepoRoot
+                $resolvedOrigin | Should-Be $resolvedRepoRoot
 
                 $profileParent = Split-Path -Parent $profileRoot
                 $profileLeaf = Split-Path -Leaf $profileRoot
                 $backupPattern = "$profileLeaf-backup-*"
-                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern).Count | Should -Be 1
+                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern).Count | Should-Be 1
             }
             finally
             {
@@ -76,25 +76,25 @@ Describe 'install.ps1 integration tests' {
             {
                 & $script:installScript -ProfileRoot $profileRoot -LocalSourcePath $script:repoRoot -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should -BeTrue
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should-BeTruthy
 
                 foreach ($name in @('Functions/Local', 'Help', 'Modules', 'PSReadLine', 'Scripts'))
                 {
                     $nameDir = Join-Path -Path $profileRoot -ChildPath $name
                     $preservedFile = Join-Path -Path $nameDir -ChildPath 'original.txt'
-                    Test-Path $preservedFile | Should -BeTrue
-                    (Get-Content $preservedFile) | Should -Be "original-$name"
+                    Test-Path $preservedFile | Should-BeTruthy
+                    (Get-Content $preservedFile) | Should-Be "original-$name"
                 }
 
                 $configFile = Join-Path -Path $profileRoot -ChildPath 'powershell.config.json'
-                Test-Path $configFile | Should -BeTrue
-                (Get-Content $configFile -Raw).Trim() | Should -Be '{ "experimentalFeatures": [] }'
+                Test-Path $configFile | Should-BeTruthy
+                (Get-Content $configFile -Raw).Trim() | Should-Be '{ "experimentalFeatures": [] }'
 
                 $profileParent = Split-Path -Parent $profileRoot
                 $profileLeaf = Split-Path -Leaf $profileRoot
                 $backupPattern = "$profileLeaf-backup-*"
                 $backups = Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern
-                $backups.Count | Should -Be 1
+                $backups.Count | Should-Be 1
             }
             finally
             {
@@ -143,15 +143,15 @@ Describe 'install.ps1 integration tests' {
 
                 & $script:installScript -ProfileRoot $profileRoot -LocalSourcePath $sourceRoot -SkipBackup -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should -BeTrue
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'stale-root.ps1') | Should -BeFalse
-                Test-Path (Join-Path -Path $staleFunctionPath -ChildPath 'stale.ps1') | Should -BeFalse
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Functions/New/new.ps1') | Should -BeTrue
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should-BeTruthy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'stale-root.ps1') | Should-BeFalsy
+                Test-Path (Join-Path -Path $staleFunctionPath -ChildPath 'stale.ps1') | Should-BeFalsy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Functions/New/new.ps1') | Should-BeTruthy
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Functions/Local/original.ps1') | Should -BeTrue
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Functions/Local/source-only.ps1') | Should -BeFalse
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/UserModule/UserModule.psm1') | Should -BeTrue
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/SourceModule/SourceModule.psm1') | Should -BeFalse
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Functions/Local/original.ps1') | Should-BeTruthy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Functions/Local/source-only.ps1') | Should-BeFalsy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/UserModule/UserModule.psm1') | Should-BeTruthy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/SourceModule/SourceModule.psm1') | Should-BeFalsy
             }
             finally
             {
@@ -221,16 +221,16 @@ Describe 'install.ps1 integration tests' {
 
                 { & $script:installScript -ProfileRoot $profileRoot -LocalSourcePath $sourceRoot -Verbose:$false } | Should -Not -Throw
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should -BeTrue
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'stale-root.ps1') | Should -BeFalse
-                Test-Path $lockedModuleFile | Should -BeTrue
-                (Get-Content $lockedModuleFile) | Should -Be 'locked module content'
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/SourceModule/SourceModule.psm1') | Should -BeFalse
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should-BeTruthy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'stale-root.ps1') | Should-BeFalsy
+                Test-Path $lockedModuleFile | Should-BeTruthy
+                (Get-Content $lockedModuleFile) | Should-Be 'locked module content'
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/SourceModule/SourceModule.psm1') | Should-BeFalsy
 
                 $backup = Get-ChildItem -Path (Split-Path -Parent $profileRoot) -Directory -Filter 'WindowsPowerShell-backup-*' | Select-Object -First 1
                 $backup | Should -Not -BeNullOrEmpty
-                Test-Path (Join-Path -Path $backup.FullName -ChildPath 'stale-root.ps1') | Should -BeTrue
-                Test-Path (Join-Path -Path $backup.FullName -ChildPath 'Modules/PSReadLine/2.3.6/PSReadLine.dll') | Should -BeFalse
+                Test-Path (Join-Path -Path $backup.FullName -ChildPath 'stale-root.ps1') | Should-BeTruthy
+                Test-Path (Join-Path -Path $backup.FullName -ChildPath 'Modules/PSReadLine/2.3.6/PSReadLine.dll') | Should-BeFalsy
             }
             finally
             {
@@ -273,8 +273,8 @@ Describe 'install.ps1 integration tests' {
 
                 & $script:installScript -ProfileRoot $profileRoot -LocalSourcePath $sourceRoot -SkipBackup -SkipPreserveDirectories -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should -BeTrue
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'fsmonitor--daemon.ipc') | Should -BeFalse
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should-BeTruthy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'fsmonitor--daemon.ipc') | Should-BeFalsy
             }
             finally
             {
@@ -309,9 +309,9 @@ Describe 'install.ps1 integration tests' {
 
                 & $script:installScript -ProfileRoot $profileRoot -RepositoryUrl $remoteRepo -SkipPreserveDirectories -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should -BeTrue
-                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1')) | Should -Be '# git remote profile'
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/RemoteModule.psm1') | Should -BeTrue
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1') | Should-BeTruthy
+                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'Microsoft.PowerShell_profile.ps1')) | Should-Be '# git remote profile'
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'Modules/RemoteModule.psm1') | Should-BeTruthy
             }
             finally
             {
@@ -343,12 +343,12 @@ Describe 'install.ps1 integration tests' {
                 $profileParent = Split-Path -Parent $profileRoot
                 $profileLeaf = Split-Path -Leaf $profileRoot
                 $backupPattern = "$profileLeaf-backup-*"
-                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern -ErrorAction SilentlyContinue).Count | Should -Be 0
+                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern -ErrorAction SilentlyContinue).Count | Should-Be 0
 
                 foreach ($name in @('Functions/Local', 'Help', 'Modules', 'PSReadLine', 'Scripts'))
                 {
                     $preservedFile = Join-Path -Path (Join-Path -Path $profileRoot -ChildPath $name) -ChildPath 'original.txt'
-                    Test-Path $preservedFile | Should -BeFalse
+                    Test-Path $preservedFile | Should-BeFalsy
                 }
             }
             finally
@@ -370,7 +370,7 @@ Describe 'install.ps1 integration tests' {
 
             try
             {
-                { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingBackup -Verbose:$false } | Should -Throw
+                { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingBackup -Verbose:$false } | Should-Throw
             }
             finally
             {
@@ -401,19 +401,19 @@ Describe 'install.ps1 integration tests' {
 
                 # Functions/Local exists in the repo, so check if user files were NOT preserved
                 $funcLocalTestFile = Join-Path -Path (Join-Path -Path $profileRoot -ChildPath 'Functions/Local') -ChildPath 'test.txt'
-                Test-Path $funcLocalTestFile | Should -BeFalse
+                Test-Path $funcLocalTestFile | Should-BeFalsy
 
                 # These directories should be reinstalled fresh (no preserved user files)
                 foreach ($name in @('Help', 'Modules', 'PSReadLine'))
                 {
                     $testFile = Join-Path -Path (Join-Path -Path $profileRoot -ChildPath $name) -ChildPath 'test.txt'
-                    Test-Path $testFile | Should -BeFalse
+                    Test-Path $testFile | Should-BeFalsy
                 }
 
                 $profileParent = Split-Path -Parent $profileRoot
                 $profileLeaf = Split-Path -Leaf $profileRoot
                 $backupPattern = "$profileLeaf-backup-*"
-                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern -ErrorAction SilentlyContinue).Count | Should -Be 0
+                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern -ErrorAction SilentlyContinue).Count | Should-Be 0
             }
             finally
             {
@@ -450,7 +450,7 @@ Describe 'install.ps1 integration tests' {
 
                 & $script:installScript -ProfileRoot $profileRoot -RepositoryUrl $remoteRepo -SkipBackup -SkipPreserveDirectories -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'cloned.txt') | Should -BeTrue
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'cloned.txt') | Should-BeTruthy
             }
             finally
             {
@@ -486,19 +486,19 @@ Describe 'install.ps1 integration tests' {
                 & $script:installScript -ProfileRoot $profileRoot -RestorePath $backupRoot -Verbose:$false
 
                 $restoredProfile = Join-Path -Path $profileRoot -ChildPath 'profile.ps1'
-                Test-Path $restoredProfile | Should -BeTrue
-                (Get-Content $restoredProfile) | Should -Be 'restored profile'
+                Test-Path $restoredProfile | Should-BeTruthy
+                (Get-Content $restoredProfile) | Should-Be 'restored profile'
 
                 $modulesFile = Join-Path -Path (Join-Path -Path $profileRoot -ChildPath 'Modules') -ChildPath 'module.psm1'
-                Test-Path $modulesFile | Should -BeTrue
-                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'powershell.config.json') -Raw).Trim() | Should -Be '{ "restored": true }'
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'stale.ps1') | Should -BeFalse
+                Test-Path $modulesFile | Should-BeTruthy
+                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'powershell.config.json') -Raw).Trim() | Should-Be '{ "restored": true }'
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'stale.ps1') | Should-BeFalsy
 
                 # Verify no backup was created
                 $profileParent = Split-Path -Parent $profileRoot
                 $profileLeaf = Split-Path -Leaf $profileRoot
                 $backupPattern = "$profileLeaf-backup-*"
-                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern -ErrorAction SilentlyContinue).Count | Should -Be 0
+                (Get-ChildItem -Path $profileParent -Directory -Filter $backupPattern -ErrorAction SilentlyContinue).Count | Should-Be 0
             }
             finally
             {
@@ -528,12 +528,12 @@ Describe 'install.ps1 integration tests' {
                 & $script:installScript -ProfileRoot $profileRoot -RestorePath $backupRoot -BackupPath $explicitBackup -Verbose:$false
 
                 # Verify restore happened
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'restored.ps1') | Should -BeTrue
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'current.ps1') | Should -BeFalse
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'restored.ps1') | Should-BeTruthy
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'current.ps1') | Should-BeFalsy
 
                 # Verify backup was created with the pre-restore content
-                Test-Path (Join-Path -Path $explicitBackup -ChildPath 'current.ps1') | Should -BeTrue
-                (Get-Content (Join-Path -Path $explicitBackup -ChildPath 'current.ps1')) | Should -Be 'current profile'
+                Test-Path (Join-Path -Path $explicitBackup -ChildPath 'current.ps1') | Should-BeTruthy
+                (Get-Content (Join-Path -Path $explicitBackup -ChildPath 'current.ps1')) | Should-Be 'current profile'
             }
             finally
             {
@@ -566,9 +566,9 @@ Describe 'install.ps1 integration tests' {
                 $modulesFile = Join-Path -Path (Join-Path -Path $profileRoot -ChildPath 'Modules') -ChildPath 'original.txt'
                 $helpFile = Join-Path -Path (Join-Path -Path $profileRoot -ChildPath 'Help') -ChildPath 'original.txt'
 
-                Test-Path $scriptsFile | Should -BeTrue
-                Test-Path $modulesFile | Should -BeFalse
-                Test-Path $helpFile | Should -BeFalse
+                Test-Path $scriptsFile | Should-BeTruthy
+                Test-Path $modulesFile | Should-BeFalsy
+                Test-Path $helpFile | Should-BeFalsy
             }
             finally
             {
@@ -589,7 +589,7 @@ Describe 'install.ps1 integration tests' {
 
             try
             {
-                { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingBackup -Verbose:$false } | Should -Throw
+                { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingBackup -Verbose:$false } | Should-Throw
             }
             finally
             {
@@ -620,12 +620,12 @@ Describe 'install.ps1 integration tests' {
 
                 $profileParent = Split-Path -Parent $profileRoot
                 $profileLeaf = Split-Path -Leaf $profileRoot
-                (Get-ChildItem -Path $profileParent -Directory -Filter "$profileLeaf-backup-*").Count | Should -Be 0
+                (Get-ChildItem -Path $profileParent -Directory -Filter "$profileLeaf-backup-*").Count | Should-Be 0
 
                 foreach ($name in @('Functions/Local', 'Help', 'Modules', 'PSReadLine', 'Scripts'))
                 {
                     $preservedFile = Join-Path -Path (Join-Path -Path $profileRoot -ChildPath $name) -ChildPath 'keep.txt'
-                    Test-Path $preservedFile | Should -BeFalse
+                    Test-Path $preservedFile | Should-BeFalsy
                 }
             }
             finally
@@ -648,7 +648,7 @@ Describe 'install.ps1 integration tests' {
 
             try
             {
-                Should -Throw -ActualValue { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingRestore -Verbose:$false }
+                Should-Throw -ActualValue { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingRestore -Verbose:$false }
             }
             finally
             {
@@ -675,13 +675,13 @@ Describe 'install.ps1 integration tests' {
 
                 & $script:installScript -ProfileRoot $profileRoot -LocalSourcePath $sourceRoot -WhatIf -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'current.ps1') | Should -BeTrue
-                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'current.ps1')) | Should -Be 'current profile'
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'installed.ps1') | Should -BeFalse
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'current.ps1') | Should-BeTruthy
+                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'current.ps1')) | Should-Be 'current profile'
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'installed.ps1') | Should-BeFalsy
 
                 $profileParent = Split-Path -Parent $profileRoot
                 $profileLeaf = Split-Path -Leaf $profileRoot
-                (Get-ChildItem -Path $profileParent -Directory -Filter "$profileLeaf-backup-*" -ErrorAction SilentlyContinue).Count | Should -Be 0
+                (Get-ChildItem -Path $profileParent -Directory -Filter "$profileLeaf-backup-*" -ErrorAction SilentlyContinue).Count | Should-Be 0
             }
             finally
             {
@@ -702,7 +702,7 @@ Describe 'install.ps1 integration tests' {
 
                 & $script:installScript -ProfileRoot $profileRoot -RepositoryUrl $script:repoRoot -SkipBackup -SkipPreserveDirectories -WhatIf -Verbose:$false
 
-                Test-Path -Path $profileRoot | Should -BeFalse
+                Test-Path -Path $profileRoot | Should-BeFalsy
             }
             finally
             {
@@ -728,10 +728,10 @@ Describe 'install.ps1 integration tests' {
 
                 & $script:installScript -ProfileRoot $profileRoot -RestorePath $backupRoot -BackupPath $explicitBackup -WhatIf -Verbose:$false
 
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'current.ps1') | Should -BeTrue
-                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'current.ps1')) | Should -Be 'current profile'
-                Test-Path (Join-Path -Path $profileRoot -ChildPath 'restored.ps1') | Should -BeFalse
-                Test-Path -Path $explicitBackup | Should -BeFalse
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'current.ps1') | Should-BeTruthy
+                (Get-Content (Join-Path -Path $profileRoot -ChildPath 'current.ps1')) | Should-Be 'current profile'
+                Test-Path (Join-Path -Path $profileRoot -ChildPath 'restored.ps1') | Should-BeFalsy
+                Test-Path -Path $explicitBackup | Should-BeFalsy
             }
             finally
             {

--- a/Tests/Integration/ProfileManagement/install.Tests.ps1
+++ b/Tests/Integration/ProfileManagement/install.Tests.ps1
@@ -648,7 +648,7 @@ Describe 'install.ps1 integration tests' {
 
             try
             {
-                Should-Throw -ActualValue { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingRestore -Verbose:$false }
+                Should-Throw -ScriptBlock { & $script:installScript -ProfileRoot $profileRoot -RestorePath $missingRestore -Verbose:$false }
             }
             finally
             {

--- a/Tests/Integration/Security/Protect-PathWithPassword.Tests.ps1
+++ b/Tests/Integration/Security/Protect-PathWithPassword.Tests.ps1
@@ -82,7 +82,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
 
             # Verify binary data integrity
             $restoredData = [System.IO.File]::ReadAllBytes($decResult.DecryptedPath)
-            $restoredData | Should-Be $binaryData
+            [Convert]::ToBase64String($restoredData) | Should-Be ([Convert]::ToBase64String($binaryData))
         }
 
         It 'Should handle large files efficiently' {
@@ -141,7 +141,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
 
                 # Verify content (comparing with the same bytes we wrote)
                 $restoredBytes = [System.IO.File]::ReadAllBytes($decResult.DecryptedPath)
-                $restoredBytes | Should-Be $contentBytes
+                [Convert]::ToBase64String($restoredBytes) | Should-Be ([Convert]::ToBase64String($contentBytes))
             }
         }
     }
@@ -160,7 +160,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $encBytes2 = [System.IO.File]::ReadAllBytes($enc2.EncryptedPath)
 
             # Files should be different (due to random salt and IV)
-            $encBytes1 | Should-NotBe $encBytes2
+            [Convert]::ToBase64String($encBytes1) | Should-NotBe ([Convert]::ToBase64String($encBytes2))
 
             # But both should decrypt to the same content
             Remove-Item $testFile -Force
@@ -290,8 +290,8 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $iv = $encryptedBytes[32..47]
 
             # Verify salt and IV are not all zeros (proper randomness)
-            $salt | Should-NotBe (@(0) * 32)
-            $iv | Should-NotBe (@(0) * 16)
+            [Convert]::ToBase64String([byte[]]$salt) | Should-NotBe ([Convert]::ToBase64String([byte[]](@(0) * 32)))
+            [Convert]::ToBase64String([byte[]]$iv) | Should-NotBe ([Convert]::ToBase64String([byte[]](@(0) * 16)))
 
             # Verify we can decrypt it
             Remove-Item $testFile -Force
@@ -472,7 +472,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
 
             # Verify binary integrity
             $restoredData = [System.IO.File]::ReadAllBytes($decResult.DecryptedPath)
-            $restoredData | Should-Be $binaryData
+            [Convert]::ToBase64String($restoredData) | Should-Be ([Convert]::ToBase64String($binaryData))
         }
 
         It 'Should provide information about OpenSSL script availability' {

--- a/Tests/Integration/Security/Protect-PathWithPassword.Tests.ps1
+++ b/Tests/Integration/Security/Protect-PathWithPassword.Tests.ps1
@@ -82,7 +82,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
 
             # Verify binary data integrity
             $restoredData = [System.IO.File]::ReadAllBytes($decResult.DecryptedPath)
-            $restoredData | Should -Be $binaryData
+            $restoredData | Should-Be $binaryData
         }
 
         It 'Should handle large files efficiently' {
@@ -98,8 +98,8 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $encTime = ($encEndTime - $encStartTime).TotalSeconds
 
             # Verify encryption succeeded
-            $encResult.Success | Should -Be $true
-            Test-Path $encResult.EncryptedPath | Should -Be $true
+            $encResult.Success | Should-Be $true
+            Test-Path $encResult.EncryptedPath | Should-Be $true
 
             # Measure decryption time
             Remove-Item $largeFile -Force
@@ -109,13 +109,13 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $decTime = ($decEndTime - $decStartTime).TotalSeconds
 
             # Verify decryption succeeded
-            $decResult.Success | Should -Be $true
+            $decResult.Success | Should-Be $true
             $restoredContent = [System.IO.File]::ReadAllText($decResult.DecryptedPath)
-            $restoredContent | Should -Be $largeContent
+            $restoredContent | Should-Be $largeContent
 
             # Performance check (should complete within reasonable time)
-            $encTime | Should -BeLessThan 30
-            $decTime | Should -BeLessThan 30
+            $encTime | Should-BeLessThan 30
+            $decTime | Should-BeLessThan 30
         }
 
         It 'Should handle different text encodings' {
@@ -141,7 +141,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
 
                 # Verify content (comparing with the same bytes we wrote)
                 $restoredBytes = [System.IO.File]::ReadAllBytes($decResult.DecryptedPath)
-                $restoredBytes | Should -Be $contentBytes
+                $restoredBytes | Should-Be $contentBytes
             }
         }
     }
@@ -160,7 +160,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $encBytes2 = [System.IO.File]::ReadAllBytes($enc2.EncryptedPath)
 
             # Files should be different (due to random salt and IV)
-            $encBytes1 | Should -Not -Be $encBytes2
+            $encBytes1 | Should-NotBe $encBytes2
 
             # But both should decrypt to the same content
             Remove-Item $testFile -Force
@@ -169,7 +169,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
 
             $content1 = Get-Content $dec1.DecryptedPath -Raw
             $content2 = Get-Content $dec2.DecryptedPath -Raw
-            $content1 | Should -Be $content2
+            $content1 | Should-Be $content2
         }
 
         It 'Should fail gracefully with incorrect password' {
@@ -187,11 +187,11 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $decResult = Unprotect-PathWithPassword -Path $encResult.EncryptedPath -Password $wrongPassword -ErrorAction SilentlyContinue
 
             # Should fail
-            $decResult.Success | Should -Be $false
-            $decResult.Error | Should -Match 'Decryption failed|Invalid password'
+            $decResult.Success | Should-Be $false
+            $decResult.Error | Should-MatchString 'Decryption failed|Invalid password'
 
             # Original file should not be restored
-            Test-Path $testFile | Should -Be $false
+            Test-Path $testFile | Should-Be $false
         }
     }
 
@@ -210,8 +210,8 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $encResults = Get-ChildItem -Path $script:TestDir -File | Protect-PathWithPassword -Password $script:TestPassword
 
             # All encryptions should succeed
-            $encResults | Should -HaveCount 5
-            $encResults | ForEach-Object { $_.Success | Should -Be $true }
+            $encResults | Should-BeCollection -Count 5
+            $encResults | ForEach-Object { $_.Success | Should-Be $true }
 
             # Remove original files
             $testFiles | ForEach-Object { Remove-Item $_ -Force }
@@ -220,16 +220,16 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $decResults = Get-ChildItem -Path $script:TestDir -File -Filter '*.enc' | Unprotect-PathWithPassword -Password $script:TestPassword
 
             # All decryptions should succeed
-            $decResults | Should -HaveCount 5
-            $decResults | ForEach-Object { $_.Success | Should -Be $true }
+            $decResults | Should-BeCollection -Count 5
+            $decResults | ForEach-Object { $_.Success | Should-Be $true }
 
             # Verify all files are restored with correct content
             for ($i = 1; $i -le 5; $i++)
             {
                 $restoredFile = Join-Path -Path $script:TestDir -ChildPath "batch_test_$i.txt"
-                Test-Path $restoredFile | Should -Be $true
+                Test-Path $restoredFile | Should-Be $true
                 $content = Get-Content $restoredFile -Raw
-                $content.Trim() | Should -Be "Batch content for file $i"
+                $content.Trim() | Should-Be "Batch content for file $i"
             }
         }
 
@@ -264,9 +264,9 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             # Verify all files are restored
             foreach ($file in $files)
             {
-                Test-Path $file.Path | Should -Be $true
+                Test-Path $file.Path | Should-Be $true
                 $content = Get-Content $file.Path -Raw
-                $content.Trim() | Should -Be $file.Content
+                $content.Trim() | Should-Be $file.Content
             }
         }
     }
@@ -283,23 +283,23 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $encryptedBytes = [System.IO.File]::ReadAllBytes($encResult.EncryptedPath)
 
             # Verify expected structure: 32-byte salt + 16-byte IV + encrypted data
-            $encryptedBytes.Length | Should -BeGreaterThan 48  # Minimum size
+            $encryptedBytes.Length | Should-BeGreaterThan 48  # Minimum size
 
             # Extract components
             $salt = $encryptedBytes[0..31]
             $iv = $encryptedBytes[32..47]
 
             # Verify salt and IV are not all zeros (proper randomness)
-            $salt | Should -Not -Be (@(0) * 32)
-            $iv | Should -Not -Be (@(0) * 16)
+            $salt | Should-NotBe (@(0) * 32)
+            $iv | Should-NotBe (@(0) * 16)
 
             # Verify we can decrypt it
             Remove-Item $testFile -Force
             $decResult = Unprotect-PathWithPassword -Path $encResult.EncryptedPath -Password $script:TestPassword
 
-            $decResult.Success | Should -Be $true
+            $decResult.Success | Should-Be $true
             $content = Get-Content $decResult.DecryptedPath -Raw
-            $content | Should -Be 'Cross-platform test content'
+            $content | Should-Be 'Cross-platform test content'
         }
 
         It 'Should handle files encrypted on different PowerShell versions' {
@@ -314,13 +314,13 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $encryptedBytes = [System.IO.File]::ReadAllBytes($encResult.EncryptedPath)
 
             # Manually verify structure (same as what Unprotect expects)
-            $encryptedBytes.Length | Should -BeGreaterOrEqual 64
+            $encryptedBytes.Length | Should-BeGreaterThanOrEqual 64
 
             # Decrypt should work
             Remove-Item $testFile -Force
             $decResult = Unprotect-PathWithPassword -Path $encResult.EncryptedPath -Password $script:TestPassword
 
-            $decResult.Success | Should -Be $true
+            $decResult.Success | Should-Be $true
         }
     }
 
@@ -386,7 +386,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             Write-Verbose "Bash encrypt output: $bashOutput"
 
             # Verify bash created the file
-            Test-Path $encryptedFile | Should -Be $true
+            Test-Path $encryptedFile | Should-Be $true
 
             # Remove original
             Remove-Item $testFile -Force
@@ -396,9 +396,9 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $decResult = Unprotect-PathWithPassword -Path $encryptedFile -Password $pwPassword
 
             # Verify decryption
-            $decResult.Success | Should -Be $true
+            $decResult.Success | Should-Be $true
             $content = Get-Content $decResult.DecryptedPath -Raw
-            $content | Should -Be $originalContent
+            $content | Should-Be $originalContent
         }
 
         It 'Should encrypt files that the OpenSSL bash script can decrypt' {
@@ -425,8 +425,8 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             $encResult = Protect-PathWithPassword -Path $testFile -Password $pwPassword
 
             # Verify encryption
-            $encResult.Success | Should -Be $true
-            Test-Path $encResult.EncryptedPath | Should -Be $true
+            $encResult.Success | Should-Be $true
+            Test-Path $encResult.EncryptedPath | Should-Be $true
 
             # Remove original
             Remove-Item $testFile -Force
@@ -437,9 +437,9 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
             Write-Verbose "Bash decrypt output: $bashOutput"
 
             # Verify bash decrypted successfully
-            Test-Path $decryptedFile | Should -Be $true
+            Test-Path $decryptedFile | Should-Be $true
             $content = Get-Content $decryptedFile -Raw
-            $content | Should -Be $originalContent
+            $content | Should-Be $originalContent
 
             # Cleanup
             Remove-Item $decryptedFile -Force -ErrorAction SilentlyContinue
@@ -472,7 +472,7 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
 
             # Verify binary integrity
             $restoredData = [System.IO.File]::ReadAllBytes($decResult.DecryptedPath)
-            $restoredData | Should -Be $binaryData
+            $restoredData | Should-Be $binaryData
         }
 
         It 'Should provide information about OpenSSL script availability' {
@@ -481,14 +481,14 @@ Describe 'Protect-PathWithPassword and Unprotect-PathWithPassword Integration Te
                 Write-Host 'OpenSSL bash script available and functional' -ForegroundColor Green
                 $opensslVersion = bash -c 'openssl version' 2>&1
                 Write-Host "OpenSSL version: $opensslVersion" -ForegroundColor Cyan
-                $true | Should -Be $true
+                $true | Should-Be $true
             }
             else
             {
                 $reason = if ($script:SkipReason) { $script:SkipReason } else { 'Unknown reason' }
                 Write-Host "OpenSSL interoperability tests skipped: $reason" -ForegroundColor Yellow
                 Write-Host 'For full compatibility testing, install OpenSSL 3.0+ with KDF support' -ForegroundColor Yellow
-                $true | Should -Be $true
+                $true | Should-Be $true
             }
         }
     }

--- a/Tests/Integration/Utilities/Base64Encoding.Tests.ps1
+++ b/Tests/Integration/Utilities/Base64Encoding.Tests.ps1
@@ -71,7 +71,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $result = [System.IO.File]::ReadAllBytes($outputFile)
-            $result | Should-Be $bytes
+            [Convert]::ToBase64String($result) | Should-Be ([Convert]::ToBase64String($bytes))
         }
 
         It 'Should handle large text file' {
@@ -220,7 +220,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $result = [System.IO.File]::ReadAllBytes($outputFile)
-            $result | Should-Be $imageBytes
+            [Convert]::ToBase64String($result) | Should-Be ([Convert]::ToBase64String($imageBytes))
         }
 
         It 'Should handle configuration data' {
@@ -263,7 +263,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $result = [System.IO.File]::ReadAllBytes($outputFile)
-            $result | Should-Be $bytes
+            [Convert]::ToBase64String($result) | Should-Be ([Convert]::ToBase64String($bytes))
         }
     }
 }

--- a/Tests/Integration/Utilities/Base64Encoding.Tests.ps1
+++ b/Tests/Integration/Utilities/Base64Encoding.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
         It 'Should encode and decode through pipeline' {
             $original = 'Pipeline integration test'
             $result = $original | ConvertTo-Base64 | ConvertFrom-Base64
-            $result | Should -Be $original
+            $result | Should-Be $original
         }
 
         It 'Should handle multiple items through pipeline' {
@@ -31,9 +31,9 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             $encoded = $items | ConvertTo-Base64
             $decoded = ($encoded -split "`n") | ConvertFrom-Base64
 
-            $decoded -join ',' | Should -Match 'First'
-            $decoded -join ',' | Should -Match 'Second'
-            $decoded -join ',' | Should -Match 'Third'
+            $decoded -join ',' | Should-MatchString 'First'
+            $decoded -join ',' | Should-MatchString 'Second'
+            $decoded -join ',' | Should-MatchString 'Third'
         }
 
         It 'Should work with Get-Content pipeline' {
@@ -57,7 +57,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $result = Get-Content -Path $outputFile -Raw
-            $result.TrimEnd() | Should -Be $content
+            $result.TrimEnd() | Should-Be $content
         }
 
         It 'Should encode and decode binary file' {
@@ -71,7 +71,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $result = [System.IO.File]::ReadAllBytes($outputFile)
-            $result | Should -Be $bytes
+            $result | Should-Be $bytes
         }
 
         It 'Should handle large text file' {
@@ -87,7 +87,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
 
             $originalContent = Get-Content -Path $sourceFile -Raw
             $decodedContent = Get-Content -Path $outputFile -Raw
-            $decodedContent | Should -Be $originalContent
+            $decodedContent | Should-Be $originalContent
         }
 
         It 'Should handle empty file' {
@@ -96,7 +96,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             '' | Set-Content -Path $sourceFile -NoNewline
 
             $encoded = ConvertTo-Base64 -Path $sourceFile
-            $encoded | Should -Be ''
+            $encoded | Should-Be ''
         }
     }
 
@@ -105,7 +105,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             $original = 'Hello World!?&=subject+query/test'
             $encoded = ConvertTo-Base64 -InputObject $original -UrlSafe
             $decoded = ConvertFrom-Base64 -InputObject $encoded -UrlSafe
-            $decoded | Should -Be $original
+            $decoded | Should-Be $original
         }
 
         It 'Should round-trip with URL-safe encoding for files' {
@@ -116,14 +116,14 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             $content | Set-Content -Path $sourceFile -NoNewline
 
             $encoded = ConvertTo-Base64 -Path $sourceFile -UrlSafe
-            $encoded | Should -Not -Match '\+'
-            $encoded | Should -Not -Match '/'
-            $encoded | Should -Not -Match '='
+            $encoded | Should-NotMatchString '\+'
+            $encoded | Should-NotMatchString '/'
+            $encoded | Should-NotMatchString '='
 
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile -UrlSafe
 
             $result = Get-Content -Path $outputFile -Raw
-            $result.TrimEnd() | Should -Be $content
+            $result.TrimEnd() | Should-Be $content
         }
 
         It 'Should handle various padding scenarios with URL-safe encoding' {
@@ -139,7 +139,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             {
                 $encoded = ConvertTo-Base64 -InputObject $str -UrlSafe
                 $decoded = ConvertFrom-Base64 -InputObject $encoded -UrlSafe
-                $decoded | Should -Be $str
+                $decoded | Should-Be $str
             }
         }
     }
@@ -156,7 +156,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             {
                 $encoded = ConvertTo-Base64 -InputObject $case.Content
                 $decoded = ConvertFrom-Base64 -InputObject $encoded
-                $decoded | Should -Be $case.Content -Because $case.Description
+                $decoded | Should-Be $case.Content -Because $case.Description
             }
         }
 
@@ -173,7 +173,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             {
                 $encoded = ConvertTo-Base64 -InputObject $str
                 $decoded = ConvertFrom-Base64 -InputObject $encoded
-                $decoded | Should -Be $str
+                $decoded | Should-Be $str
             }
         }
     }
@@ -187,7 +187,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             $encoded = ConvertTo-Base64 -InputObject $credentials
             $decoded = ConvertFrom-Base64 -InputObject $encoded
 
-            $decoded | Should -Be $credentials
+            $decoded | Should-Be $credentials
         }
 
         It 'Should handle JWT-like tokens (URL-safe)' {
@@ -204,8 +204,8 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             $decodedHeader = ConvertFrom-Base64 -InputObject $encodedHeader -UrlSafe
             $decodedPayload = ConvertFrom-Base64 -InputObject $encodedPayload -UrlSafe
 
-            $decodedHeader | Should -Be $header
-            $decodedPayload | Should -Be $payload
+            $decodedHeader | Should-Be $header
+            $decodedPayload | Should-Be $payload
         }
 
         It 'Should encode small image file' {
@@ -220,7 +220,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $result = [System.IO.File]::ReadAllBytes($outputFile)
-            $result | Should -Be $imageBytes
+            $result | Should-Be $imageBytes
         }
 
         It 'Should handle configuration data' {
@@ -233,7 +233,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             $encoded = ConvertTo-Base64 -InputObject $config
             $decoded = ConvertFrom-Base64 -InputObject $encoded
 
-            $decoded | Should -Be $config
+            $decoded | Should-Be $config
         }
     }
 
@@ -242,14 +242,14 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             $longString = 'A' * 10000
             $encoded = ConvertTo-Base64 -InputObject $longString
             $decoded = ConvertFrom-Base64 -InputObject $encoded
-            $decoded | Should -Be $longString
+            $decoded | Should-Be $longString
         }
 
         It 'Should handle special whitespace characters' {
             $testInput = "Tab:`t Space: NewLine:`n CarriageReturn:`r"
             $encoded = ConvertTo-Base64 -InputObject $testInput
             $decoded = ConvertFrom-Base64 -InputObject $encoded
-            $decoded | Should -Be $testInput
+            $decoded | Should-Be $testInput
         }
 
         It 'Should handle null bytes in binary data' {
@@ -263,7 +263,7 @@ Describe 'Base64 Encoding Integration Tests' -Tag 'Integration' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $result = [System.IO.File]::ReadAllBytes($outputFile)
-            $result | Should -Be $bytes
+            $result | Should-Be $bytes
         }
     }
 }

--- a/Tests/Integration/Utilities/Convert-LineEnding.Tests.ps1
+++ b/Tests/Integration/Utilities/Convert-LineEnding.Tests.ps1
@@ -97,34 +97,34 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # Verify PowerShell files were converted
             $mainContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:SourceDir -ChildPath 'main.ps1'))
-            $mainContent | Should -Not -Match "`r"
-            $mainContent | Should -Match "Write-Host 'Hello World'"
+            $mainContent | Should-NotMatchString "`r"
+            $mainContent | Should-MatchString "Write-Host 'Hello World'"
 
             # Verify JSON files were converted
             $jsonContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:SourceDir -ChildPath 'config.json'))
-            $jsonContent | Should -Not -Match "`r"
-            $jsonContent | Should -Match '"setting"'
+            $jsonContent | Should-NotMatchString "`r"
+            $jsonContent | Should-MatchString '"setting"'
 
             # Verify Markdown files were converted
             $readmeContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:DocsDir -ChildPath 'README.md'))
-            $readmeContent | Should -Not -Match "`r"
-            $readmeContent | Should -Match 'Project Documentation'
+            $readmeContent | Should-NotMatchString "`r"
+            $readmeContent | Should-MatchString 'Project Documentation'
 
             # Verify shell scripts were converted
             $shellContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:ScriptsDir -ChildPath 'build.sh'))
-            $shellContent | Should -Not -Match "`r"
-            $shellContent | Should -Match 'Building project'
+            $shellContent | Should-NotMatchString "`r"
+            $shellContent | Should-MatchString 'Building project'
         }
 
         It 'Should preserve binary files unchanged' {
             # Binary files should not be modified
             $exeBytes = [System.IO.File]::ReadAllBytes((Join-Path -Path $script:BinaryDir -ChildPath 'app.exe'))
-            $exeBytes[0] | Should -Be 77  # MZ header intact
-            $exeBytes[1] | Should -Be 90
+            $exeBytes[0] | Should-Be 77  # MZ header intact
+            $exeBytes[1] | Should-Be 90
 
             $pngBytes = [System.IO.File]::ReadAllBytes((Join-Path -Path $script:BinaryDir -ChildPath 'image.png'))
-            $pngBytes[0] | Should -Be 137  # PNG header intact
-            $pngBytes[1] | Should -Be 80
+            $pngBytes[0] | Should-Be 137  # PNG header intact
+            $pngBytes[1] | Should-Be 80
         }
 
         It 'Should respect default exclusions for node_modules' {
@@ -163,8 +163,8 @@ Describe 'Convert-LineEnding Integration Tests' {
             Convert-LineEnding -Path $script:Utf8File -LineEnding 'LF'
 
             $result = [System.IO.File]::ReadAllText($script:Utf8File, [System.Text.Encoding]::UTF8)
-            $result | Should -Not -Match "`r"
-            $result | Should -Match 'café, naïve, résumé'
+            $result | Should-NotMatchString "`r"
+            $result | Should-MatchString 'café, naïve, résumé'
         }
 
         It 'Should preserve UTF-8 BOM across platforms' {
@@ -172,22 +172,22 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # Check BOM is preserved
             $bytes = [System.IO.File]::ReadAllBytes($script:Utf8BomFile)
-            $bytes[0] | Should -Be 0xEF
-            $bytes[1] | Should -Be 0xBB
-            $bytes[2] | Should -Be 0xBF
+            $bytes[0] | Should-Be 0xEF
+            $bytes[1] | Should-Be 0xBB
+            $bytes[2] | Should-Be 0xBF
 
             # Check content is correct
             $result = [System.IO.File]::ReadAllText($script:Utf8BomFile, [System.Text.Encoding]::UTF8)
-            $result | Should -Not -Match "`r"
-            $result | Should -Match 'café, naïve, résumé'
+            $result | Should-NotMatchString "`r"
+            $result | Should-MatchString 'café, naïve, résumé'
         }
 
         It 'Should handle ASCII files correctly' {
             Convert-LineEnding -Path $script:AsciiFile -LineEnding 'CRLF'
 
             $result = [System.IO.File]::ReadAllText($script:AsciiFile, [System.Text.Encoding]::ASCII)
-            $result | Should -Match "`r`n"
-            $result | Should -Match 'Simple ASCII text'
+            $result | Should-MatchString "`r`n"
+            $result | Should-MatchString 'Simple ASCII text'
         }
     }
 
@@ -225,14 +225,14 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # PowerShell files should be converted
             $mainContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:PipelineDir -ChildPath 'main.ps1'))
-            $mainContent | Should -Not -Match "`r"
+            $mainContent | Should-NotMatchString "`r"
 
             $helperContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:SubDir1 -ChildPath 'helper.ps1'))
-            $helperContent | Should -Not -Match "`r"
+            $helperContent | Should-NotMatchString "`r"
 
             # Other files should remain unchanged
             $jsonContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:PipelineDir -ChildPath 'config.json'))
-            $jsonContent | Should -Match "`r"  # Should still have CRLF
+            $jsonContent | Should-MatchString "`r"  # Should still have CRLF
         }
 
         It 'Should work with Where-Object filtering in pipeline' {
@@ -245,7 +245,7 @@ Describe 'Convert-LineEnding Integration Tests' {
             if ($processedFiles)
             {
                 $processedFiles | ForEach-Object {
-                    $_.Success | Should -Be $true
+                    $_.Success | Should-Be $true
                 }
             }
             # This tests the integration with complex pipeline scenarios
@@ -258,7 +258,7 @@ Describe 'Convert-LineEnding Integration Tests' {
             $results | Should -Not -BeNullOrEmpty
             $results | ForEach-Object {
                 $_.FilePath | Should -Not -BeNullOrEmpty
-                $_.Success | Should -Be $true
+                $_.Success | Should-Be $true
                 $_.SourceEncoding | Should -Not -BeNullOrEmpty
                 $_.TargetEncoding | Should -Not -BeNullOrEmpty
             }
@@ -279,8 +279,8 @@ Describe 'Convert-LineEnding Integration Tests' {
 
                 if ($results)
                 {
-                    $results.Success | Should -Be $false
-                    $results.Error | Should -Match 'read-only'
+                    $results.Success | Should-Be $false
+                    $results.Error | Should-MatchString 'read-only'
                 }
             }
             finally
@@ -371,18 +371,18 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # Source files should be converted
             $mainJsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:SourceCodeDir -ChildPath 'main.js'))
-            $mainJsContent | Should -Not -Match "`r"
+            $mainJsContent | Should-NotMatchString "`r"
 
             $utilsTsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:SourceCodeDir -ChildPath 'utils.ts'))
-            $utilsTsContent | Should -Not -Match "`r"
+            $utilsTsContent | Should-NotMatchString "`r"
 
             # Test files should be converted (not in dist, not minified)
             $testJsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:TestsDir -ChildPath 'main.test.js'))
-            $testJsContent | Should -Not -Match "`r"
+            $testJsContent | Should-NotMatchString "`r"
 
             # Minified files should be excluded
             $minJsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:DistDir -ChildPath 'bundle.min.js'))
-            $minJsContent | Should -Match "`r"  # Should still have CRLF
+            $minJsContent | Should-MatchString "`r"  # Should still have CRLF
         }
 
         It 'Should handle multiple exclude patterns effectively' {
@@ -405,18 +405,18 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # Only main source files should be converted
             $mainJsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:SourceCodeDir -ChildPath 'main.js'))
-            $mainJsContent | Should -Not -Match "`r"
+            $mainJsContent | Should-NotMatchString "`r"
 
             $utilsTsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:SourceCodeDir -ChildPath 'utils.ts'))
-            $utilsTsContent | Should -Not -Match "`r"
+            $utilsTsContent | Should-NotMatchString "`r"
 
             # Test files should be excluded
             $testJsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:TestsDir -ChildPath 'main.test.js'))
-            $testJsContent | Should -Match "`r"  # Should still have CRLF
+            $testJsContent | Should-MatchString "`r"  # Should still have CRLF
 
             # Dist files should be excluded
             $minJsContent = [System.IO.File]::ReadAllText((Join-Path -Path $script:DistDir -ChildPath 'bundle.min.js'))
-            $minJsContent | Should -Match "`r"  # Should still have CRLF
+            $minJsContent | Should-MatchString "`r"  # Should still have CRLF
         }
     }
 
@@ -461,30 +461,30 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # Check files that should have had newlines added
             $noEndingResult = $results | Where-Object { $_.FilePath -like '*no-ending.txt' }
-            $noEndingResult.EndingNewlineAdded | Should -Be $true
+            $noEndingResult.EndingNewlineAdded | Should-Be $true
 
             $singleLineResult = $results | Where-Object { $_.FilePath -like '*single-line.txt' }
-            $singleLineResult.EndingNewlineAdded | Should -Be $true
+            $singleLineResult.EndingNewlineAdded | Should-Be $true
 
             $subNoEndingResult = $results | Where-Object { $_.FilePath -like '*sub-no-ending.js' }
-            $subNoEndingResult.EndingNewlineAdded | Should -Be $true
+            $subNoEndingResult.EndingNewlineAdded | Should-Be $true
 
             # Check files that should NOT have had newlines added
             $withEndingResult = $results | Where-Object { $_.FilePath -like '*with-ending.txt' }
-            $withEndingResult.EndingNewlineAdded | Should -Be $false
+            $withEndingResult.EndingNewlineAdded | Should-Be $false
 
             $subWithEndingResult = $results | Where-Object { $_.FilePath -like '*sub-with-ending.js' }
-            $subWithEndingResult.EndingNewlineAdded | Should -Be $false
+            $subWithEndingResult.EndingNewlineAdded | Should-Be $false
 
             # Verify file contents
             $noEndingContent = [System.IO.File]::ReadAllText($script:NoEndingFile)
-            $noEndingContent | Should -Be "Line 1`nLine 2 no ending`n"
+            $noEndingContent | Should-Be "Line 1`nLine 2 no ending`n"
 
             $withEndingContent = [System.IO.File]::ReadAllText($script:WithEndingFile)
-            $withEndingContent | Should -Be "Line 1`nLine 2`n"
+            $withEndingContent | Should-Be "Line 1`nLine 2`n"
 
             $singleLineContent = [System.IO.File]::ReadAllText($script:SingleLineFile)
-            $singleLineContent | Should -Be "Single line content`n"
+            $singleLineContent | Should-Be "Single line content`n"
         }
 
         It 'Should work with file filtering and EnsureEndingNewline' {
@@ -500,20 +500,20 @@ Describe 'Convert-LineEnding Integration Tests' {
             $results = Convert-LineEnding -Path $script:EndingTestDir -LineEnding 'LF' -EnsureEndingNewline -Recurse -Include '*.js' -PassThru
 
             # Should only process .js files
-            $results | Should -HaveCount 2
-            $results | ForEach-Object { $_.FilePath | Should -Match '\.js$' }
+            $results | Should-BeCollection -Count 2
+            $results | ForEach-Object { $_.FilePath | Should-MatchString '\.js$' }
 
             # Check that the .js file without ending newline was processed
             $jsNoEndingResult = $results | Where-Object { $_.FilePath -like '*sub-no-ending.js' }
-            $jsNoEndingResult.EndingNewlineAdded | Should -Be $true
+            $jsNoEndingResult.EndingNewlineAdded | Should-Be $true
 
             # Check that the .js file with ending newline was not modified for newline
             $jsWithEndingResult = $results | Where-Object { $_.FilePath -like '*sub-with-ending.js' }
-            $jsWithEndingResult.EndingNewlineAdded | Should -Be $false
+            $jsWithEndingResult.EndingNewlineAdded | Should-Be $false
 
             # Verify non-.js files were not processed (should still not end with newline)
             $finalNoEndingContent = [System.IO.File]::ReadAllText($script:NoEndingFile)
-            $finalNoEndingContent | Should -Not -Match ([char]10 + '$')  # Should still not end with newline
+            $finalNoEndingContent | Should-NotMatchString ([char]10 + '$')  # Should still not end with newline
         }
 
         It 'Should show correct information in WhatIf mode with EnsureEndingNewline' {
@@ -526,7 +526,7 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # File should not be modified
             $contentAfter = [System.IO.File]::ReadAllText($script:NoEndingFile)
-            $contentAfter | Should -Be $content  # Should be unchanged
+            $contentAfter | Should-Be $content  # Should be unchanged
         }
 
         It 'Should work correctly with encoding conversion and ending newline' {
@@ -538,18 +538,18 @@ Describe 'Convert-LineEnding Integration Tests' {
             $result = Convert-LineEnding -Path $testFile -LineEnding 'LF' -Encoding 'UTF8BOM' -EnsureEndingNewline -PassThru
 
             # Should have both encoding change and ending newline added
-            $result.EncodingChanged | Should -Be $true
-            $result.EndingNewlineAdded | Should -Be $true
+            $result.EncodingChanged | Should-Be $true
+            $result.EndingNewlineAdded | Should-Be $true
 
             # Verify BOM was added
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
-            $bytes[0] | Should -Be 0xEF
-            $bytes[1] | Should -Be 0xBB
-            $bytes[2] | Should -Be 0xBF
+            $bytes[0] | Should-Be 0xEF
+            $bytes[1] | Should-Be 0xBB
+            $bytes[2] | Should-Be 0xBF
 
             # Verify content and ending newline
             $content = [System.IO.File]::ReadAllText($testFile)
-            $content | Should -Be "Test content with café`n"
+            $content | Should-Be "Test content with café`n"
         }
 
         It 'Should handle large number of files efficiently with EnsureEndingNewline' {
@@ -576,17 +576,17 @@ Describe 'Convert-LineEnding Integration Tests' {
             $results = Convert-LineEnding -Path $manyFilesDir -LineEnding 'LF' -EnsureEndingNewline -Recurse -PassThru
 
             # Should have processed all files
-            $results | Should -HaveCount $fileCount
+            $results | Should-BeCollection -Count $fileCount
 
             # Files without ending newlines should have had them added
             $filesWithNewlineAdded = $results | Where-Object EndingNewlineAdded
-            $filesWithNewlineAdded | Should -HaveCount ($fileCount / 2)  # Half the files
+            $filesWithNewlineAdded | Should-BeCollection -Count ($fileCount / 2)  # Half the files
 
             # Verify all files now end with newlines
             foreach ($file in $filesCreated)
             {
                 $content = [System.IO.File]::ReadAllText($file)
-                $content | Should -Match "`n$"
+                $content | Should-MatchString "`n$"
             }
         }
 
@@ -599,15 +599,15 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             $result = Convert-LineEnding -Path $attributeTestFile -LineEnding 'LF' -EnsureEndingNewline -PassThru
 
-            $result.EndingNewlineAdded | Should -Be $true
-            $result.Success | Should -Be $true
+            $result.EndingNewlineAdded | Should-Be $true
+            $result.Success | Should-Be $true
 
             # Verify content was modified correctly
             $content = [System.IO.File]::ReadAllText($attributeTestFile)
-            $content | Should -Be "Test content`n"
+            $content | Should-Be "Test content`n"
 
             # File should still exist and be accessible
-            Test-Path $attributeTestFile | Should -Be $true
+            Test-Path $attributeTestFile | Should-Be $true
         }
     }
 
@@ -639,7 +639,7 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # Should have results for all files
             $results | Should -Not -BeNullOrEmpty
-            $results | Should -HaveCount 3
+            $results | Should-BeCollection -Count 3
 
             # Platform detection logic
             if ($PSVersionTable.PSVersion.Major -lt 6)
@@ -655,11 +655,11 @@ Describe 'Convert-LineEnding Integration Tests' {
             $results | ForEach-Object {
                 if ($script:IsWindowsPlatform)
                 {
-                    $_.LineEnding | Should -Be 'CRLF'
+                    $_.LineEnding | Should-Be 'CRLF'
                 }
                 else
                 {
-                    $_.LineEnding | Should -Be 'LF'
+                    $_.LineEnding | Should-Be 'LF'
                 }
             }
         }
@@ -673,7 +673,7 @@ Describe 'Convert-LineEnding Integration Tests' {
             $result = Convert-LineEnding -Path $script:MixedFile -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Skipped | Should -Be $false
+            $result.Skipped | Should-Be $false
 
             # Platform detection
             if ($PSVersionTable.PSVersion.Major -lt 6)
@@ -687,17 +687,17 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             if ($script:IsWindowsPlatform)
             {
-                $result.LineEnding | Should -Be 'CRLF'
+                $result.LineEnding | Should-Be 'CRLF'
                 # Verify file content has CRLF
                 $finalContent = [System.IO.File]::ReadAllText($script:MixedFile)
-                $finalContent | Should -Match "`r`n"
+                $finalContent | Should-MatchString "`r`n"
             }
             else
             {
-                $result.LineEnding | Should -Be 'LF'
+                $result.LineEnding | Should-Be 'LF'
                 # Verify file content has only LF
                 $finalContent = [System.IO.File]::ReadAllText($script:MixedFile)
-                $finalContent | Should -Not -Match "`r"
+                $finalContent | Should-NotMatchString "`r"
             }
         }
 
@@ -716,15 +716,15 @@ Describe 'Convert-LineEnding Integration Tests' {
             {
                 # On Windows, CRLF file should be skipped when using Auto
                 $result = Convert-LineEnding -Path $script:CrlfFile -PassThru
-                $result.Skipped | Should -Be $true
-                $result.LineEnding | Should -Be 'CRLF'
+                $result.Skipped | Should-Be $true
+                $result.LineEnding | Should-Be 'CRLF'
             }
             else
             {
                 # On Unix/Linux/macOS, LF file should be skipped when using Auto
                 $result = Convert-LineEnding -Path $script:LfFile -PassThru
-                $result.Skipped | Should -Be $true
-                $result.LineEnding | Should -Be 'LF'
+                $result.Skipped | Should-Be $true
+                $result.LineEnding | Should-Be 'LF'
             }
         }
     }
@@ -810,9 +810,9 @@ Describe 'Convert-LineEnding Integration Tests' {
             $result = Convert-LineEnding -Path $singleTestFile -LineEnding 'LF' -PreserveTimestamps -PassThru
 
             # Verify the file was converted successfully
-            $result.Success | Should -Be $true
-            $result.Converted | Should -Be $true
-            $result.Skipped | Should -Be $false
+            $result.Success | Should-Be $true
+            $result.Converted | Should-Be $true
+            $result.Skipped | Should-Be $false
 
             # Verify timestamps were preserved
             $newFileInfo = Get-Item $singleTestFile
@@ -822,13 +822,13 @@ Describe 'Convert-LineEnding Integration Tests' {
 
             # Use platform-appropriate tolerance: Windows NTFS can have different precision than APFS/ext4
             $tolerance = if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) { 2 } else { 0.1 }
-            $creationDiff | Should -BeLessThan $tolerance -Because 'Creation time should be preserved'
-            $writeDiff | Should -BeLessThan $tolerance -Because 'Last write time should be preserved'
+            $creationDiff | Should-BeLessThan $tolerance -Because 'Creation time should be preserved'
+            $writeDiff | Should-BeLessThan $tolerance -Because 'Last write time should be preserved'
 
             # Verify content was actually converted
             $afterBytes = [System.IO.File]::ReadAllBytes($singleTestFile)
             $hasCarriageReturn = $afterBytes -contains 13
-            $hasCarriageReturn | Should -Be $false -Because 'File should not contain CR bytes after LF conversion'
+            $hasCarriageReturn | Should-Be $false -Because 'File should not contain CR bytes after LF conversion'
 
             # Clean up
             Remove-Item $singleTestFile -Force -ErrorAction SilentlyContinue
@@ -851,18 +851,18 @@ Describe 'Convert-LineEnding Integration Tests' {
             $result = Convert-LineEnding -Path $singleTestFile -LineEnding 'LF' -PassThru
 
             # Verify the file was converted
-            $result.Success | Should -Be $true
-            $result.Converted | Should -Be $true
+            $result.Success | Should-Be $true
+            $result.Converted | Should-Be $true
 
             # Verify timestamps were NOT preserved (should be current time)
             $newFileInfo = Get-Item $singleTestFile
             $currentTime = Get-Date
 
             # Timestamps should be recent (within last 30 seconds)
-            ($currentTime - $newFileInfo.LastWriteTime).TotalSeconds | Should -BeLessThan 30 -Because 'Last write time should be current when not preserving timestamps'
+            ($currentTime - $newFileInfo.LastWriteTime).TotalSeconds | Should-BeLessThan 30 -Because 'Last write time should be current when not preserving timestamps'
 
             # Should not be the original past time
-            $newFileInfo.LastWriteTime | Should -Not -Be $pastTime -Because 'Timestamp should have changed when PreserveTimestamps is not specified'
+            $newFileInfo.LastWriteTime | Should-NotBe $pastTime -Because 'Timestamp should have changed when PreserveTimestamps is not specified'
 
             # Clean up
             Remove-Item $singleTestFile -Force -ErrorAction SilentlyContinue
@@ -901,7 +901,7 @@ Describe 'Convert-LineEnding Integration Tests' {
                     break
                 }
             }
-            $hasCrLf | Should -Be $true -Because 'CRLF test file should actually contain CRLF bytes'
+            $hasCrLf | Should-Be $true -Because 'CRLF test file should actually contain CRLF bytes'
 
             # LF file should contain standalone LF (0A) without preceding CR
             $hasStandaloneLf = $false
@@ -918,7 +918,7 @@ Describe 'Convert-LineEnding Integration Tests' {
                     }
                 }
             }
-            $hasStandaloneLf | Should -Be $true -Because 'LF test file should actually contain standalone LF bytes'
+            $hasStandaloneLf | Should-Be $true -Because 'LF test file should actually contain standalone LF bytes'
 
             # Set past timestamps on both files
             $pastTime = (Get-Date).AddDays(-7)
@@ -936,8 +936,8 @@ Describe 'Convert-LineEnding Integration Tests' {
             $convertedResults = @($results | Where-Object { $_.Converted -eq $true })
             $skippedResults = @($results | Where-Object { $_.Skipped -eq $true })
 
-            $convertedResults.Count | Should -Be 1 -Because 'One file should have been converted from CRLF to LF'
-            $skippedResults.Count | Should -Be 1 -Because 'One file should have been skipped (already LF)'
+            $convertedResults.Count | Should-Be 1 -Because 'One file should have been converted from CRLF to LF'
+            $skippedResults.Count | Should-Be 1 -Because 'One file should have been skipped (already LF)'
 
             # Both files should have preserved timestamps when -PreserveTimestamps is specified
             $allResults = @($convertedResults) + @($skippedResults)
@@ -950,8 +950,8 @@ Describe 'Convert-LineEnding Integration Tests' {
 
                 # Use platform-appropriate tolerance: Windows NTFS can have different precision than APFS/ext4
                 $tolerance = if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) { 2 } else { 0.1 }
-                $creationDiff | Should -BeLessThan $tolerance -Because 'Timestamps should be preserved when -PreserveTimestamps is specified'
-                $writeDiff | Should -BeLessThan $tolerance -Because 'Timestamps should be preserved when -PreserveTimestamps is specified'
+                $creationDiff | Should-BeLessThan $tolerance -Because 'Timestamps should be preserved when -PreserveTimestamps is specified'
+                $writeDiff | Should-BeLessThan $tolerance -Because 'Timestamps should be preserved when -PreserveTimestamps is specified'
             }
 
             # Clean up

--- a/Tests/Integration/Utilities/Copy-Directory.Tests.ps1
+++ b/Tests/Integration/Utilities/Copy-Directory.Tests.ps1
@@ -51,11 +51,11 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip -Recurse
 
-            $result.TotalFiles | Should -Be 2
-            $result.TotalDirectories | Should -Be 0
-            Test-Path "$destDir\file1.txt" | Should -Be $true
-            Test-Path "$destDir\file2.txt" | Should -Be $true
-            (Get-Content -Path "$destDir\file1.txt") | Should -Be 'file1 content'
+            $result.TotalFiles | Should-Be 2
+            $result.TotalDirectories | Should-Be 0
+            Test-Path "$destDir\file1.txt" | Should-Be $true
+            Test-Path "$destDir\file2.txt" | Should-Be $true
+            (Get-Content -Path "$destDir\file1.txt") | Should-Be 'file1 content'
         }
 
         It 'Should copy nested directory structure' {
@@ -70,11 +70,11 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip -Recurse
 
-            $result.TotalFiles | Should -Be 3
-            $result.TotalDirectories | Should -Be 3
-            Test-Path "$destDir\dir1\file1.txt" | Should -Be $true
-            Test-Path "$destDir\dir1\subdir1\file2.txt" | Should -Be $true
-            Test-Path "$destDir\dir2\file3.txt" | Should -Be $true
+            $result.TotalFiles | Should-Be 3
+            $result.TotalDirectories | Should-Be 3
+            Test-Path "$destDir\dir1\file1.txt" | Should-Be $true
+            Test-Path "$destDir\dir1\subdir1\file2.txt" | Should-Be $true
+            Test-Path "$destDir\dir2\file3.txt" | Should-Be $true
         }
 
         It 'Should preserve file contents during copy' {
@@ -87,7 +87,7 @@ Describe 'Copy-Directory Integration Tests' {
 
             Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip | Out-Null
 
-            (Get-Content -Path "$destDir\test.txt") | Should -Be $testContent
+            (Get-Content -Path "$destDir\test.txt") | Should-Be $testContent
         }
     }
 
@@ -113,9 +113,9 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip -Recurse
 
-            $result.FilesSkipped | Should -Be 1
-            $result.FilesOverwritten | Should -Be 0
-            (Get-Content -Path "$destDir\existing.txt") | Should -Be 'old content'
+            $result.FilesSkipped | Should-Be 1
+            $result.FilesOverwritten | Should-Be 0
+            (Get-Content -Path "$destDir\existing.txt") | Should-Be 'old content'
         }
 
         It 'Should copy new files in Skip mode' {
@@ -127,9 +127,9 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip
 
-            $result.TotalFiles | Should -Be 1
-            $result.FilesSkipped | Should -Be 0
-            Test-Path "$destDir\newfile.txt" | Should -Be $true
+            $result.TotalFiles | Should-Be 1
+            $result.FilesSkipped | Should-Be 0
+            Test-Path "$destDir\newfile.txt" | Should-Be $true
         }
 
         It 'Should track mixed skip and copy operations' {
@@ -146,10 +146,10 @@ Describe 'Copy-Directory Integration Tests' {
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip
 
             # TotalFiles tracks copied files, FilesSkipped tracks skipped files
-            $result.TotalFiles | Should -Be 1
-            $result.FilesSkipped | Should -Be 1
-            (Get-Content -Path "$destDir\file1.txt") | Should -Be 'new 1'
-            (Get-Content -Path "$destDir\file2.txt") | Should -Be 'old 2'
+            $result.TotalFiles | Should-Be 1
+            $result.FilesSkipped | Should-Be 1
+            (Get-Content -Path "$destDir\file1.txt") | Should-Be 'new 1'
+            (Get-Content -Path "$destDir\file2.txt") | Should-Be 'old 2'
         }
     }
 
@@ -175,8 +175,8 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Overwrite
 
-            $result.FilesOverwritten | Should -Be 1
-            (Get-Content -Path "$destDir\file.txt") | Should -Be 'new content'
+            $result.FilesOverwritten | Should-Be 1
+            (Get-Content -Path "$destDir\file.txt") | Should-Be 'new content'
         }
 
         It 'Should overwrite multiple files in Overwrite mode' {
@@ -193,9 +193,9 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Overwrite
 
-            $result.FilesOverwritten | Should -Be 2
-            (Get-Content -Path "$destDir\file1.txt") | Should -Be 'new1'
-            (Get-Content -Path "$destDir\file2.txt") | Should -Be 'new2'
+            $result.FilesOverwritten | Should-Be 2
+            (Get-Content -Path "$destDir\file1.txt") | Should-Be 'new1'
+            (Get-Content -Path "$destDir\file2.txt") | Should-Be 'new2'
         }
     }
 
@@ -225,8 +225,8 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode IfNewer
 
-            $result.FilesOverwritten | Should -Be 1
-            (Get-Content -Path "$destDir\file.txt") | Should -Be 'new content'
+            $result.FilesOverwritten | Should-Be 1
+            (Get-Content -Path "$destDir\file.txt") | Should-Be 'new content'
         }
 
         It 'Should skip if destination is newer or equal' {
@@ -245,8 +245,8 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode IfNewer
 
-            $result.FilesSkipped | Should -Be 1
-            (Get-Content -Path "$destDir\file.txt") | Should -Be 'old content'
+            $result.FilesSkipped | Should-Be 1
+            (Get-Content -Path "$destDir\file.txt") | Should-Be 'old content'
         }
 
         It 'Should handle timestamp comparison correctly' {
@@ -269,7 +269,7 @@ Describe 'Copy-Directory Integration Tests' {
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode IfNewer
 
             # Should skip if timestamps are equal (not newer)
-            $result.FilesSkipped | Should -Be 1
+            $result.FilesSkipped | Should-Be 1
         }
     }
 
@@ -299,10 +299,10 @@ Describe 'Copy-Directory Integration Tests' {
 
             Copy-Directory -Source $sourceDir -Destination $destDir -ExcludeDirectories '.git' -UpdateMode Skip -Recurse
 
-            Test-Path "$destDir\.git" | Should -Be $false
-            Test-Path "$destDir\src\app\.git" | Should -Be $false
-            Test-Path "$destDir\src\app\main.ps1" | Should -Be $true
-            Test-Path "$destDir\src\lib\helper.ps1" | Should -Be $true
+            Test-Path "$destDir\.git" | Should-Be $false
+            Test-Path "$destDir\src\app\.git" | Should-Be $false
+            Test-Path "$destDir\src\app\main.ps1" | Should-Be $true
+            Test-Path "$destDir\src\lib\helper.ps1" | Should-Be $true
         }
 
         It 'Should exclude multiple build artifact directories' {
@@ -322,11 +322,11 @@ Describe 'Copy-Directory Integration Tests' {
             $result = Copy-Directory -Source $sourceDir -Destination $destDir `
                 -ExcludeDirectories 'bin', 'obj', 'dist' -UpdateMode Skip -Recurse
 
-            $result.ExcludedDirectories | Should -Be 3
-            Test-Path "$destDir\bin" | Should -Be $false
-            Test-Path "$destDir\obj" | Should -Be $false
-            Test-Path "$destDir\dist" | Should -Be $false
-            Test-Path "$destDir\src\main.ps1" | Should -Be $true
+            $result.ExcludedDirectories | Should-Be 3
+            Test-Path "$destDir\bin" | Should-Be $false
+            Test-Path "$destDir\obj" | Should-Be $false
+            Test-Path "$destDir\dist" | Should-Be $false
+            Test-Path "$destDir\src\main.ps1" | Should-Be $true
         }
     }
 
@@ -350,7 +350,7 @@ Describe 'Copy-Directory Integration Tests' {
             Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip -WhatIf
 
             # Destination should not exist with WhatIf
-            Test-Path $destDir | Should -Be $false
+            Test-Path $destDir | Should-Be $false
         }
     }
 
@@ -371,7 +371,7 @@ Describe 'Copy-Directory Integration Tests' {
 
             {
                 Copy-Directory -Source $sourceDir -Destination $sourceDir -UpdateMode Skip -Recurse
-            } | Should -Throw -ExpectedMessage '*same directory*'
+            } | Should-Throw -ExceptionMessage '*same directory*'
         }
 
         It 'Should reject recursive copy when destination is inside source' {
@@ -382,7 +382,7 @@ Describe 'Copy-Directory Integration Tests' {
 
             {
                 Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip -Recurse
-            } | Should -Throw -ExpectedMessage '*inside the source directory*'
+            } | Should-Throw -ExceptionMessage '*inside the source directory*'
         }
     }
 
@@ -412,9 +412,9 @@ Describe 'Copy-Directory Integration Tests' {
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip -Recurse
 
             # 5 files total
-            $result.TotalFiles | Should -Be 5
+            $result.TotalFiles | Should-Be 5
             # 3 directories: dir1, dir1\subdir1, dir2
-            $result.TotalDirectories | Should -Be 3
+            $result.TotalDirectories | Should-Be 3
         }
 
         It 'Should measure duration correctly' {
@@ -427,7 +427,7 @@ Describe 'Copy-Directory Integration Tests' {
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip
 
             $result.Duration | Should -Not -BeNullOrEmpty
-            $result.Duration.TotalMilliseconds | Should -BeGreaterThan 0
+            $result.Duration.TotalMilliseconds | Should-BeGreaterThan 0
         }
 
         It 'Should correctly count skipped vs overwritten files' {
@@ -449,9 +449,9 @@ Describe 'Copy-Directory Integration Tests' {
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip
 
             # TotalFiles = copied files, FilesSkipped = files that existed and were skipped
-            $result.TotalFiles | Should -Be 1  # Only file1 was copied
-            $result.FilesSkipped | Should -Be 2  # Files 2 and 3 were skipped
-            $result.FilesOverwritten | Should -Be 0
+            $result.TotalFiles | Should-Be 1  # Only file1 was copied
+            $result.FilesSkipped | Should-Be 2  # Files 2 and 3 were skipped
+            $result.FilesOverwritten | Should-Be 0
         }
     }
 
@@ -478,10 +478,10 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -ThrottleLimit 4
 
-            $result.TotalFiles | Should -Be 20
+            $result.TotalFiles | Should-Be 20
             1..20 | ForEach-Object {
-                Test-Path "$destDir\file$_.txt" | Should -Be $true
-                (Get-Content -Path "$destDir\file$_.txt") | Should -Be "content for file $_"
+                Test-Path "$destDir\file$_.txt" | Should-Be $true
+                (Get-Content -Path "$destDir\file$_.txt") | Should-Be "content for file $_"
             }
         }
 
@@ -501,16 +501,16 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -ThrottleLimit 8 -Recurse
 
-            $result.TotalFiles | Should -Be 25
-            $result.TotalDirectories | Should -Be 4
+            $result.TotalFiles | Should-Be 25
+            $result.TotalDirectories | Should-Be 4
 
             # Verify content integrity across all levels
             1..5 | ForEach-Object {
-                (Get-Content -Path "$destDir\root$_.txt") | Should -Be "root $_"
-                (Get-Content -Path "$destDir\level1\l1_$_.txt") | Should -Be "level1 $_"
-                (Get-Content -Path "$destDir\level1\level2\l2_$_.txt") | Should -Be "level2 $_"
-                (Get-Content -Path "$destDir\level1\level2\level3\l3_$_.txt") | Should -Be "level3 $_"
-                (Get-Content -Path "$destDir\another\a$_.txt") | Should -Be "another $_"
+                (Get-Content -Path "$destDir\root$_.txt") | Should-Be "root $_"
+                (Get-Content -Path "$destDir\level1\l1_$_.txt") | Should-Be "level1 $_"
+                (Get-Content -Path "$destDir\level1\level2\l2_$_.txt") | Should-Be "level2 $_"
+                (Get-Content -Path "$destDir\level1\level2\level3\l3_$_.txt") | Should-Be "level3 $_"
+                (Get-Content -Path "$destDir\another\a$_.txt") | Should-Be "another $_"
             }
         }
 
@@ -529,9 +529,9 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Skip -ThrottleLimit 4
 
-            $result.TotalFiles | Should -Be 5  # Only files 6-10 copied
-            $result.FilesSkipped | Should -Be 5  # Files 1-5 skipped
-            $result.FilesOverwritten | Should -Be 0
+            $result.TotalFiles | Should-Be 5  # Only files 6-10 copied
+            $result.FilesSkipped | Should-Be 5  # Files 1-5 skipped
+            $result.FilesOverwritten | Should-Be 0
         }
 
         It 'Should correctly track statistics in parallel mode with Overwrite' {
@@ -549,13 +549,13 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode Overwrite -ThrottleLimit 4
 
-            $result.TotalFiles | Should -Be 10  # All 10 files copied
-            $result.FilesSkipped | Should -Be 0
-            $result.FilesOverwritten | Should -Be 5  # Files 1-5 overwritten
+            $result.TotalFiles | Should-Be 10  # All 10 files copied
+            $result.FilesSkipped | Should-Be 0
+            $result.FilesOverwritten | Should-Be 5  # Files 1-5 overwritten
 
             # Verify all files have new content
             1..10 | ForEach-Object {
-                (Get-Content -Path "$destDir\file$_.txt") | Should -Be "new $_"
+                (Get-Content -Path "$destDir\file$_.txt") | Should-Be "new $_"
             }
         }
 
@@ -579,9 +579,9 @@ Describe 'Copy-Directory Integration Tests' {
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -UpdateMode IfNewer -ThrottleLimit 4
 
             # Files 1-3: overwritten (newer), Files 4-6: newly copied
-            $result.TotalFiles | Should -Be 6  # All 6 files copied
-            $result.FilesOverwritten | Should -Be 3  # Files 1-3 overwritten
-            $result.FilesSkipped | Should -Be 0
+            $result.TotalFiles | Should-Be 6  # All 6 files copied
+            $result.FilesOverwritten | Should-Be 3  # Files 1-3 overwritten
+            $result.FilesSkipped | Should-Be 0
         }
 
         It 'Should produce consistent results between sequential and parallel modes' {
@@ -604,15 +604,15 @@ Describe 'Copy-Directory Integration Tests' {
             $resultSeq = Copy-Directory -Source $sourceSeqDir -Destination $destSeqDir -ThrottleLimit 1 -Recurse
             $resultPar = Copy-Directory -Source $sourceParDir -Destination $destParDir -ThrottleLimit 8 -Recurse
 
-            $resultSeq.TotalFiles | Should -Be $resultPar.TotalFiles
-            $resultSeq.TotalDirectories | Should -Be $resultPar.TotalDirectories
-            $resultSeq.FilesSkipped | Should -Be $resultPar.FilesSkipped
-            $resultSeq.FilesOverwritten | Should -Be $resultPar.FilesOverwritten
+            $resultSeq.TotalFiles | Should-Be $resultPar.TotalFiles
+            $resultSeq.TotalDirectories | Should-Be $resultPar.TotalDirectories
+            $resultSeq.FilesSkipped | Should-Be $resultPar.FilesSkipped
+            $resultSeq.FilesOverwritten | Should-Be $resultPar.FilesOverwritten
 
             # Verify content is identical
             1..10 | ForEach-Object {
-                (Get-Content "$destSeqDir\file$_.txt") | Should -Be (Get-Content "$destParDir\file$_.txt")
-                (Get-Content "$destSeqDir\sub\sub$_.txt") | Should -Be (Get-Content "$destParDir\sub\sub$_.txt")
+                (Get-Content "$destSeqDir\file$_.txt") | Should-Be (Get-Content "$destParDir\file$_.txt")
+                (Get-Content "$destSeqDir\sub\sub$_.txt") | Should-Be (Get-Content "$destParDir\sub\sub$_.txt")
             }
         }
 
@@ -632,12 +632,12 @@ Describe 'Copy-Directory Integration Tests' {
 
             $result = Copy-Directory -Source $sourceDir -Destination $destDir -ExcludeDirectories '.git', 'node_modules' -ThrottleLimit 4 -Recurse
 
-            $result.TotalFiles | Should -Be 5
-            $result.ExcludedDirectories | Should -Be 2
+            $result.TotalFiles | Should-Be 5
+            $result.ExcludedDirectories | Should-Be 2
 
-            Test-Path "$destDir\include" | Should -Be $true
-            Test-Path "$destDir\.git" | Should -Be $false
-            Test-Path "$destDir\node_modules" | Should -Be $false
+            Test-Path "$destDir\include" | Should-Be $true
+            Test-Path "$destDir\.git" | Should-Be $false
+            Test-Path "$destDir\node_modules" | Should-Be $false
         }
 
         It 'Should be faster with parallel processing for large file sets' {
@@ -656,13 +656,13 @@ Describe 'Copy-Directory Integration Tests' {
             $resultPar = Copy-Directory -Source $sourceDir -Destination $destParDir -ThrottleLimit 8
 
             # Both should complete successfully with same file count
-            $resultSeq.TotalFiles | Should -Be 50
-            $resultPar.TotalFiles | Should -Be 50
+            $resultSeq.TotalFiles | Should-Be 50
+            $resultPar.TotalFiles | Should-Be 50
 
             # Parallel should generally be faster or equal (file I/O can be unpredictable)
             # We just verify both complete without errors
-            $resultSeq.Duration | Should -BeOfType [TimeSpan]
-            $resultPar.Duration | Should -BeOfType [TimeSpan]
+            $resultSeq.Duration | Should-HaveType ([TimeSpan])
+            $resultPar.Duration | Should-HaveType ([TimeSpan])
         }
     }
 }

--- a/Tests/Integration/Utilities/Remove-OldFile.Tests.ps1
+++ b/Tests/Integration/Utilities/Remove-OldFile.Tests.ps1
@@ -66,16 +66,16 @@ Describe 'Remove-OldFile Integration Tests' {
         It 'Should remove only files older than threshold' {
             $result = Remove-OldFile -Path $script:testDir -OlderThan 7 -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 3
+            $result.FilesRemoved | Should-Be 3
 
             # Verify old files are gone
-            Test-Path (Join-Path -Path $script:testDir -ChildPath 'old_file_1.txt') | Should -Be $false
-            Test-Path (Join-Path -Path $script:testDir -ChildPath 'old_file_2.txt') | Should -Be $false
-            Test-Path (Join-Path -Path $script:testDir -ChildPath 'old_file_3.txt') | Should -Be $false
+            Test-Path (Join-Path -Path $script:testDir -ChildPath 'old_file_1.txt') | Should-Be $false
+            Test-Path (Join-Path -Path $script:testDir -ChildPath 'old_file_2.txt') | Should-Be $false
+            Test-Path (Join-Path -Path $script:testDir -ChildPath 'old_file_3.txt') | Should-Be $false
 
             # Verify recent and current files remain
-            Test-Path (Join-Path -Path $script:testDir -ChildPath 'recent_file_1.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testDir -ChildPath 'current.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testDir -ChildPath 'recent_file_1.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testDir -ChildPath 'current.txt') | Should-Be $true
         }
 
         It 'Should calculate space freed correctly' {
@@ -91,8 +91,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $spaceTestDir -OlderThan 5 -Confirm:$false
 
-            $result.TotalSpaceFreed | Should -BeGreaterThan 1000000
-            $result.TotalSpaceFreedMB | Should -BeGreaterThan 0.9
+            $result.TotalSpaceFreed | Should-BeGreaterThan 1000000
+            $result.TotalSpaceFreedMB | Should-BeGreaterThan 0.9
 
             Remove-TestDirectory -Path $spaceTestDir
         }
@@ -115,8 +115,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $script:timeTestDir -OlderThan 24 -Unit Hours -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 1
-            Test-Path $file | Should -Be $false
+            $result.FilesRemoved | Should-Be 1
+            Test-Path $file | Should-Be $false
         }
 
         It 'Should work with Days unit' {
@@ -126,8 +126,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $script:timeTestDir -OlderThan 10 -Unit Days -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 1
-            Test-Path $file | Should -Be $false
+            $result.FilesRemoved | Should-Be 1
+            Test-Path $file | Should-Be $false
         }
 
         It 'Should work with Months unit' {
@@ -137,8 +137,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $script:timeTestDir -OlderThan 3 -Unit Months -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 1
-            Test-Path $file | Should -Be $false
+            $result.FilesRemoved | Should-Be 1
+            Test-Path $file | Should-Be $false
         }
 
         It 'Should work with Years unit' {
@@ -148,8 +148,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $script:timeTestDir -OlderThan 1 -Unit Years -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 1
-            Test-Path $file | Should -Be $false
+            $result.FilesRemoved | Should-Be 1
+            Test-Path $file | Should-Be $false
         }
     }
 
@@ -173,15 +173,15 @@ Describe 'Remove-OldFile Integration Tests' {
         It 'Should only remove files matching Include pattern' {
             $result = Remove-OldFile -Path $script:filterDir -OlderThan 7 -Include '*.log' -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 3
+            $result.FilesRemoved | Should-Be 3
 
             # .log files should be removed
-            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file1.log') | Should -Be $false
-            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file3.log') | Should -Be $false
+            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file1.log') | Should-Be $false
+            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file3.log') | Should-Be $false
 
             # Other files should remain
-            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file2.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file4.tmp') | Should -Be $true
+            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file2.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:filterDir -ChildPath 'file4.tmp') | Should-Be $true
         }
 
         It 'Should exclude files matching Exclude pattern' {
@@ -197,8 +197,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $excludeTestDir -OlderThan 7 -Exclude 'keep*' -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 2
-            Test-Path (Join-Path -Path $excludeTestDir -ChildPath 'keep1.txt') | Should -Be $true
+            $result.FilesRemoved | Should-Be 2
+            Test-Path (Join-Path -Path $excludeTestDir -ChildPath 'keep1.txt') | Should-Be $true
 
             Remove-TestDirectory -Path $excludeTestDir
         }
@@ -215,8 +215,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $multiIncludeDir -OlderThan 7 -Include @('*.log', '*.tmp') -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 4
-            Test-Path (Join-Path -Path $multiIncludeDir -ChildPath 'file3.txt') | Should -Be $true
+            $result.FilesRemoved | Should-Be 4
+            Test-Path (Join-Path -Path $multiIncludeDir -ChildPath 'file3.txt') | Should-Be $true
 
             Remove-TestDirectory -Path $multiIncludeDir
         }
@@ -249,13 +249,13 @@ Describe 'Remove-OldFile Integration Tests' {
         It 'Should exclude specified directories from processing' {
             $result = Remove-OldFile -Path $script:dirExcludeTest -OlderThan 7 -ExcludeDirectory 'KeepMe' -Recurse -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 1
+            $result.FilesRemoved | Should-Be 1
 
             # File in excluded directory should remain
-            Test-Path (Join-Path -Path $script:dirExcludeTest -ChildPath 'KeepMe/file_keep.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:dirExcludeTest -ChildPath 'KeepMe/file_keep.txt') | Should-Be $true
 
             # File in processed directory should be removed
-            Test-Path (Join-Path -Path $script:dirExcludeTest -ChildPath 'ProcessMe/file_process.txt') | Should -Be $false
+            Test-Path (Join-Path -Path $script:dirExcludeTest -ChildPath 'ProcessMe/file_process.txt') | Should-Be $false
         }
     }
 
@@ -293,16 +293,16 @@ Describe 'Remove-OldFile Integration Tests' {
         It 'Should remove empty directories when specified' {
             $result = Remove-OldFile -Path $script:emptyDirTest -OlderThan 7 -RemoveEmptyDirectories -Recurse -Confirm:$false -ErrorAction SilentlyContinue
 
-            $result.FilesRemoved | Should -Be 2
-            $result.DirectoriesRemoved | Should -BeGreaterOrEqual 2
+            $result.FilesRemoved | Should-Be 2
+            $result.DirectoriesRemoved | Should-BeGreaterThanOrEqual 2
 
             # Empty directories should be removed
-            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'SubDir1/SubDir2') | Should -Be $false
-            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'SubDir1') | Should -Be $false
+            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'SubDir1/SubDir2') | Should-Be $false
+            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'SubDir1') | Should-Be $false
 
             # Directory with remaining files should exist
-            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'MixedDir') | Should -Be $true
-            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'MixedDir/new.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'MixedDir') | Should-Be $true
+            Test-Path (Join-Path -Path $script:emptyDirTest -ChildPath 'MixedDir/new.txt') | Should-Be $true
         }
 
         It 'Should not remove directories when flag not set' {
@@ -317,11 +317,11 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $noRemoveDir -OlderThan 7 -Recurse -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 1
-            $result.DirectoriesRemoved | Should -Be 0
+            $result.FilesRemoved | Should-Be 1
+            $result.DirectoriesRemoved | Should-Be 0
 
             # Directory should still exist (empty)
-            Test-Path $subDir | Should -Be $true
+            Test-Path $subDir | Should-Be $true
 
             Remove-TestDirectory -Path $noRemoveDir
         }
@@ -359,9 +359,9 @@ Describe 'Remove-OldFile Integration Tests' {
             $result = Remove-OldFile -Path $script:forceTestDir -OlderThan 7 -Confirm:$false
 
             # Only normal file should be removed
-            $result.FilesRemoved | Should -Be 1
-            Test-Path (Join-Path -Path $script:forceTestDir -ChildPath 'readonly.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:forceTestDir -ChildPath 'normal.txt') | Should -Be $false
+            $result.FilesRemoved | Should-Be 1
+            Test-Path (Join-Path -Path $script:forceTestDir -ChildPath 'readonly.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:forceTestDir -ChildPath 'normal.txt') | Should-Be $false
         }
 
         It 'Should remove read-only files with Force' {
@@ -378,8 +378,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $script:forceTestDir -OlderThan 7 -Force -Confirm:$false
 
-            $result.FilesRemoved | Should -BeGreaterOrEqual 1
-            Test-Path $readOnlyFile | Should -Be $false
+            $result.FilesRemoved | Should-BeGreaterThanOrEqual 1
+            Test-Path $readOnlyFile | Should-Be $false
         }
     }
 
@@ -413,8 +413,8 @@ Describe 'Remove-OldFile Integration Tests' {
 
             # Should process both directories and return a single summary
             $result | Should -Not -BeNullOrEmpty
-            $result.FilesRemoved | Should -Be 4
-            $result.Errors | Should -Be 0
+            $result.FilesRemoved | Should-Be 4
+            $result.Errors | Should-Be 0
         }
     }
 
@@ -424,7 +424,7 @@ Describe 'Remove-OldFile Integration Tests' {
 
             $result = Remove-OldFile -Path $nonExistent -OlderThan 1 -ErrorAction SilentlyContinue
 
-            $result.Errors | Should -BeGreaterThan 0
+            $result.Errors | Should-BeGreaterThan 0
         }
 
         It 'Should continue processing after individual file errors' {
@@ -445,8 +445,8 @@ Describe 'Remove-OldFile Integration Tests' {
             $result = Remove-OldFile -Path $errorTestDir -OlderThan 7 -Confirm:$false
 
             # Should remove file2 even if file1 fails
-            $result.FilesRemoved | Should -BeGreaterOrEqual 1
-            Test-Path $file2 | Should -Be $false
+            $result.FilesRemoved | Should-BeGreaterThanOrEqual 1
+            Test-Path $file2 | Should-Be $false
 
             # Cleanup
             (Get-Item $file1).IsReadOnly = $false

--- a/Tests/Integration/Utilities/Rename-File.Tests.ps1
+++ b/Tests/Integration/Utilities/Rename-File.Tests.ps1
@@ -43,12 +43,12 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Get-ChildItem -Path $script:testRoot -Filter 'IMG_*.jpg' |
             Rename-File -NewName 'vacation_2024_{0:D4}.jpg' -Counter
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'vacation_2024_0001.jpg') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'vacation_2024_0002.jpg') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'vacation_2024_0005.jpg') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'vacation_2024_0001.jpg') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'vacation_2024_0002.jpg') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'vacation_2024_0005.jpg') | Should-Be $true
 
             # Verify old names are gone
-            Get-ChildItem -Path $script:testRoot -Filter 'IMG_*.jpg' | Should -HaveCount 0
+            Get-ChildItem -Path $script:testRoot -Filter 'IMG_*.jpg' | Should-BeCollection -Count 0
         }
     }
 
@@ -76,10 +76,10 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Rename-File -Normalize -RemoveShellMetaCharacters -ReplaceSpacesWith '_' -ToLower
 
             $files = Get-ChildItem -Path $script:testRoot | Sort-Object Name
-            $files.Name | Should -Contain 'budget-2024_final.xlsx'
-            $files.Name | Should -Contain 'meeting_notes_1.txt'
-            $files.Name | Should -Contain 'project__plan.docx'
-            $files.Name | Should -Contain 'resume.pdf'
+            $files.Name | Should-ContainCollection 'budget-2024_final.xlsx'
+            $files.Name | Should-ContainCollection 'meeting_notes_1.txt'
+            $files.Name | Should-ContainCollection 'project__plan.docx'
+            $files.Name | Should-ContainCollection 'resume.pdf'
         }
     }
 
@@ -105,9 +105,9 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Get-ChildItem -Path $script:testRoot |
             Rename-File -UrlDecode -RemoveShellMetaCharacters -ReplaceSpacesWith '_'
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'document_file.pdf') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'report+2024.xlsx') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_1.jpg') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'document_file.pdf') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'report+2024.xlsx') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_1.jpg') | Should-Be $true
         }
     }
 
@@ -139,9 +139,9 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Get-ChildItem -Path $script:testRoot -Filter '*.avi' |
             Rename-File -ReplaceSpacesWith '.' -ToLower
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'The Great Movie 2024.mkv') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'Another Movie Title.mp4') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'tv.show.s01e01.avi') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'The Great Movie 2024.mkv') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'Another Movie Title.mp4') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'tv.show.s01e01.avi') | Should-Be $true
         }
     }
 
@@ -167,9 +167,9 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Get-ChildItem -Path $script:testRoot -Filter '*.txt' |
             Rename-File -Expression { $_ -replace '(\d{4})(\d{2})(\d{2})_', '$1-$2-$3_' }
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-01_report.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-02_notes.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-03_data.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-01_report.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-02_notes.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-03_data.txt') | Should-Be $true
         }
     }
 
@@ -191,11 +191,11 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Get-ChildItem -Path $script:testRoot -Filter '*.dat' |
             Rename-File -NewExtension '.txt'
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'data1.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'data2.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'data3.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'data1.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'data2.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'data3.txt') | Should-Be $true
 
-            Get-ChildItem -Path $script:testRoot -Filter '*.dat' | Should -HaveCount 0
+            Get-ChildItem -Path $script:testRoot -Filter '*.dat' | Should-BeCollection -Count 0
         }
     }
 
@@ -227,9 +227,9 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
         It 'Should process files recursively in all subdirectories' {
             Rename-File -Path $script:testRoot -Recurse -ReplaceSpacesWith '_' -ToLower
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'SubDir1/test_file_1.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'SubDir2/test_file_2.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'SubDir1/test_file_1.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'SubDir2/test_file_2.txt') | Should-Be $true
         }
     }
 
@@ -256,11 +256,11 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Rename-File -ToCamelCase
 
             $files = Get-ChildItem -Path $script:testRoot -Filter '*.js' | Sort-Object Name
-            $files | Should -HaveCount 3
+            $files | Should-BeCollection -Count 3
             # Verify camelCase format: first letter lowercase, subsequent words capitalized
-            $files[0].Name | Should -Be 'anotherFunction.js'
-            $files[1].Name | Should -Be 'myFunction.js'
-            $files[2].Name | Should -Be 'thirdFunction.js'
+            $files[0].Name | Should-Be 'anotherFunction.js'
+            $files[1].Name | Should-Be 'myFunction.js'
+            $files[2].Name | Should-Be 'thirdFunction.js'
         }
 
         It 'Should convert all files to PascalCase convention' {
@@ -268,11 +268,11 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Rename-File -ToPascalCase
 
             $files = Get-ChildItem -Path $script:testRoot -Filter '*.js' | Sort-Object Name
-            $files | Should -HaveCount 3
+            $files | Should-BeCollection -Count 3
             # Verify PascalCase format: first letter of each word capitalized
-            $files[0].Name | Should -Be 'AnotherFunction.js'
-            $files[1].Name | Should -Be 'MyFunction.js'
-            $files[2].Name | Should -Be 'ThirdFunction.js'
+            $files[0].Name | Should-Be 'AnotherFunction.js'
+            $files[1].Name | Should-Be 'MyFunction.js'
+            $files[2].Name | Should-Be 'ThirdFunction.js'
         }
     }
 
@@ -299,9 +299,9 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Rename-File -Prepend '2024-01-15_' -Append '_archived' -Counter -CounterFormat 'D2'
 
             # Files are processed in alphabetical order: application, debug, error
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-15_application_archived01.log') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-15_debug_archived02.log') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-15_error_archived03.log') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-15_application_archived01.log') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-15_debug_archived02.log') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024-01-15_error_archived03.log') | Should-Be $true
         }
     }
 
@@ -333,7 +333,7 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             foreach ($file in $files)
             {
                 # Verify no problematic characters remain
-                $file.Name | Should -Not -Match '[<>:"/\\|?*#~]'
+                $file.Name | Should-NotMatchString '[<>:"/\\|?*#~]'
             }
         }
     }
@@ -358,14 +358,14 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Rename-File -ToUpper
 
             $files = Get-ChildItem -Path $script:testRoot -Filter '*.txt' | Sort-Object Name
-            $files | Should -HaveCount 5
+            $files | Should-BeCollection -Count 5
             # First three files should be uppercase (FILE1, FILE2, FILE3)
-            $files[0].Name | Should -Be 'FILE1.TXT'
-            $files[1].Name | Should -Be 'FILE2.TXT'
-            $files[2].Name | Should -Be 'FILE3.TXT'
+            $files[0].Name | Should-Be 'FILE1.TXT'
+            $files[1].Name | Should-Be 'FILE2.TXT'
+            $files[2].Name | Should-Be 'FILE3.TXT'
             # Last two files should remain lowercase
-            $files[3].Name | Should -Be 'file4.txt'
-            $files[4].Name | Should -Be 'file5.txt'
+            $files[3].Name | Should-Be 'file4.txt'
+            $files[4].Name | Should-Be 'file5.txt'
         }
 
         It 'Should work with PassThru for further processing' {
@@ -373,9 +373,9 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
             Rename-File -Prepend 'processed_' -PassThru |
             Select-Object -ExpandProperty Name
 
-            $result | Should -HaveCount 5
-            $result | Should -Contain 'processed_file1.txt'
-            $result | Should -Contain 'processed_file5.txt'
+            $result | Should-BeCollection -Count 5
+            $result | Should-ContainCollection 'processed_file1.txt'
+            $result | Should-ContainCollection 'processed_file5.txt'
         }
     }
 
@@ -408,9 +408,9 @@ Describe 'Rename-File Integration Tests' -Tag 'Integration', 'Utilities' {
                 '\d{4}-\d{2}-\d{2}' = 'DATE'
             }
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'rpt_DATE.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'dat_DATE.csv') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'log_DATE.log') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'rpt_DATE.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'dat_DATE.csv') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'log_DATE.log') | Should-Be $true
         }
     }
 }

--- a/Tests/Integration/Utilities/Replace-StringInFile.Tests.ps1
+++ b/Tests/Integration/Utilities/Replace-StringInFile.Tests.ps1
@@ -72,22 +72,22 @@ The UserService class provides user management functionality.
 
             # Verify results
             $content1 = Get-Content -Path $file1 -Raw
-            $content1 | Should -Match 'public class AccountService'
-            $content1 | Should -Match 'private readonly IUserRepository userRepository'  # Should not change
-            $content1 | Should -Match 'public AccountService\(IUserRepository userRepository\)'
+            $content1 | Should-MatchString 'public class AccountService'
+            $content1 | Should-MatchString 'private readonly IUserRepository userRepository'  # Should not change
+            $content1 | Should-MatchString 'public AccountService\(IUserRepository userRepository\)'
 
             $content2 = Get-Content -Path $file2 -Raw
-            $content2 | Should -Match '// ACCOUNT_SERVICE endpoint'  # Separator-aware matching replaces USER_SERVICE
-            $content2 | Should -Match 'private readonly AccountService accountService'
-            $content2 | Should -Match 'public UserController\(AccountService accountService\)'
+            $content2 | Should-MatchString '// ACCOUNT_SERVICE endpoint'  # Separator-aware matching replaces USER_SERVICE
+            $content2 | Should-MatchString 'private readonly AccountService accountService'
+            $content2 | Should-MatchString 'public UserController\(AccountService accountService\)'
 
             $content3 = Get-Content -Path $file3 -Raw
-            $content3 | Should -Match '# AccountService Documentation'
-            $content3 | Should -Match 'The AccountService class'
+            $content3 | Should-MatchString '# AccountService Documentation'
+            $content3 | Should-MatchString 'The AccountService class'
 
             # Verify all files were processed
-            $results.Count | Should -Be 3
-            ($results | Where-Object { $_.ReplacementsMade }).Count | Should -Be 3
+            $results.Count | Should-Be 3
+            ($results | Where-Object { $_.ReplacementsMade }).Count | Should-Be 3
         }
 
         It 'Should preserve camelCase and PascalCase in JavaScript code refactoring' {
@@ -104,11 +104,11 @@ function setUserName(newUserName) {
             $result = Replace-StringInFile -Path $jsFile -OldString 'username' -NewString 'accountid' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $jsFile -Raw
-            $content | Should -Match 'const accountId = getAccountId\(\);'
-            $content | Should -Match "const AccountId = 'John';"
-            $content | Should -Match 'function setAccountId\(newAccountId\)'
-            $content | Should -Match 'this\.accountId = newAccountId;'
-            $result.MatchCount | Should -Be 7  # userName, getUserName, UserName, setUserName, newUserName (x2), userName
+            $content | Should-MatchString 'const accountId = getAccountId\(\);'
+            $content | Should-MatchString "const AccountId = 'John';"
+            $content | Should-MatchString 'function setAccountId\(newAccountId\)'
+            $content | Should-MatchString 'this\.accountId = newAccountId;'
+            $result.MatchCount | Should-Be 7  # userName, getUserName, UserName, setUserName, newUserName (x2), userName
         }
 
         It 'Should update variable names in configuration files' {
@@ -124,11 +124,11 @@ database_user=admin
             $result = Replace-StringInFile -Path $configFile -OldString 'database' -NewString 'postgres' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $configFile -Raw
-            $content | Should -Match 'postgres_host=localhost'
-            $content | Should -Match 'POSTGRES_PORT=5432'
-            $content | Should -Match 'Postgres_Name=myapp'
-            $content | Should -Match 'postgres_user=admin'
-            $result.MatchCount | Should -Be 4
+            $content | Should-MatchString 'postgres_host=localhost'
+            $content | Should-MatchString 'POSTGRES_PORT=5432'
+            $content | Should-MatchString 'Postgres_Name=myapp'
+            $content | Should-MatchString 'postgres_user=admin'
+            $result.MatchCount | Should-Be 4
         }
 
         It 'Should handle multiple wildcard files with PreserveCase' {
@@ -145,11 +145,11 @@ database_user=admin
             $results = Replace-StringInFile -Path $pattern -OldString 'oldproduct' -NewString 'newproduct' -CaseInsensitive -PreserveCase
 
             # Verify each file
-            Get-Content -Path (Join-Path -Path $docsDir -ChildPath 'features.md') -Raw | Should -Be 'NewProduct features'
-            Get-Content -Path (Join-Path -Path $docsDir -ChildPath 'install.md') -Raw | Should -Be 'NEWPRODUCT installation'
-            Get-Content -Path (Join-Path -Path $docsDir -ChildPath 'config.md') -Raw | Should -Be 'newproduct configuration'
+            Get-Content -Path (Join-Path -Path $docsDir -ChildPath 'features.md') -Raw | Should-Be 'NewProduct features'
+            Get-Content -Path (Join-Path -Path $docsDir -ChildPath 'install.md') -Raw | Should-Be 'NEWPRODUCT installation'
+            Get-Content -Path (Join-Path -Path $docsDir -ChildPath 'config.md') -Raw | Should-Be 'newproduct configuration'
 
-            $results.Count | Should -Be 3
+            $results.Count | Should-Be 3
         }
 
         It 'Should preserve snake_case in Python code' {
@@ -165,11 +165,11 @@ def get_user_name():
             $result = Replace-StringInFile -Path $pyFile -OldString 'user_name' -NewString 'account_id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $pyFile -Raw
-            $content | Should -Match 'def get_account_id\(\):'
-            $content | Should -Match 'account_id = "admin"'
-            $content | Should -Match 'ACCOUNT_ID = "ADMIN"'
-            $content | Should -Match 'return account_id'
-            $result.MatchCount | Should -Be 4
+            $content | Should-MatchString 'def get_account_id\(\):'
+            $content | Should-MatchString 'account_id = "admin"'
+            $content | Should-MatchString 'ACCOUNT_ID = "ADMIN"'
+            $content | Should-MatchString 'return account_id'
+            $result.MatchCount | Should-Be 4
         }
 
         It 'Should preserve kebab-case in CSS' {
@@ -188,11 +188,11 @@ def get_user_name():
             $result = Replace-StringInFile -Path $cssFile -OldString 'primary-color' -NewString 'brand-color' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $cssFile -Raw
-            $content | Should -Match '--brand-color: #007bff;'
-            $content | Should -Match '--BRAND-COLOR: #0056b3;'
-            $content | Should -Match '\.brand-color \{'
-            $content | Should -Match 'var\(--brand-color\);'
-            $result.MatchCount | Should -Be 4
+            $content | Should-MatchString '--brand-color: #007bff;'
+            $content | Should-MatchString '--BRAND-COLOR: #0056b3;'
+            $content | Should-MatchString '\.brand-color \{'
+            $content | Should-MatchString 'var\(--brand-color\);'
+            $result.MatchCount | Should-Be 4
         }
 
         It 'Should preserve SCREAMING_SNAKE_CASE in environment files' {
@@ -207,11 +207,11 @@ DATABASE-URL=postgresql://localhost/db
             $result = Replace-StringInFile -Path $envFile -OldString 'database_url' -NewString 'db_connection' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $envFile -Raw
-            $content | Should -Match 'DB_CONNECTION=postgresql://localhost/db'
-            $content | Should -Match 'db_connection=postgresql://localhost/db'
-            $content | Should -Match 'DB-CONNECTION=postgresql://localhost/db'
+            $content | Should-MatchString 'DB_CONNECTION=postgresql://localhost/db'
+            $content | Should-MatchString 'db_connection=postgresql://localhost/db'
+            $content | Should-MatchString 'DB-CONNECTION=postgresql://localhost/db'
             # Note: Separator-aware matching now matches DATABASE-URL because separators are interchangeable
-            $result.MatchCount | Should -Be 3
+            $result.MatchCount | Should-Be 3
         }
     }
 
@@ -228,18 +228,18 @@ foobar everywhere
             # Make changes with backup
             $result = Replace-StringInFile -Path $testFile -OldString 'foobar' -NewString 'bazqux' -CaseInsensitive -PreserveCase -Backup
 
-            $result.BackupCreated | Should -Be $true
+            $result.BackupCreated | Should-Be $true
 
             # Verify changes were made
             $newContent = Get-Content -Path $testFile -Raw
-            $newContent | Should -Not -Be $originalContent
+            $newContent | Should-NotBe $originalContent
 
             # Rollback using backup
             Copy-Item -Path "$testFile.bak" -Destination $testFile -Force
 
             # Verify rollback
             $rolledBack = Get-Content -Path $testFile -Raw
-            $rolledBack | Should -Be $originalContent
+            $rolledBack | Should-Be $originalContent
         }
     }
 
@@ -251,7 +251,7 @@ foobar everywhere
             Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase -Encoding UTF8
 
             $content = Get-Content -Path $testFile -Encoding UTF8 -Raw
-            $content | Should -Be 'Goodbye café'
+            $content | Should-Be 'Goodbye café'
         }
 
         It 'Should work with ASCII encoding' {
@@ -261,7 +261,7 @@ foobar everywhere
             Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase -Encoding ASCII
 
             $content = Get-Content -Path $testFile -Encoding ASCII -Raw
-            $content | Should -Be 'GOODBYE world'
+            $content | Should-Be 'GOODBYE world'
         }
     }
 
@@ -284,13 +284,13 @@ foobar everywhere
             $result = Replace-StringInFile -Path $testFile -OldString 'foo' -NewString 'bar' -CaseInsensitive -PreserveCase
 
             # Verify
-            $result.MatchCount | Should -Be 1000
-            $result.ReplacementsMade | Should -Be $true
+            $result.MatchCount | Should-Be 1000
+            $result.ReplacementsMade | Should-Be $true
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Match 'bar is on line'
-            $content | Should -Match 'BAR is on line'
-            $content | Should -Match 'Bar is on line'
+            $content | Should-MatchString 'bar is on line'
+            $content | Should-MatchString 'BAR is on line'
+            $content | Should-MatchString 'Bar is on line'
         }
     }
 
@@ -338,13 +338,13 @@ foobar everywhere
             $content2 = Get-Content -Path $file2 -Raw
 
             # Standard should replace all with exact replacement text
-            $content1 | Should -Be 'goodbye goodbye goodbye'
+            $content1 | Should-Be 'goodbye goodbye goodbye'
 
             # PreserveCase should maintain original case patterns
-            $content2 | Should -Be 'GOODBYE goodbye Goodbye'
+            $content2 | Should-Be 'GOODBYE goodbye Goodbye'
 
             # Both should report same match count
-            $result1.MatchCount | Should -Be $result2.MatchCount
+            $result1.MatchCount | Should-Be $result2.MatchCount
         }
     }
 }

--- a/Tests/Integration/Utilities/Search-FileContent.Tests.ps1
+++ b/Tests/Integration/Utilities/Search-FileContent.Tests.ps1
@@ -110,40 +110,40 @@ Write-Host "Example usage"
 
         It 'Should search only top-level project files by default after recursion became opt-in' {
             $results = Search-FileContent -Pattern 'TODO:' -Path $script:projectDir -Simple
-            $results.Count | Should -Be 2
-            ($results.Path | Select-Object -Unique).Count | Should -Be 1
-            $results[0].Path | Should -Be (Join-Path -Path $script:projectDir -ChildPath 'README.md')
+            $results.Count | Should-Be 2
+            ($results.Path | Select-Object -Unique).Count | Should-Be 1
+            $results[0].Path | Should-Be (Join-Path -Path $script:projectDir -ChildPath 'README.md')
         }
 
         It 'Should find all TODO comments across project' {
             $results = Search-FileContent -Pattern 'TODO:' -Path $script:projectDir -Simple -Recurse
             # Should find TODOs in src files, test files, and README, but not in .git
-            $results.Count | Should -BeGreaterOrEqual 4
-            $results.Path | Should -Not -BeLike '*.git*'
+            $results.Count | Should-BeGreaterThanOrEqual 4
+            $results.Path | Should-NotBeLikeString '*.git*'
         }
 
         It 'Should find function declarations in PowerShell files' {
             $results = Search-FileContent -Pattern 'function\s+\w+-\w+' -Path $script:projectDir -Include '*.ps1' -Simple -Recurse
             # Should find Get-UserData and Set-UserData
-            $results.Count | Should -BeGreaterOrEqual 2
+            $results.Count | Should-BeGreaterThanOrEqual 2
         }
 
         It 'Should exclude test files when requested' {
             $results = Search-FileContent -Pattern 'TODO' -Path $script:projectDir -Exclude '*.Tests.ps1' -Simple -Recurse
-            $results.Path | Should -Not -BeLike '*Tests.ps1'
+            $results.Path | Should-NotBeLikeString '*Tests.ps1'
         }
 
         It 'Should search only PowerShell files' {
             $results = Search-FileContent -Pattern 'Write-' -Path $script:projectDir -Include '*.ps1' -Simple -Recurse
-            $results.Count | Should -BeGreaterOrEqual 2
-            $results.Path | ForEach-Object { $_ | Should -BeLike '*.ps1' }
+            $results.Count | Should-BeGreaterThanOrEqual 2
+            $results.Path | ForEach-Object { $_ | Should-BeLikeString '*.ps1' }
         }
 
         It 'Should find matches with context lines' {
             $results = Search-FileContent -Pattern 'function Get-UserData' -Path $script:projectDir -Simple -Before 0 -After 2 -Recurse
             $results | Should -Not -BeNullOrEmpty
             # Verify it's finding the function
-            $results[0].Line | Should -BeLike '*Get-UserData*'
+            $results[0].Line | Should-BeLikeString '*Get-UserData*'
         }
     }
 
@@ -176,28 +176,28 @@ camelCaseVariable = true
             $pattern = '\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'
             $results = Search-FileContent -Pattern $pattern -Path $script:codeDir -Simple
             # Should find 192.168.1.1 and 10.0.0.1, but not 256.1.1.1
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should find email addresses' {
             $pattern = '\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
             $results = Search-FileContent -Pattern $pattern -Path $script:codeDir -Simple
             # Should find test@example.com and user@domain.co.uk
-            $results.Count | Should -BeGreaterOrEqual 2
+            $results.Count | Should-BeGreaterThanOrEqual 2
         }
 
         It 'Should find PowerShell function declarations' {
             $pattern = 'function\s+[A-Z][a-z]+-[A-Z][a-z]+'
             $results = Search-FileContent -Pattern $pattern -Path $script:codeDir -Simple
             # Should find Test-Connection and Get-Item
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should find PowerShell variables' {
             $pattern = '\$[a-zA-Z_][a-zA-Z0-9_]*'
             $results = Search-FileContent -Pattern $pattern -Path $script:codeDir -Simple
             # Should find $variable and $another_var
-            $results.Count | Should -BeGreaterOrEqual 2
+            $results.Count | Should-BeGreaterThanOrEqual 2
         }
     }
 
@@ -223,14 +223,14 @@ camelCaseVariable = true
 
         It 'Should work with Get-ChildItem pipeline' {
             $results = Get-ChildItem $script:pipelineDir -Filter 'file*.txt' | Search-FileContent -Pattern 'MATCH' -Simple
-            $results.Count | Should -Be 5
+            $results.Count | Should-Be 5
         }
 
         It 'Should work with Where-Object in pipeline' {
             $results = Get-ChildItem $script:pipelineDir -File |
             Where-Object { $_.Name -like 'file*' } |
             Search-FileContent -Pattern 'MATCH' -Simple
-            $results.Count | Should -Be 5
+            $results.Count | Should-Be 5
         }
 
         It 'Should chain with other cmdlets' {
@@ -238,8 +238,8 @@ camelCaseVariable = true
             Search-FileContent -Pattern 'MATCH' -FilesOnly -Simple |
             ForEach-Object { Split-Path $_.Path -Leaf }
 
-            $fileNames.Count | Should -Be 5
-            $fileNames | Should -Contain 'file1.txt'
+            $fileNames.Count | Should-Be 5
+            $fileNames | Should-ContainCollection 'file1.txt'
         }
     }
 
@@ -271,16 +271,16 @@ Line 5 with another MATCH
             $stopwatch.Stop()
 
             # Should find 2 matches per file * 50 files = 100 matches
-            $results.Count | Should -Be 100
+            $results.Count | Should-Be 100
 
             # Should complete in reasonable time (less than 5 seconds for 50 files)
-            $stopwatch.Elapsed.TotalSeconds | Should -BeLessThan 5
+            $stopwatch.Elapsed.TotalSeconds | Should-BeLessThan 5
         }
 
         It 'Should count matches efficiently' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:perfDir -CountOnly -Simple
-            $results.Count | Should -Be 50
-            $results | ForEach-Object { $_.MatchCount | Should -Be 2 }
+            $results.Count | Should-Be 50
+            $results | ForEach-Object { $_.MatchCount | Should-Be 2 }
         }
     }
 
@@ -311,17 +311,17 @@ Line 5 with another MATCH
 
         It 'Should search across different file types' {
             $results = Search-FileContent -Pattern 'PATTERN' -Path $script:mixedDir -Simple
-            $results.Count | Should -Be 5
+            $results.Count | Should-Be 5
         }
 
         It 'Should filter by specific file types' {
             $results = Search-FileContent -Pattern 'PATTERN' -Path $script:mixedDir -Include '*.ps1', '*.md' -Simple
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should exclude specific file types' {
             $results = Search-FileContent -Pattern 'PATTERN' -Path $script:mixedDir -Exclude '*.log', '*.xml' -Simple
-            $results.Count | Should -Be 3
+            $results.Count | Should-Be 3
         }
     }
 
@@ -351,13 +351,13 @@ Line 5 with another MATCH
         It 'Should handle large files correctly' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:largeFileDir -Simple
             # Should find 10 matches (at lines 100, 200, 300, ..., 1000)
-            $results.Count | Should -Be 10
+            $results.Count | Should-Be 10
         }
 
         It 'Should provide correct line numbers in large files' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:largeFileDir -Simple
-            $results[0].LineNumber | Should -Be 100
-            $results[9].LineNumber | Should -Be 1000
+            $results[0].LineNumber | Should-Be 100
+            $results[9].LineNumber | Should-Be 1000
         }
     }
 
@@ -383,18 +383,18 @@ Line with backslash: \PATTERN\
 
         It 'Should find patterns with special characters around them' {
             $results = Search-FileContent -Pattern 'PATTERN' -Path $script:specialDir -Simple
-            $results.Count | Should -BeGreaterOrEqual 5
+            $results.Count | Should-BeGreaterThanOrEqual 5
         }
 
         It 'Should handle bracket patterns with literal matching' {
             $results = @(Search-FileContent -Pattern '[PATTERN]' -Path $script:specialDir -Simple -Literal)
-            $results.Count | Should -Be 1
-            $results[0].Line | Should -BeLike '*[PATTERN]*'
+            $results.Count | Should-Be 1
+            $results[0].Line | Should-BeLikeString '*[PATTERN]*'
         }
 
         It 'Should handle regex special characters properly' {
             $results = @(Search-FileContent -Pattern '\[PATTERN\]' -Path $script:specialDir -Simple)
-            $results.Count | Should -Be 1
+            $results.Count | Should-Be 1
         }
     }
 
@@ -423,13 +423,13 @@ Line with backslash: \PATTERN\
 
         It 'Should search deep nested directories with -Recurse' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:nestedDir -Simple -Recurse
-            $results.Count | Should -Be 5
+            $results.Count | Should-Be 5
         }
 
         It 'Should respect MaxDepth limitation' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:nestedDir -Simple -Recurse -MaxDepth 2
             # Should only find matches in level1 and level2
-            $results.Count | Should -BeLessOrEqual 2
+            $results.Count | Should-BeLessThanOrEqual 2
         }
 
     }
@@ -454,22 +454,22 @@ Fifth line with MATCH
 
         It 'Should provide detailed results in Simple mode' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:outputDir -Simple
-            $results.Count | Should -Be 3
-            $results[0].PSObject.Properties.Name | Should -Contain 'Path'
-            $results[0].PSObject.Properties.Name | Should -Contain 'LineNumber'
-            $results[0].PSObject.Properties.Name | Should -Contain 'Line'
-            $results[0].PSObject.Properties.Name | Should -Contain 'Match'
+            $results.Count | Should-Be 3
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'Path'
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'LineNumber'
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'Line'
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'Match'
         }
 
         It 'Should provide count in CountOnly mode' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:outputDir -CountOnly -Simple
-            $results.MatchCount | Should -Be 3
+            $results.MatchCount | Should-Be 3
         }
 
         It 'Should provide only paths in FilesOnly mode' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:outputDir -FilesOnly -Simple
-            $results.PSObject.Properties.Name | Should -Contain 'Path'
-            $results.PSObject.Properties.Name | Should -Not -Contain 'LineNumber'
+            $results.PSObject.Properties.Name | Should-ContainCollection 'Path'
+            $results.PSObject.Properties.Name | Should-NotContainCollection 'LineNumber'
         }
     }
 
@@ -567,13 +567,13 @@ api_key=development_key
             $uniqueVariations = $results.Variation | Select-Object -Unique
             # Should find apiKey (camelCase) and ApiKey (PascalCase) across files
             # Note: api_key, API_KEY, api-key won't match because of separators
-            $uniqueVariations.Count | Should -BeGreaterOrEqual 2
+            $uniqueVariations.Count | Should-BeGreaterThanOrEqual 2
         }
 
         It 'Should correctly count each variation across files' {
             $results = Search-FileContent -Pattern 'apikey' -Path $script:codebaseDir -CaseInsensitive -IncludeCaseVariations -Simple -Recurse
             $apiKeyResults = $results | Where-Object { $_.Variation -eq 'apiKey' }
-            $apiKeyResults.Count | Should -BeGreaterThan 0
+            $apiKeyResults.Count | Should-BeGreaterThan 0
         }
 
         It 'Should identify JavaScript camelCase usage' {
@@ -603,7 +603,7 @@ api_key=development_key
             {
                 $result.Files | Should -Not -BeNullOrEmpty
                 # Files should be an array (or single value if only one file)
-                @($result.Files).Count | Should -BeGreaterThan 0
+                @($result.Files).Count | Should-BeGreaterThan 0
             }
         }
 
@@ -615,7 +615,7 @@ api_key=development_key
             {
                 foreach ($file in $result.Files)
                 {
-                    $file | Should -Match '\.(js|ts)$'
+                    $file | Should-MatchString '\.(js|ts)$'
                 }
             }
         }
@@ -623,22 +623,22 @@ api_key=development_key
         It 'Should show most common variation first when sorted' {
             $results = Search-FileContent -Pattern 'apikey' -Path $script:codebaseDir -CaseInsensitive -IncludeCaseVariations -Simple -Recurse
             $sortedResults = $results | Sort-Object -Property Count -Descending
-            $sortedResults[0].Count | Should -BeGreaterOrEqual $sortedResults[-1].Count
+            $sortedResults[0].Count | Should-BeGreaterThanOrEqual $sortedResults[-1].Count
         }
 
         It 'Should handle multiple variations in same file' {
             $results = Search-FileContent -Pattern 'apikey' -Path (Join-Path -Path $script:codebaseDir -ChildPath 'src/config.js') -CaseInsensitive -IncludeCaseVariations -Simple
-            $results.Count | Should -BeGreaterThan 1
+            $results.Count | Should-BeGreaterThan 1
         }
 
         It 'Should provide accurate file occurrence counts' {
             $results = Search-FileContent -Pattern 'apikey' -Path $script:codebaseDir -CaseInsensitive -IncludeCaseVariations -Simple -Recurse
             foreach ($result in $results)
             {
-                $result.Count | Should -BeGreaterThan 0
-                $result.Files.Count | Should -BeGreaterThan 0
+                $result.Count | Should-BeGreaterThan 0
+                $result.Files.Count | Should-BeGreaterThan 0
                 # Total count should be >= number of files (could be multiple matches per file)
-                $result.Count | Should -BeGreaterOrEqual $result.Files.Count
+                $result.Count | Should-BeGreaterThanOrEqual $result.Files.Count
             }
         }
 
@@ -648,8 +648,8 @@ api_key=development_key
             # Should not include config.json or .env files
             foreach ($result in $results)
             {
-                $result.Files | Should -Not -Contain (Join-Path -Path $script:codebaseDir -ChildPath 'config.json')
-                $result.Files | Should -Not -Contain (Join-Path -Path $script:codebaseDir -ChildPath '.env')
+                $result.Files | Should-NotContainCollection (Join-Path -Path $script:codebaseDir -ChildPath 'config.json')
+                $result.Files | Should-NotContainCollection (Join-Path -Path $script:codebaseDir -ChildPath '.env')
             }
         }
     }

--- a/Tests/Integration/Utilities/Search-FileContent.Tests.ps1
+++ b/Tests/Integration/Utilities/Search-FileContent.Tests.ps1
@@ -119,7 +119,7 @@ Write-Host "Example usage"
             $results = Search-FileContent -Pattern 'TODO:' -Path $script:projectDir -Simple -Recurse
             # Should find TODOs in src files, test files, and README, but not in .git
             $results.Count | Should-BeGreaterThanOrEqual 4
-            $results.Path | Should-NotBeLikeString '*.git*'
+            $results.Path | ForEach-Object { $_ | Should-NotBeLikeString '*.git*' }
         }
 
         It 'Should find function declarations in PowerShell files' {
@@ -130,7 +130,7 @@ Write-Host "Example usage"
 
         It 'Should exclude test files when requested' {
             $results = Search-FileContent -Pattern 'TODO' -Path $script:projectDir -Exclude '*.Tests.ps1' -Simple -Recurse
-            $results.Path | Should-NotBeLikeString '*Tests.ps1'
+            $results.Path | ForEach-Object { $_ | Should-NotBeLikeString '*Tests.ps1' }
         }
 
         It 'Should search only PowerShell files' {

--- a/Tests/Integration/Utilities/Set-FileEncoding.Tests.ps1
+++ b/Tests/Integration/Utilities/Set-FileEncoding.Tests.ps1
@@ -31,14 +31,14 @@ Describe 'Set-FileEncoding Integration Tests' -Tag 'Integration' {
 
         $results = Set-FileEncoding -Path (Join-Path -Path $textDir -ChildPath '*.txt') -Encoding UTF16BE -PassThru
 
-        $results.Count | Should -Be 2
-        ($results | Where-Object { $_.Success }).Count | Should -Be 2
-        ($results | Where-Object { -not $_.Skipped }).Count | Should -Be 2
+        $results.Count | Should-Be 2
+        ($results | Where-Object { $_.Success }).Count | Should-Be 2
+        ($results | Where-Object { -not $_.Skipped }).Count | Should-Be 2
 
-        (Get-FileEncoding -FilePath $firstTextFile).CodePage | Should -Be 1201
-        (Get-FileEncoding -FilePath $secondTextFile).CodePage | Should -Be 1201
-        (Get-FileEncoding -FilePath $markdownFile).CodePage | Should -Be 65001
-        [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($binaryFile)) | Should -Be $binaryBefore
+        (Get-FileEncoding -FilePath $firstTextFile).CodePage | Should-Be 1201
+        (Get-FileEncoding -FilePath $secondTextFile).CodePage | Should-Be 1201
+        (Get-FileEncoding -FilePath $markdownFile).CodePage | Should-Be 65001
+        [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($binaryFile)) | Should-Be $binaryBefore
     }
 
     It 'Works in the pipeline and returns one summary object per processed file' {
@@ -53,11 +53,11 @@ Describe 'Set-FileEncoding Integration Tests' -Tag 'Integration' {
         $results = Get-ChildItem -Path $pipelineDir -Filter '*.ps1' |
         Set-FileEncoding -Encoding UTF8BOM -PassThru
 
-        $results.Count | Should -Be 2
-        ($results | Where-Object { $_.Success }).Count | Should -Be 2
-        ($results | Where-Object { $_.TargetEncoding -match 'UTF-8' }).Count | Should -Be 2
+        $results.Count | Should-Be 2
+        ($results | Where-Object { $_.Success }).Count | Should-Be 2
+        ($results | Where-Object { $_.TargetEncoding -match 'UTF-8' }).Count | Should-Be 2
 
-        (Get-FileEncoding -FilePath $firstScript).GetPreamble().Length | Should -Be 3
-        (Get-FileEncoding -FilePath $secondScript).GetPreamble().Length | Should -Be 3
+        (Get-FileEncoding -FilePath $firstScript).GetPreamble().Length | Should-Be 3
+        (Get-FileEncoding -FilePath $secondScript).GetPreamble().Length | Should-Be 3
     }
 }

--- a/Tests/Integration/Utilities/Sync-Directory.Tests.ps1
+++ b/Tests/Integration/Utilities/Sync-Directory.Tests.ps1
@@ -50,10 +50,10 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 $Result = Sync-Directory -Source $Source -Destination $Dest
 
                 # Verify
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'file1.txt') | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'file2.txt') | Should -BeTrue
-                Get-Content (Join-Path -Path $Dest -ChildPath 'file1.txt') | Should -Be 'File 1 content'
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'file1.txt') | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'file2.txt') | Should-BeTruthy
+                Get-Content (Join-Path -Path $Dest -ChildPath 'file1.txt') | Should-Be 'File 1 content'
             }
             finally
             {
@@ -81,10 +81,10 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 $Result = Sync-Directory -Source $Source -Destination $Dest
 
                 # Verify
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'root.txt') | Should -BeTrue
-                Test-Path (Join-Path -Path (Join-Path -Path $Dest -ChildPath 'subdir1') -ChildPath 'level1.txt') | Should -BeTrue
-                Test-Path (Join-Path -Path (Join-Path -Path (Join-Path -Path $Dest -ChildPath 'subdir1') -ChildPath 'subdir2') -ChildPath 'level2.txt') | Should -BeTrue
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'root.txt') | Should-BeTruthy
+                Test-Path (Join-Path -Path (Join-Path -Path $Dest -ChildPath 'subdir1') -ChildPath 'level1.txt') | Should-BeTruthy
+                Test-Path (Join-Path -Path (Join-Path -Path (Join-Path -Path $Dest -ChildPath 'subdir1') -ChildPath 'subdir2') -ChildPath 'level2.txt') | Should-BeTruthy
             }
             finally
             {
@@ -108,9 +108,9 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 $Result = Sync-Directory -Source $Source -Destination $Dest
 
                 # Verify - both tools should preserve empty directories
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'empty-subdir') | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'file.txt') | Should -BeTrue
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'empty-subdir') | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'file.txt') | Should-BeTruthy
             }
             finally
             {
@@ -132,7 +132,7 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 'Original content' | Out-File (Join-Path -Path $Source -ChildPath 'file1.txt')
 
                 $Result1 = Sync-Directory -Source $Source -Destination $Dest
-                $Result1.Success | Should -BeTrue
+                $Result1.Success | Should-BeTruthy
 
                 # Modify source and add new file
                 Start-Sleep -Seconds 1 # Ensure timestamp difference (rsync uses seconds)
@@ -142,11 +142,11 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
 
                 # Second sync
                 $Result2 = Sync-Directory -Source $Source -Destination $Dest
-                $Result2.Success | Should -BeTrue
+                $Result2.Success | Should-BeTruthy
 
                 # Verify both files exist with correct content
-                Get-Content (Join-Path -Path $Dest -ChildPath 'file1.txt') | Should -Be 'Modified content'
-                Get-Content (Join-Path -Path $Dest -ChildPath 'file2.txt') | Should -Be 'New file'
+                Get-Content (Join-Path -Path $Dest -ChildPath 'file1.txt') | Should-Be 'Modified content'
+                Get-Content (Join-Path -Path $Dest -ChildPath 'file2.txt') | Should-Be 'New file'
             }
             finally
             {
@@ -175,9 +175,9 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 $Result = Sync-Directory -Source $Source -Destination $Dest -Delete
 
                 # Verify
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'keep.txt') | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'delete.txt') | Should -BeFalse
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'keep.txt') | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'delete.txt') | Should-BeFalsy
             }
             finally
             {
@@ -203,9 +203,9 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 $Result = Sync-Directory -Source $Source -Destination $Dest
 
                 # Verify both files exist
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'source.txt') | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'extra.txt') | Should -BeTrue
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'source.txt') | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'extra.txt') | Should-BeTruthy
             }
             finally
             {
@@ -232,10 +232,10 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 $Result = Sync-Directory -Source $Source -Destination $Dest -ExcludeFiles '*.log', '*.tmp'
 
                 # Verify
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'include.txt') | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'exclude.log') | Should -BeFalse
-                Test-Path (Join-Path -Path $Dest -ChildPath 'temp.tmp') | Should -BeFalse
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'include.txt') | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'exclude.log') | Should-BeFalsy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'temp.tmp') | Should-BeFalsy
             }
             finally
             {
@@ -263,9 +263,9 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
                 $Result = Sync-Directory -Source $Source -Destination $Dest -ExcludeDirectories 'node_modules'
 
                 # Verify
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'include-dir') | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'node_modules') | Should -BeFalse
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'include-dir') | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'node_modules') | Should-BeFalsy
             }
             finally
             {
@@ -287,8 +287,8 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
 
                 $Result = Sync-Directory -Source $Source -Destination $Dest
 
-                $Result.Success | Should -BeTrue
-                Test-Path (Join-Path -Path $Dest -ChildPath 'file with spaces.txt') | Should -BeTrue
+                $Result.Success | Should-BeTruthy
+                Test-Path (Join-Path -Path $Dest -ChildPath 'file with spaces.txt') | Should-BeTruthy
             }
             finally
             {
@@ -314,8 +314,8 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
 
                 $Result = Sync-Directory -Source $Source -Destination $Dest
 
-                $Result.Success | Should -BeTrue
-                (Get-ChildItem -Path $Dest -File).Count | Should -Be 50
+                $Result.Success | Should-BeTruthy
+                (Get-ChildItem -Path $Dest -File).Count | Should-Be 50
             }
             finally
             {
@@ -331,7 +331,7 @@ Describe 'Sync-Directory Integration Tests' -Tag 'Integration' {
             $Dest = Join-Path -Path $script:TestRoot -ChildPath 'error-dest'
 
             { Sync-Directory -Source $NonExistent -Destination $Dest -ErrorAction Stop } |
-            Should -Throw '*does not exist*'
+            Should-Throw '*does not exist*'
         }
     }
 }

--- a/Tests/Unit/Developer/Get-DotNetVersion.Tests.ps1
+++ b/Tests/Unit/Developer/Get-DotNetVersion.Tests.ps1
@@ -15,15 +15,15 @@ Describe 'Get-DotNetVersion' {
             $result = Get-DotNetVersion
             $result | Should -Not -BeNullOrEmpty
             $result | ForEach-Object {
-                $_.PSObject.Properties.Name | Should -Contain 'ComputerName'
-                $_.PSObject.Properties.Name | Should -Contain 'RuntimeType'
-                $_.PSObject.Properties.Name | Should -Contain 'Version'
-                $_.PSObject.Properties.Name | Should -Contain 'Type'
+                $_.PSObject.Properties.Name | Should-ContainCollection 'ComputerName'
+                $_.PSObject.Properties.Name | Should-ContainCollection 'RuntimeType'
+                $_.PSObject.Properties.Name | Should-ContainCollection 'Version'
+                $_.PSObject.Properties.Name | Should-ContainCollection 'Type'
             }
         }
 
         It 'Rejects mutually exclusive -FrameworkOnly and -DotNetOnly' {
-            { Get-DotNetVersion -FrameworkOnly -DotNetOnly } | Should -Throw
+            { Get-DotNetVersion -FrameworkOnly -DotNetOnly } | Should-Throw
         }
 
     }
@@ -51,10 +51,10 @@ Describe 'Get-DotNetVersion' {
 
             $result = Get-DotNetVersion -ComputerName $script:RemoteTestComputerName -DotNetOnly -WarningAction SilentlyContinue
 
-            $result | Should -HaveCount 1
-            $result[0].RuntimeType | Should -Be '.NET'
-            $result[0].Version | Should -Be 'Error'
-            $result[0].Error | Should -Match 'session failure'
+            $result | Should-BeCollection -Count 1
+            $result[0].RuntimeType | Should-Be '.NET'
+            $result[0].Version | Should-Be 'Error'
+            $result[0].Error | Should-MatchString 'session failure'
         }
 
         It 'Returns only .NET Framework error rows with -FrameworkOnly' {
@@ -64,10 +64,10 @@ Describe 'Get-DotNetVersion' {
 
             $result = Get-DotNetVersion -ComputerName $script:RemoteTestComputerName -FrameworkOnly -WarningAction SilentlyContinue
 
-            $result | Should -HaveCount 1
-            $result[0].RuntimeType | Should -Be '.NET Framework'
-            $result[0].Version | Should -Be 'Error'
-            $result[0].Error | Should -Match 'session failure'
+            $result | Should-BeCollection -Count 1
+            $result[0].RuntimeType | Should-Be '.NET Framework'
+            $result[0].Version | Should-Be 'Error'
+            $result[0].Error | Should-MatchString 'session failure'
         }
     }
 
@@ -116,8 +116,8 @@ Describe 'Get-DotNetVersion' {
             $netRows = $result | Where-Object { $_.RuntimeType -eq '.NET' }
 
             $netRows | Should -Not -BeNullOrEmpty
-            @($netRows | Where-Object { $_.Version -eq '10.0.0-preview.7.25380.108' }).Count | Should -Be 1
-            @($netRows | Where-Object { $_.Version -eq '10.0.0' -and $_.IsLatest }).Count | Should -Be 1
+            @($netRows | Where-Object { $_.Version -eq '10.0.0-preview.7.25380.108' }).Count | Should-Be 1
+            @($netRows | Where-Object { $_.Version -eq '10.0.0' -and $_.IsLatest }).Count | Should-Be 1
         }
 
         It 'Includes SDK rows when -All is used without -IncludeSDKs' {
@@ -125,7 +125,7 @@ Describe 'Get-DotNetVersion' {
             $sdkRows = $result | Where-Object { $_.RuntimeType -eq '.NET SDK' -and $_.Type -eq 'SDK' }
 
             $sdkRows | Should -Not -BeNullOrEmpty
-            @($sdkRows | Where-Object { $_.Version -eq '10.0.100-preview.2.25164.34' }).Count | Should -Be 1
+            @($sdkRows | Where-Object { $_.Version -eq '10.0.100-preview.2.25164.34' }).Count | Should-Be 1
         }
     }
 
@@ -158,8 +158,8 @@ Describe 'Get-DotNetVersion' {
                 $netRow = $result | Where-Object { $_.RuntimeType -eq '.NET' } | Select-Object -First 1
 
                 $netRow | Should -Not -BeNullOrEmpty
-                $netRow.Version | Should -Be '8.0.14'
-                $netRow.Type | Should -Be 'Runtime'
+                $netRow.Version | Should-Be '8.0.14'
+                $netRow.Type | Should-Be 'Runtime'
             }
             finally
             {
@@ -223,8 +223,8 @@ Describe 'Get-DotNetVersion' {
                 $sdkRow = $result | Where-Object { $_.RuntimeType -eq '.NET SDK' } | Select-Object -First 1
 
                 $sdkRow | Should -Not -BeNullOrEmpty
-                $sdkRow.Version | Should -Be '10.0.200'
-                $sdkRow.Type | Should -Be 'SDK'
+                $sdkRow.Version | Should-Be '10.0.200'
+                $sdkRow.Type | Should-Be 'SDK'
             }
             finally
             {

--- a/Tests/Unit/Developer/GitHubPullRequests.Tests.ps1
+++ b/Tests/Unit/Developer/GitHubPullRequests.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'GitHub pull request function' {
                 if ($args[0] -eq 'api' -and $args[-1] -like '/search/issues*')
                 {
                     $query = Get-TestSearchQuery -Path $args[-1]
-                    $query | Should -Be 'is:pr state:open author:octocat'
+                    $query | Should-Be 'is:pr state:open author:octocat'
 
                     $global:LASTEXITCODE = 0
                     return Get-TestPullRequestSearchResponse -TotalCount 1 -Items @(
@@ -136,12 +136,12 @@ Describe 'GitHub pull request function' {
 
             $result = Get-GitHubPullRequest
 
-            $result.State | Should -Be 'Open'
-            $result.Author | Should -Be 'octocat'
-            $result.PullRequestCount | Should -Be 1
-            $result.PullRequests[0].Repository | Should -Be 'octo-org/service-api'
-            $result.PullRequests[0].Number | Should -Be 42
-            $result.PullRequests[0].IsMerged | Should -BeFalse
+            $result.State | Should-Be 'Open'
+            $result.Author | Should-Be 'octocat'
+            $result.PullRequestCount | Should-Be 1
+            $result.PullRequests[0].Repository | Should-Be 'octo-org/service-api'
+            $result.PullRequests[0].Number | Should-Be 42
+            $result.PullRequests[0].IsMerged | Should-BeFalsy
         }
 
         It 'searches merged pull requests for a specified author without resolving the current user' {
@@ -154,7 +154,7 @@ Describe 'GitHub pull request function' {
                 if ($args[0] -eq 'api' -and $args[-1] -like '/search/issues*')
                 {
                     $query = Get-TestSearchQuery -Path $args[-1]
-                    $query | Should -Be 'is:pr is:merged author:hubot'
+                    $query | Should-Be 'is:pr is:merged author:hubot'
 
                     $global:LASTEXITCODE = 0
                     return Get-TestPullRequestSearchResponse -TotalCount 1 -Items @(
@@ -167,9 +167,9 @@ Describe 'GitHub pull request function' {
 
             $result = Get-GitHubPullRequest -Author 'hubot' -State Merged
 
-            $result.Query | Should -Be 'is:pr is:merged author:hubot'
-            $result.PullRequests[0].IsMerged | Should -BeTrue
-            ([DateTime]$result.PullRequests[0].MergedAt).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') | Should -Be '2026-01-03T00:00:00Z'
+            $result.Query | Should-Be 'is:pr is:merged author:hubot'
+            $result.PullRequests[0].IsMerged | Should-BeTruthy
+            ([DateTime]$result.PullRequests[0].MergedAt).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') | Should-Be '2026-01-03T00:00:00Z'
         }
 
         It 'uses the closed unmerged search qualifiers for closed pull requests' {
@@ -177,7 +177,7 @@ Describe 'GitHub pull request function' {
                 if ($args[0] -eq 'api' -and $args[-1] -like '/search/issues*')
                 {
                     $query = Get-TestSearchQuery -Path $args[-1]
-                    $query | Should -Be 'is:pr state:closed -is:merged author:octocat'
+                    $query | Should-Be 'is:pr state:closed -is:merged author:octocat'
 
                     $global:LASTEXITCODE = 0
                     return Get-TestPullRequestSearchResponse -TotalCount 0 -Items @()
@@ -188,8 +188,8 @@ Describe 'GitHub pull request function' {
 
             $result = Get-GitHubPullRequest -Author 'octocat' -State Closed
 
-            $result.Query | Should -Be 'is:pr state:closed -is:merged author:octocat'
-            $result.PullRequestCount | Should -Be 0
+            $result.Query | Should-Be 'is:pr state:closed -is:merged author:octocat'
+            $result.PullRequestCount | Should-Be 0
         }
 
         It 'supports repository-scoped searches from all authors' {
@@ -202,7 +202,7 @@ Describe 'GitHub pull request function' {
                 if ($args[0] -eq 'api' -and $args[-1] -like '/search/issues*')
                 {
                     $query = Get-TestSearchQuery -Path $args[-1]
-                    $query | Should -Be 'is:pr state:open repo:octo-org/service-api'
+                    $query | Should-Be 'is:pr state:open repo:octo-org/service-api'
 
                     $global:LASTEXITCODE = 0
                     return Get-TestPullRequestSearchResponse -TotalCount 1 -Items @(
@@ -216,9 +216,9 @@ Describe 'GitHub pull request function' {
             $result = Get-GitHubPullRequest -Repository 'octo-org/service-api' -AllAuthors
 
             $result.Author | Should -BeNullOrEmpty
-            $result.AllAuthors | Should -BeTrue
-            $result.Repository | Should -Be 'octo-org/service-api'
-            $result.PullRequests[0].Author | Should -Be 'monalisa'
+            $result.AllAuthors | Should-BeTruthy
+            $result.Repository | Should-Be 'octo-org/service-api'
+            $result.PullRequests[0].Author | Should-Be 'monalisa'
         }
 
         It 'retrieves all available search pages with the REST fallback' {
@@ -228,7 +228,7 @@ Describe 'GitHub pull request function' {
                 if ($Method -eq 'GET' -and $Uri -like 'https://api.github.com/search/issues*page=1')
                 {
                     $query = Get-TestSearchQuery -Path $Uri
-                    $query | Should -Be 'is:pr state:open author:octocat org:octo-org'
+                    $query | Should-Be 'is:pr state:open author:octocat org:octo-org'
 
                     return [PSCustomObject]@{
                         total_count = 101
@@ -255,22 +255,22 @@ Describe 'GitHub pull request function' {
 
             $result = Get-GitHubPullRequest -Author 'octocat' -Organization 'octo-org' -Token $script:TokenValue
 
-            $result.Transport | Should -Be 'RestApi'
-            $result.PullRequestCount | Should -Be 101
-            $result.TotalCount | Should -Be 101
-            $result.SearchResultLimitReached | Should -BeFalse
+            $result.Transport | Should-Be 'RestApi'
+            $result.PullRequestCount | Should-Be 101
+            $result.TotalCount | Should-Be 101
+            $result.SearchResultLimitReached | Should-BeFalsy
         }
 
         It 'requires a scope filter when searching all authors' {
             {
                 Get-GitHubPullRequest -AllAuthors
-            } | Should -Throw '*Use -AllAuthors only with -Owner, -Organization, or -Repository*'
+            } | Should-Throw '*Use -AllAuthors only with -Owner, -Organization, or -Repository*'
         }
 
         It 'rejects owner and organization filters together' {
             {
                 Get-GitHubPullRequest -Owner 'octocat' -Organization 'octo-org'
-            } | Should -Throw '*Use only one of -Owner or -Organization*'
+            } | Should-Throw '*Use only one of -Owner or -Organization*'
         }
 
         It 'rejects whitespace-only search filter values' -ForEach @(
@@ -282,13 +282,13 @@ Describe 'GitHub pull request function' {
         ) {
             {
                 Get-GitHubPullRequest @Parameters
-            } | Should -Throw $Error
+            } | Should-Throw $Error
         }
 
         It 'rejects a repository host that conflicts with an explicitly supplied GitHub host' {
             {
                 Get-GitHubPullRequest -Repository 'github.example.com/octo-org/service-api' -GitHubHost 'github.invalid' -AllAuthors
-            } | Should -Throw "*Repository 'github.example.com/octo-org/service-api' resolves to host 'github.example.com', which does not match -GitHubHost 'github.invalid'.*"
+            } | Should-Throw "*Repository 'github.example.com/octo-org/service-api' resolves to host 'github.example.com', which does not match -GitHubHost 'github.invalid'.*"
         }
     }
 }

--- a/Tests/Unit/Developer/GitHubRepositoryTopics.Tests.ps1
+++ b/Tests/Unit/Developer/GitHubRepositoryTopics.Tests.ps1
@@ -63,11 +63,11 @@ Describe 'GitHub repository topic functions' {
 
             $result = Get-GitHubRepositoryTopic -Repository 'octo-org/service-api'
 
-            $result.Repository | Should -Be 'octo-org/service-api'
-            $result.Topics | Should -Be @('powershell', 'automation')
-            $result.AllTopics | Should -Be @('powershell', 'automation')
+            $result.Repository | Should-Be 'octo-org/service-api'
+            $result.Topics | Should-BeCollection @('powershell', 'automation')
+            $result.AllTopics | Should-BeCollection @('powershell', 'automation')
             $result.MissingTopics | Should -BeNullOrEmpty
-            $result.TopicCount | Should -Be 2
+            $result.TopicCount | Should-Be 2
         }
 
         It 'filters requested topics and reports missing topic names' {
@@ -83,10 +83,10 @@ Describe 'GitHub repository topic functions' {
 
             $result = Get-GitHubRepositoryTopic -Name @(' PowerShell ', 'Missing', 'powershell') -Repository 'octo-org/service-api'
 
-            $result.RequestedTopics | Should -Be @('powershell', 'missing')
-            $result.Topics | Should -Be @('powershell')
-            $result.MissingTopics | Should -Be @('missing')
-            $result.TotalTopicCount | Should -Be 2
+            $result.RequestedTopics | Should-BeCollection @('powershell', 'missing')
+            $result.Topics | Should-BeCollection @('powershell')
+            $result.MissingTopics | Should-BeCollection @('missing')
+            $result.TotalTopicCount | Should-Be 2
         }
     }
 
@@ -104,10 +104,10 @@ Describe 'GitHub repository topic functions' {
 
             $result = Set-GitHubRepositoryTopic -Name @('Automation', ' powershell ') -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Unchanged'
-            $result.Changed | Should -BeFalse
-            $result.Topics | Should -Be @('powershell', 'automation')
-            Should -Invoke -CommandName gh -ParameterFilter {
+            $result.Status | Should-Be 'Unchanged'
+            $result.Changed | Should-BeFalsy
+            $result.Topics | Should-BeCollection @('powershell', 'automation')
+            Should-Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains 'PUT'
             } -Times 0 -Exactly
         }
@@ -139,11 +139,11 @@ Describe 'GitHub repository topic functions' {
 
             $result = Set-GitHubRepositoryTopic -Name @(' PowerShell ', 'DevOps', 'devops ') -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Updated'
-            $result.AddedTopics | Should -Be @('devops')
-            $result.Topics | Should -Be @('powershell', 'automation', 'devops')
-            $script:TempRequestBodies.Count | Should -Be 1
-            $script:TempRequestBodies[0] | Should -Match '"names":\["powershell","automation","devops"\]'
+            $result.Status | Should-Be 'Updated'
+            $result.AddedTopics | Should-BeCollection @('devops')
+            $result.Topics | Should-BeCollection @('powershell', 'automation', 'devops')
+            $script:TempRequestBodies.Count | Should-Be 1
+            $script:TempRequestBodies[0] | Should-MatchString '"names":\["powershell","automation","devops"\]'
         }
 
         It 'falls back to the REST API when gh is not installed' {
@@ -159,7 +159,7 @@ Describe 'GitHub repository topic functions' {
 
                 if ($Method -eq 'PUT' -and $Uri -eq 'https://api.github.com/repos/octo-org/service-api/topics')
                 {
-                    $Body | Should -Match '"names":\["powershell","automation"\]'
+                    $Body | Should-MatchString '"names":\["powershell","automation"\]'
 
                     return [PSCustomObject]@{
                         names = @('powershell', 'automation')
@@ -176,9 +176,9 @@ Describe 'GitHub repository topic functions' {
             }
             $result = Set-GitHubRepositoryTopic @setGitHubRepositoryTopicParams
 
-            $result.Status | Should -Be 'Updated'
-            $result.Transport | Should -Be 'RestApi'
-            $result.Topics | Should -Be @('powershell', 'automation')
+            $result.Status | Should-Be 'Updated'
+            $result.Transport | Should-Be 'RestApi'
+            $result.Topics | Should-BeCollection @('powershell', 'automation')
         }
     }
 
@@ -196,10 +196,10 @@ Describe 'GitHub repository topic functions' {
 
             $result = Remove-GitHubRepositoryTopic -Name @('missing', ' Missing ') -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'AlreadyAbsent'
-            $result.Changed | Should -BeFalse
-            $result.Topics | Should -Be @('powershell', 'automation')
-            Should -Invoke -CommandName gh -ParameterFilter {
+            $result.Status | Should-Be 'AlreadyAbsent'
+            $result.Changed | Should-BeFalsy
+            $result.Topics | Should-BeCollection @('powershell', 'automation')
+            Should-Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains 'PUT'
             } -Times 0 -Exactly
         }
@@ -231,11 +231,11 @@ Describe 'GitHub repository topic functions' {
 
             $result = Remove-GitHubRepositoryTopic -Name @('Automation', 'missing') -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Removed'
-            $result.RemovedTopics | Should -Be @('automation')
-            $result.Topics | Should -Be @('powershell', 'devops')
-            $script:TempRequestBodies.Count | Should -Be 1
-            $script:TempRequestBodies[0] | Should -Match '"names":\["powershell","devops"\]'
+            $result.Status | Should-Be 'Removed'
+            $result.RemovedTopics | Should-BeCollection @('automation')
+            $result.Topics | Should-BeCollection @('powershell', 'devops')
+            $script:TempRequestBodies.Count | Should-Be 1
+            $script:TempRequestBodies[0] | Should-MatchString '"names":\["powershell","devops"\]'
         }
     }
 }

--- a/Tests/Unit/Developer/GitHubSecrets.Tests.ps1
+++ b/Tests/Unit/Developer/GitHubSecrets.Tests.ps1
@@ -116,9 +116,9 @@ Describe 'GitHub secret functions' {
 
             $result = Set-GitHubSecret -Name 'DEVCONTAINER_PAT' -Value $script:SecretValue -Scope User
 
-            $result.Status | Should -Be 'Created'
-            $script:CapturedSecretSetArguments | Should -Contain '--user'
-            $script:CapturedSecretSetArguments | Should -Not -Contain '--app'
+            $result.Status | Should-Be 'Created'
+            $script:CapturedSecretSetArguments | Should-ContainCollection '--user'
+            $script:CapturedSecretSetArguments | Should-NotContainCollection '--app'
         }
 
         It 'normalizes and de-duplicates selected repositories for -Scope User' {
@@ -161,9 +161,9 @@ Describe 'GitHub secret functions' {
 
             $reposIndex = [Array]::IndexOf($script:CapturedSecretSetArguments, '--repos')
 
-            $result.Status | Should -Be 'Created'
-            $reposIndex | Should -BeGreaterThan -1
-            $script:CapturedSecretSetArguments[$reposIndex + 1] | Should -Be 'octo-org/service-api'
+            $result.Status | Should-Be 'Created'
+            $reposIndex | Should-BeGreaterThan -1
+            $script:CapturedSecretSetArguments[$reposIndex + 1] | Should-Be 'octo-org/service-api'
         }
 
         It 'rejects -SelectedRepository combined with non-selected -Visibility for organization scope' -ForEach @(
@@ -181,7 +181,7 @@ Describe 'GitHub secret functions' {
 
             {
                 Set-GitHubSecret @setGitHubSecretParams
-            } | Should -Throw "*'-Visibility selected'*"
+            } | Should-Throw "*'-Visibility selected'*"
         }
 
         It 'rejects whitespace-only entries in -SelectedRepository for organization scope' {
@@ -195,7 +195,7 @@ Describe 'GitHub secret functions' {
 
             {
                 Set-GitHubSecret @setGitHubSecretParams
-            } | Should -Throw '*empty or whitespace*'
+            } | Should-Throw '*empty or whitespace*'
         }
 
         It 'rejects bare selected repository names for -Scope User' {
@@ -208,7 +208,7 @@ Describe 'GitHub secret functions' {
 
             {
                 Set-GitHubSecret @setGitHubSecretParams
-            } | Should -Throw '*must use OWNER/REPO format*'
+            } | Should-Throw '*must use OWNER/REPO format*'
         }
 
         It 'supports environment scope through -Scope Environment' {
@@ -232,9 +232,9 @@ Describe 'GitHub secret functions' {
             }
             $result = Set-GitHubSecret @setGitHubSecretParams
 
-            $result.Status | Should -Be 'WhatIf'
-            $result.Scope | Should -Be 'Environment'
-            $result.Target | Should -Be "environment 'Production' in octo-org/service-api"
+            $result.Status | Should-Be 'WhatIf'
+            $result.Scope | Should-Be 'Environment'
+            $result.Target | Should-Be "environment 'Production' in octo-org/service-api"
         }
 
         It 'supports organization scope through -Scope Organization' {
@@ -257,9 +257,9 @@ Describe 'GitHub secret functions' {
             }
             $result = Set-GitHubSecret @setGitHubSecretParams
 
-            $result.Status | Should -Be 'WhatIf'
-            $result.Scope | Should -Be 'Organization'
-            $result.Target | Should -Be 'organization octo-org'
+            $result.Status | Should-Be 'WhatIf'
+            $result.Scope | Should-Be 'Organization'
+            $result.Target | Should-Be 'organization octo-org'
         }
 
         It 'rejects non-codespaces applications for -Scope User' {
@@ -272,7 +272,7 @@ Describe 'GitHub secret functions' {
 
             {
                 Set-GitHubSecret @setGitHubSecretParams
-            } | Should -Throw '*User secrets support only the codespaces application*'
+            } | Should-Throw '*User secrets support only the codespaces application*'
         }
 
         It 'rejects invalid secret names before making GitHub calls' -ForEach @(
@@ -282,11 +282,11 @@ Describe 'GitHub secret functions' {
         ) {
             {
                 Set-GitHubSecret -Name $Name -Value $script:SecretValue -Scope Repository -Repository 'octo-org/service-api'
-            } | Should -Throw $Error
+            } | Should-Throw $Error
 
             {
                 Remove-GitHubSecret -Name $Name -Scope Repository -Repository 'octo-org/service-api'
-            } | Should -Throw $Error
+            } | Should-Throw $Error
         }
 
         It 'rejects environment names longer than 255 characters' {
@@ -307,11 +307,11 @@ Describe 'GitHub secret functions' {
 
             {
                 Set-GitHubSecret @setGitHubSecretParams
-            } | Should -Throw '*may not exceed 255 characters*'
+            } | Should-Throw '*may not exceed 255 characters*'
 
             {
                 Remove-GitHubSecret @removeGitHubSecretParams
-            } | Should -Throw '*may not exceed 255 characters*'
+            } | Should-Throw '*may not exceed 255 characters*'
         }
 
         It 'accepts environment names that contain slashes' {
@@ -335,7 +335,7 @@ Describe 'GitHub secret functions' {
             }
             $result = Set-GitHubSecret @setGitHubSecretParams
 
-            $result.Status | Should -Be 'WhatIf'
+            $result.Status | Should-Be 'WhatIf'
         }
 
         It 'rejects secret values larger than 48 KB before making GitHub calls' {
@@ -347,9 +347,9 @@ Describe 'GitHub secret functions' {
 
             {
                 Set-GitHubSecret -Name 'OVERSIZED_SECRET' -Value $tooLargeValue -Scope Repository -Repository 'octo-org/service-api'
-            } | Should -Throw '*48 KB*'
+            } | Should-Throw '*48 KB*'
 
-            Should -Invoke -CommandName gh -Times 0 -Exactly
+            Should-Invoke -CommandName gh -Times 0 -Exactly
         }
 
         It 'skips existing secrets without -Force' {
@@ -365,9 +365,9 @@ Describe 'GitHub secret functions' {
 
             $result = Set-GitHubSecret -Name 'EXISTING_SECRET' -Value $script:SecretValue -Scope Repository -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Skipped'
-            $result.Changed | Should -BeFalse
-            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0 -Exactly
+            $result.Status | Should-Be 'Skipped'
+            $result.Changed | Should-BeFalsy
+            Should-Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0 -Exactly
         }
 
         It 'updates existing secrets when -Force is used' {
@@ -403,10 +403,10 @@ Describe 'GitHub secret functions' {
 
             $result = Set-GitHubSecret -Name 'EXISTING_SECRET' -Value $script:SecretValue -Scope Repository -Repository 'octo-org/service-api' -Force
 
-            $result.Status | Should -Be 'Updated'
-            $result.Changed | Should -BeTrue
-            $script:CapturedSecretSetArguments | Should -Not -Contain '--body'
-            $script:CapturedSecretStandardInput | Should -Be 'SuperSecretValue123!'
+            $result.Status | Should-Be 'Updated'
+            $result.Changed | Should-BeTruthy
+            $script:CapturedSecretSetArguments | Should-NotContainCollection '--body'
+            $script:CapturedSecretStandardInput | Should-Be 'SuperSecretValue123!'
         }
 
         It 'supports WhatIf without calling gh secret set' {
@@ -422,8 +422,8 @@ Describe 'GitHub secret functions' {
 
             $result = Set-GitHubSecret -Name 'NEW_SECRET' -Value $script:SecretValue -Scope Repository -Repository 'octo-org/service-api' -WhatIf
 
-            $result.Status | Should -Be 'WhatIf'
-            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0 -Exactly
+            $result.Status | Should-Be 'WhatIf'
+            Should-Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'set' } -Times 0 -Exactly
         }
 
         It 'throws a clear error when gh is not installed' {
@@ -431,7 +431,7 @@ Describe 'GitHub secret functions' {
 
             {
                 Set-GitHubSecret -Name 'REST_SECRET' -Value $script:SecretValue -Scope Repository -Repository 'octo-org/service-api' -Token $script:TokenValue
-            } | Should -Throw '*GitHub CLI*'
+            } | Should-Throw '*GitHub CLI*'
         }
 
         It 'redacts the secret value and token from thrown errors' {
@@ -471,9 +471,9 @@ Describe 'GitHub secret functions' {
             }
             catch
             {
-                $_.Exception.Message | Should -Not -Match 'SuperSecretValue123!'
-                $_.Exception.Message | Should -Not -Match 'ghp_Abc123Sensitive'
-                $_.Exception.Message | Should -Match '\[REDACTED\]'
+                $_.Exception.Message | Should-NotMatchString 'SuperSecretValue123!'
+                $_.Exception.Message | Should-NotMatchString 'ghp_Abc123Sensitive'
+                $_.Exception.Message | Should-MatchString '\[REDACTED\]'
             }
         }
     }
@@ -537,7 +537,7 @@ Describe 'GitHub secret functions' {
             }
             $result = & $helpers.InvokeGitHubRequest @invokeGitHubRequestParams
 
-            $result.name | Should -Be 'REGION'
+            $result.name | Should-Be 'REGION'
         }
 
         It 'preserves actionable no-token-available message in error output' {
@@ -555,8 +555,8 @@ Describe 'GitHub secret functions' {
             }
             $message = & $helpers.GetFriendlyErrorMessage @getFriendlyErrorMessageParams
 
-            $message | Should -Match 'GH_TOKEN'
-            $message | Should -Not -Match 'authentication failed'
+            $message | Should-MatchString 'GH_TOKEN'
+            $message | Should-NotMatchString 'authentication failed'
         }
 
         It 'uses the resolved git executable path when discovering the current repository' {
@@ -582,7 +582,7 @@ Describe 'GitHub secret functions' {
 
             $result = & $helpers.ResolveCurrentRepository
 
-            $result.NameWithOwner | Should -Be 'octo-org/service-api'
+            $result.NameWithOwner | Should-Be 'octo-org/service-api'
         }
 
         It 'returns null status code from exceptions that have no Response property' {
@@ -600,7 +600,7 @@ Describe 'GitHub secret functions' {
             $bareException = [System.InvalidOperationException]::new('plain message')
             $message = & $helpers.GetExceptionMessage $bareException
 
-            $message | Should -Be 'plain message'
+            $message | Should-Be 'plain message'
         }
 
         It 'quotes native process arguments that contain spaces' {
@@ -608,7 +608,7 @@ Describe 'GitHub secret functions' {
 
             $quoted = & $helpers.QuoteNativeProcessArgument -Argument 'Production Blue'
 
-            $quoted | Should -Be '"Production Blue"'
+            $quoted | Should-Be '"Production Blue"'
         }
 
         It 'uses GH_ENTERPRISE_TOKEN for gh requests to enterprise hosts' {
@@ -663,7 +663,7 @@ Describe 'GitHub secret functions' {
             }
 
             $script:ObservedGhToken | Should -BeNullOrEmpty
-            $script:ObservedEnterpriseToken | Should -Be 'enterprise-token'
+            $script:ObservedEnterpriseToken | Should-Be 'enterprise-token'
         }
     }
 
@@ -681,9 +681,9 @@ Describe 'GitHub secret functions' {
 
             $result = Remove-GitHubSecret -Name 'MISSING_SECRET' -Scope Repository -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'AlreadyAbsent'
-            $result.Changed | Should -BeFalse
-            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0 -Exactly
+            $result.Status | Should-Be 'AlreadyAbsent'
+            $result.Changed | Should-BeFalsy
+            Should-Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0 -Exactly
         }
 
         It 'disables gh interactive prompts during deletion' {
@@ -709,8 +709,8 @@ Describe 'GitHub secret functions' {
 
             $result = Remove-GitHubSecret -Name 'TO_DELETE' -Scope Repository -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Removed'
-            $script:ObservedPromptDisabled | Should -Be '1'
+            $result.Status | Should-Be 'Removed'
+            $script:ObservedPromptDisabled | Should-Be '1'
         }
 
         It 'supports WhatIf without deleting the secret' {
@@ -726,8 +726,8 @@ Describe 'GitHub secret functions' {
 
             $result = Remove-GitHubSecret -Name 'TO_DELETE' -Scope Repository -Repository 'octo-org/service-api' -WhatIf
 
-            $result.Status | Should -Be 'WhatIf'
-            Should -Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0 -Exactly
+            $result.Status | Should-Be 'WhatIf'
+            Should-Invoke -CommandName gh -ParameterFilter { $args[0] -eq 'secret' -and $args[1] -eq 'delete' } -Times 0 -Exactly
         }
 
         It 'supports user scope deletion through -Scope User' {
@@ -752,9 +752,9 @@ Describe 'GitHub secret functions' {
 
             $result = Remove-GitHubSecret -Name 'DEVCONTAINER_PAT' -Scope User
 
-            $result.Status | Should -Be 'Removed'
-            $script:CapturedDeleteArguments | Should -Contain '--user'
-            $script:CapturedDeleteArguments | Should -Not -Contain '--app'
+            $result.Status | Should-Be 'Removed'
+            $script:CapturedDeleteArguments | Should-ContainCollection '--user'
+            $script:CapturedDeleteArguments | Should-NotContainCollection '--app'
         }
 
         It 'supports organization scope during removal through -Scope Organization' {
@@ -770,9 +770,9 @@ Describe 'GitHub secret functions' {
 
             $result = Remove-GitHubSecret -Name 'ORG_SECRET' -Scope Organization -Organization 'octo-org'
 
-            $result.Status | Should -Be 'AlreadyAbsent'
-            $result.Scope | Should -Be 'Organization'
-            $result.Target | Should -Be 'organization octo-org'
+            $result.Status | Should-Be 'AlreadyAbsent'
+            $result.Scope | Should-Be 'Organization'
+            $result.Target | Should-Be 'organization octo-org'
         }
     }
 }

--- a/Tests/Unit/Developer/GitHubVariables.Tests.ps1
+++ b/Tests/Unit/Developer/GitHubVariables.Tests.ps1
@@ -67,15 +67,15 @@ Describe 'GitHub variable functions' {
         ) {
             {
                 Set-GitHubVariable -Name $Name -Value 'enabled' -Scope Repository -Repository 'octo-org/service-api'
-            } | Should -Throw $Error
+            } | Should-Throw $Error
 
             {
                 Get-GitHubVariable -Name $Name -Scope Repository -Repository 'octo-org/service-api'
-            } | Should -Throw $Error
+            } | Should-Throw $Error
 
             {
                 Remove-GitHubVariable -Name $Name -Scope Repository -Repository 'octo-org/service-api'
-            } | Should -Throw $Error
+            } | Should-Throw $Error
         }
 
         It 'rejects environment names longer than 255 characters' {
@@ -102,15 +102,15 @@ Describe 'GitHub variable functions' {
 
             {
                 Set-GitHubVariable @setGitHubVariableParams
-            } | Should -Throw '*may not exceed 255 characters*'
+            } | Should-Throw '*may not exceed 255 characters*'
 
             {
                 Get-GitHubVariable @getGitHubVariableParams
-            } | Should -Throw '*may not exceed 255 characters*'
+            } | Should-Throw '*may not exceed 255 characters*'
 
             {
                 Remove-GitHubVariable @removeGitHubVariableParams
-            } | Should -Throw '*may not exceed 255 characters*'
+            } | Should-Throw '*may not exceed 255 characters*'
         }
 
         It 'accepts environment names that contain slashes' {
@@ -132,8 +132,8 @@ Describe 'GitHub variable functions' {
             }
             $result = Get-GitHubVariable @getGitHubVariableParams
 
-            $result.Name | Should -Be 'DEPLOY_RING'
-            $result.Target | Should -Be "environment 'Production/Blue' in octo-org/service-api"
+            $result.Name | Should-Be 'DEPLOY_RING'
+            $result.Target | Should-Be "environment 'Production/Blue' in octo-org/service-api"
         }
 
         It 'returns Unchanged when the existing value already matches' {
@@ -149,9 +149,9 @@ Describe 'GitHub variable functions' {
 
             $result = Set-GitHubVariable -Name 'DOTNET_VERSION' -Value '8.0.x' -Scope Repository -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Unchanged'
-            $result.Changed | Should -BeFalse
-            Should -Invoke -CommandName gh -ParameterFilter {
+            $result.Status | Should-Be 'Unchanged'
+            $result.Changed | Should-BeFalsy
+            Should-Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and $args -contains 'PATCH'
             } -Times 0 -Exactly
         }
@@ -169,8 +169,8 @@ Describe 'GitHub variable functions' {
 
             $result = Set-GitHubVariable -Name 'DOTNET_VERSION' -Value '8.0.x' -Scope Repository -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Skipped'
-            Should -Invoke -CommandName gh -ParameterFilter {
+            $result.Status | Should-Be 'Skipped'
+            Should-Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and ($args -contains 'PATCH' -or $args -contains 'POST')
             } -Times 0 -Exactly
         }
@@ -202,9 +202,9 @@ Describe 'GitHub variable functions' {
 
             $result = Set-GitHubVariable -Name 'DOTNET_VERSION' -Value '8.0.x' -Scope Repository -Repository 'octo-org/service-api' -Force
 
-            $result.Status | Should -Be 'Updated'
-            $script:TempRequestBodies.Count | Should -Be 1
-            $script:TempRequestBodies[0] | Should -Match '"value":"8.0.x"'
+            $result.Status | Should-Be 'Updated'
+            $script:TempRequestBodies.Count | Should-Be 1
+            $script:TempRequestBodies[0] | Should-MatchString '"value":"8.0.x"'
         }
 
         It 'falls back to the REST API when gh is not installed' {
@@ -232,8 +232,8 @@ Describe 'GitHub variable functions' {
 
                 if ($Method -eq 'POST' -and $Uri -eq 'https://api.github.com/orgs/octo-org/actions/variables')
                 {
-                    $Body | Should -Match '"visibility":"selected"'
-                    $Body | Should -Match '"selected_repository_ids":\[101,102\]'
+                    $Body | Should-MatchString '"visibility":"selected"'
+                    $Body | Should-MatchString '"selected_repository_ids":\[101,102\]'
                     return $null
                 }
 
@@ -250,9 +250,9 @@ Describe 'GitHub variable functions' {
             }
             $result = Set-GitHubVariable @setGitHubVariableParams
 
-            $result.Status | Should -Be 'Created'
-            $result.Transport | Should -Be 'RestApi'
-            $script:App1LookupCount | Should -Be 1
+            $result.Status | Should-Be 'Created'
+            $result.Transport | Should-Be 'RestApi'
+            $script:App1LookupCount | Should-Be 1
         }
 
         It 'retries transient API failures with exponential backoff' {
@@ -284,9 +284,9 @@ Describe 'GitHub variable functions' {
 
             $result = Set-GitHubVariable -Name 'FEATURE_FLAG' -Value 'enabled' -Scope Repository -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'Created'
-            $script:CreateAttempts | Should -Be 2
-            Should -Invoke -CommandName Start-Sleep -Times 1
+            $result.Status | Should-Be 'Created'
+            $script:CreateAttempts | Should-Be 2
+            Should-Invoke -CommandName Start-Sleep -Times 1
         }
 
         It 'rejects -SelectedRepository combined with incompatible -Visibility' -ForEach @(
@@ -304,7 +304,7 @@ Describe 'GitHub variable functions' {
 
             {
                 Set-GitHubVariable @setGitHubVariableParams
-            } | Should -Throw "*'-Visibility selected'*"
+            } | Should-Throw "*'-Visibility selected'*"
         }
 
         It 'rejects whitespace-only entries in -SelectedRepository' {
@@ -320,7 +320,7 @@ Describe 'GitHub variable functions' {
 
             {
                 Set-GitHubVariable @setGitHubVariableParams
-            } | Should -Throw '*empty or whitespace*'
+            } | Should-Throw '*empty or whitespace*'
         }
     }
 
@@ -346,10 +346,10 @@ Describe 'GitHub variable functions' {
 
             $result = Get-GitHubVariable -Name 'REGION' -Scope Organization -Organization 'octo-org' -Token $script:TokenValue
 
-            $result.Name | Should -Be 'REGION'
-            $result.Value | Should -Be 'us-east-1'
-            $result.NumSelectedRepos | Should -Be 2
-            $result.SelectedReposUrl | Should -Be 'https://api.github.com/orgs/octo-org/actions/variables/REGION/repositories'
+            $result.Name | Should-Be 'REGION'
+            $result.Value | Should-Be 'us-east-1'
+            $result.NumSelectedRepos | Should-Be 2
+            $result.SelectedReposUrl | Should-Be 'https://api.github.com/orgs/octo-org/actions/variables/REGION/repositories'
         }
 
         It 'redacts the GitHub token from REST fallback errors' {
@@ -372,8 +372,8 @@ Describe 'GitHub variable functions' {
             }
             catch
             {
-                $_.Exception.Message | Should -Not -Match 'ghp_Abc123Sensitive'
-                $_.Exception.Message | Should -Match '\[REDACTED\]'
+                $_.Exception.Message | Should-NotMatchString 'ghp_Abc123Sensitive'
+                $_.Exception.Message | Should-MatchString '\[REDACTED\]'
             }
         }
     }
@@ -395,7 +395,7 @@ Describe 'GitHub variable functions' {
 
             {
                 & $helpers.InvokeGitHubRequest @invokeGitHubRequestParams
-            } | Should -Throw "*'GH_TOKEN'*"
+            } | Should-Throw "*'GH_TOKEN'*"
         }
     }
 
@@ -413,8 +413,8 @@ Describe 'GitHub variable functions' {
 
             $result = Remove-GitHubVariable -Name 'MISSING_FLAG' -Scope Repository -Repository 'octo-org/service-api'
 
-            $result.Status | Should -Be 'AlreadyAbsent'
-            Should -Invoke -CommandName gh -ParameterFilter {
+            $result.Status | Should-Be 'AlreadyAbsent'
+            Should-Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and $args -contains 'DELETE'
             } -Times 0 -Exactly
         }
@@ -432,8 +432,8 @@ Describe 'GitHub variable functions' {
 
             $result = Remove-GitHubVariable -Name 'FEATURE_FLAG' -Scope Repository -Repository 'octo-org/service-api' -WhatIf
 
-            $result.Status | Should -Be 'WhatIf'
-            Should -Invoke -CommandName gh -ParameterFilter {
+            $result.Status | Should-Be 'WhatIf'
+            Should-Invoke -CommandName gh -ParameterFilter {
                 $args[0] -eq 'api' -and $args -contains '--method' -and $args -contains 'DELETE'
             } -Times 0 -Exactly
         }

--- a/Tests/Unit/Developer/Import-DotEnv.Tests.ps1
+++ b/Tests/Unit/Developer/Import-DotEnv.Tests.ps1
@@ -83,9 +83,9 @@ TEST_VAR3=value3
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_VAR1 | Should -Be 'value1'
-            $env:TEST_VAR2 | Should -Be 'value2'
-            $env:TEST_VAR3 | Should -Be 'value3'
+            $env:TEST_VAR1 | Should-Be 'value1'
+            $env:TEST_VAR2 | Should-Be 'value2'
+            $env:TEST_VAR3 | Should-Be 'value3'
         }
 
         It 'Should handle spaces around equals sign' {
@@ -94,7 +94,7 @@ TEST_VAR3=value3
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_VAR1 | Should -Be 'value with spaces'
+            $env:TEST_VAR1 | Should-Be 'value with spaces'
         }
 
         It 'Should skip empty lines' {
@@ -108,8 +108,8 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_VAR1 | Should -Be 'value1'
-            $env:TEST_VAR2 | Should -Be 'value2'
+            $env:TEST_VAR1 | Should-Be 'value1'
+            $env:TEST_VAR2 | Should-Be 'value2'
         }
 
         It 'Should skip comment lines starting with #' {
@@ -123,8 +123,8 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_VAR1 | Should -Be 'value1'
-            $env:TEST_VAR2 | Should -Be 'value2'
+            $env:TEST_VAR1 | Should-Be 'value1'
+            $env:TEST_VAR2 | Should-Be 'value2'
         }
 
         It 'Should handle export prefix' {
@@ -137,9 +137,9 @@ TEST_VAR3=value3
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_VAR1 | Should -Be 'value1'
-            $env:TEST_VAR2 | Should -Be 'value2'
-            $env:TEST_VAR3 | Should -Be 'value3'
+            $env:TEST_VAR1 | Should-Be 'value1'
+            $env:TEST_VAR2 | Should-Be 'value2'
+            $env:TEST_VAR3 | Should-Be 'value3'
         }
 
         It 'Should track loaded variables' {
@@ -152,8 +152,8 @@ TEST_VAR2=value2
             Import-DotEnv -Path $script:TestEnvFile
 
             $env:__DOTENV_LOADED_VARS | Should -Not -BeNullOrEmpty
-            $env:__DOTENV_LOADED_VARS | Should -Match 'TEST_VAR1'
-            $env:__DOTENV_LOADED_VARS | Should -Match 'TEST_VAR2'
+            $env:__DOTENV_LOADED_VARS | Should-MatchString 'TEST_VAR1'
+            $env:__DOTENV_LOADED_VARS | Should-MatchString 'TEST_VAR2'
         }
 
         It 'Should return results with PassThru' {
@@ -166,11 +166,11 @@ TEST_VAR2=value2
             $result = Import-DotEnv -Path $script:TestEnvFile -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.PSObject.TypeNames[0] | Should -Be 'DotEnv.LoadResult'
-            $result.VariableCount | Should -Be 2
-            $result.Variables | Should -Contain 'TEST_VAR1'
-            $result.Variables | Should -Contain 'TEST_VAR2'
-            $result.Scope | Should -Be 'Process'
+            $result.PSObject.TypeNames[0] | Should-Be 'DotEnv.LoadResult'
+            $result.VariableCount | Should-Be 2
+            $result.Variables | Should-ContainCollection 'TEST_VAR1'
+            $result.Variables | Should-ContainCollection 'TEST_VAR2'
+            $result.Scope | Should-Be 'Process'
         }
     }
 
@@ -194,7 +194,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_DOUBLE | Should -Be 'double quoted value'
+            $env:TEST_DOUBLE | Should-Be 'double quoted value'
         }
 
         It 'Should handle single-quoted values' {
@@ -203,7 +203,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_SINGLE | Should -Be 'single quoted value'
+            $env:TEST_SINGLE | Should-Be 'single quoted value'
         }
 
         It 'Should handle unquoted values with trailing comments' {
@@ -212,7 +212,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_UNQUOTED | Should -Be 'value'
+            $env:TEST_UNQUOTED | Should-Be 'value'
         }
 
         It 'Should preserve spaces in double-quoted values' {
@@ -221,7 +221,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_DOUBLE | Should -Be '  value with spaces  '
+            $env:TEST_DOUBLE | Should-Be '  value with spaces  '
         }
 
         It 'Should preserve spaces in single-quoted values' {
@@ -230,7 +230,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_SINGLE | Should -Be '  value with spaces  '
+            $env:TEST_SINGLE | Should-Be '  value with spaces  '
         }
 
         It 'Should handle escape sequences in double-quoted values' {
@@ -239,7 +239,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_DOUBLE | Should -Match "Line 1`nLine 2`tTabbed"
+            $env:TEST_DOUBLE | Should-MatchString "Line 1`nLine 2`tTabbed"
         }
 
         It 'Should NOT expand escape sequences in single-quoted values' {
@@ -248,7 +248,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_SINGLE | Should -Be 'Line 1\nLine 2'
+            $env:TEST_SINGLE | Should-Be 'Line 1\nLine 2'
         }
 
         It 'Should handle escaped quotes in double-quoted values' {
@@ -257,7 +257,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_DOUBLE | Should -Be 'She said "Hello"'
+            $env:TEST_DOUBLE | Should-Be 'She said "Hello"'
         }
 
         It 'Should handle backslashes in double-quoted values' {
@@ -266,7 +266,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_DOUBLE | Should -Be 'C:\Windows\System32'
+            $env:TEST_DOUBLE | Should-Be 'C:\Windows\System32'
         }
     }
 
@@ -291,7 +291,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_EXPAND1 | Should -Be 'Value is existing_value'
+            $env:TEST_EXPAND1 | Should-Be 'Value is existing_value'
         }
 
         It 'Should expand variables with $VAR syntax in double quotes' {
@@ -300,7 +300,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_EXPAND2 | Should -Be 'Value is existing_value'
+            $env:TEST_EXPAND2 | Should-Be 'Value is existing_value'
         }
 
         It 'Should NOT expand variables in single quotes' {
@@ -309,7 +309,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_NO_EXPAND | Should -Be 'Value is ${EXISTING_VAR}'
+            $env:TEST_NO_EXPAND | Should-Be 'Value is ${EXISTING_VAR}'
         }
 
         It 'Should handle undefined variable expansion gracefully' {
@@ -319,7 +319,7 @@ TEST_VAR2=value2
             Import-DotEnv -Path $script:TestEnvFile
 
             # Should keep the literal variable reference if undefined
-            $env:NEW_VAR | Should -Be 'Value is ${UNDEFINED_VAR}'
+            $env:NEW_VAR | Should-Be 'Value is ${UNDEFINED_VAR}'
         }
 
         It 'Should expand multiple variables in one value' {
@@ -330,7 +330,7 @@ TEST_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:TEST_EXPAND1 | Should -Be 'first and second'
+            $env:TEST_EXPAND1 | Should-Be 'first and second'
 
             Clear-TestEnvVars -VarNames @('VAR1', 'VAR2')
         }
@@ -345,8 +345,8 @@ PATH_TWO="${PATH_ONE}/tools"
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:PATH_ONE | Should -Be '/home/user/bin'
-            $env:PATH_TWO | Should -Be '/home/user/bin/tools'
+            $env:PATH_ONE | Should-Be '/home/user/bin'
+            $env:PATH_TWO | Should-Be '/home/user/bin/tools'
 
             Clear-TestEnvVars -VarNames @('BASE', 'PATH_ONE', 'PATH_TWO')
         }
@@ -358,7 +358,7 @@ PATH_TWO="${PATH_ONE}/tools"
 
             Import-DotEnv -Path $script:TestEnvFile -Force
 
-            $env:ORIG_PATH | Should -Be '/usr/bin:/new/path'
+            $env:ORIG_PATH | Should-Be '/usr/bin:/new/path'
 
             Clear-TestEnvVars -VarNames @('ORIG_PATH')
         }
@@ -371,7 +371,7 @@ PATH_TWO="${PATH_ONE}/tools"
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:URL | Should -Be 'http://localhost:8080/api'
+            $env:URL | Should-Be 'http://localhost:8080/api'
 
             Clear-TestEnvVars -VarNames @('HOST', 'PORT', 'URL')
         }
@@ -398,8 +398,8 @@ PATH_TWO="${PATH_ONE}/tools"
 
             $result = Import-DotEnv -Path $script:TestEnvFile -PassThru
 
-            $env:EXISTING_VAR | Should -Be 'original_value'
-            $result.Skipped | Should -Contain 'EXISTING_VAR'
+            $env:EXISTING_VAR | Should-Be 'original_value'
+            $result.Skipped | Should-ContainCollection 'EXISTING_VAR'
         }
 
         It 'Should overwrite existing variables with -Force' {
@@ -408,7 +408,7 @@ PATH_TWO="${PATH_ONE}/tools"
 
             Import-DotEnv -Path $script:TestEnvFile -Force
 
-            $env:EXISTING_VAR | Should -Be 'new_value'
+            $env:EXISTING_VAR | Should-Be 'new_value'
         }
 
         It 'Should track overwritten variables with -Force' {
@@ -417,7 +417,7 @@ PATH_TWO="${PATH_ONE}/tools"
 
             Import-DotEnv -Path $script:TestEnvFile -Force
 
-            $env:__DOTENV_LOADED_VARS | Should -Match 'EXISTING_VAR'
+            $env:__DOTENV_LOADED_VARS | Should-MatchString 'EXISTING_VAR'
         }
     }
 
@@ -445,9 +445,9 @@ UNLOAD_VAR3=value3
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:UNLOAD_VAR1 | Should -Be 'value1'
-            $env:UNLOAD_VAR2 | Should -Be 'value2'
-            $env:UNLOAD_VAR3 | Should -Be 'value3'
+            $env:UNLOAD_VAR1 | Should-Be 'value1'
+            $env:UNLOAD_VAR2 | Should-Be 'value2'
+            $env:UNLOAD_VAR3 | Should-Be 'value3'
 
             Import-DotEnv -Unload
 
@@ -479,16 +479,16 @@ UNLOAD_VAR2=value2
             $result = Import-DotEnv -Unload -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.PSObject.TypeNames[0] | Should -Be 'DotEnv.UnloadResult'
-            $result.VariableCount | Should -Be 2
-            $result.Variables | Should -Contain 'UNLOAD_VAR1'
-            $result.Variables | Should -Contain 'UNLOAD_VAR2'
+            $result.PSObject.TypeNames[0] | Should-Be 'DotEnv.UnloadResult'
+            $result.VariableCount | Should-Be 2
+            $result.Variables | Should-ContainCollection 'UNLOAD_VAR1'
+            $result.Variables | Should-ContainCollection 'UNLOAD_VAR2'
         }
 
         It 'Should handle unload when no variables were loaded' {
             $result = Import-DotEnv -Unload -PassThru
 
-            $result.VariableCount | Should -Be 0
+            $result.VariableCount | Should-Be 0
             $result.Variables | Should -BeNullOrEmpty
         }
 
@@ -503,8 +503,8 @@ UNLOAD_VAR2=value2
             Import-DotEnv -Path $testEnvFile2
 
             $tracked = $env:__DOTENV_LOADED_VARS
-            $tracked | Should -Match 'UNLOAD_VAR1'
-            $tracked | Should -Match 'UNLOAD_VAR2'
+            $tracked | Should-MatchString 'UNLOAD_VAR1'
+            $tracked | Should-MatchString 'UNLOAD_VAR2'
 
             Import-DotEnv -Unload
 
@@ -536,7 +536,7 @@ UNLOAD_VAR2=value2
             try
             {
                 Import-DotEnv
-                $env:PATH_VAR | Should -Be 'default'
+                $env:PATH_VAR | Should-Be 'default'
             }
             finally
             {
@@ -555,7 +555,7 @@ UNLOAD_VAR2=value2
 
             Import-DotEnv -Path $absoluteFile
 
-            $env:PATH_VAR | Should -Be 'absolute'
+            $env:PATH_VAR | Should-Be 'absolute'
 
             if (Test-Path $absoluteFile)
             {
@@ -571,8 +571,8 @@ UNLOAD_VAR2=value2
 
             @($file1, $file2) | Import-DotEnv
 
-            $env:VAR1 | Should -Be 'value1'
-            $env:VAR2 | Should -Be 'value2'
+            $env:VAR1 | Should-Be 'value1'
+            $env:VAR2 | Should-Be 'value2'
 
             Clear-TestEnvVars -VarNames @('VAR1', 'VAR2')
             Remove-Item -Path $file1, $file2 -Force
@@ -581,7 +581,7 @@ UNLOAD_VAR2=value2
         It 'Should warn when file does not exist' {
             $nonExistent = Join-Path -Path $script:TestDir -ChildPath 'nonexistent.env'
 
-            { Import-DotEnv -Path $nonExistent -WarningAction Stop } | Should -Throw
+            { Import-DotEnv -Path $nonExistent -WarningAction Stop } | Should-Throw
         }
     }
 
@@ -605,7 +605,7 @@ UNLOAD_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VALID_VAR | Should -Be 'value'
+            $env:VALID_VAR | Should-Be 'value'
         }
 
         It 'Should accept variable names with numbers' {
@@ -614,7 +614,7 @@ UNLOAD_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VALID_VAR_123 | Should -Be 'value'
+            $env:VALID_VAR_123 | Should-Be 'value'
         }
 
         It 'Should accept variable names starting with underscore' {
@@ -623,7 +623,7 @@ UNLOAD_VAR2=value2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:_VALID_VAR | Should -Be 'value'
+            $env:_VALID_VAR | Should-Be 'value'
         }
 
         It 'Should skip invalid variable names (starting with number)' {
@@ -636,8 +636,8 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VALID_VAR | Should -Be 'valid'
-            $env:ANOTHER_VALID | Should -Be 'valid2'
+            $env:VALID_VAR | Should-Be 'valid'
+            $env:ANOTHER_VALID | Should-Be 'valid2'
             # Invalid variable should not be set
         }
     }
@@ -671,7 +671,7 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:EQUALS_VAR | Should -Be 'key=value'
+            $env:EQUALS_VAR | Should-Be 'key=value'
         }
 
         It 'Should handle empty file' {
@@ -697,7 +697,7 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:SPECIAL_VAR | Should -Be '!@#$%^&*()[]{}|;:<>?,./'
+            $env:SPECIAL_VAR | Should-Be '!@#$%^&*()[]{}|;:<>?,./'
         }
 
         It 'Should handle Windows-style line endings' {
@@ -706,8 +706,8 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VAR1 | Should -Be 'value1'
-            $env:VAR2 | Should -Be 'value2'
+            $env:VAR1 | Should-Be 'value1'
+            $env:VAR2 | Should-Be 'value2'
 
             Clear-TestEnvVars -VarNames @('VAR1', 'VAR2')
         }
@@ -718,8 +718,8 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VAR1 | Should -Be 'value1'
-            $env:VAR2 | Should -Be 'value2'
+            $env:VAR1 | Should-Be 'value1'
+            $env:VAR2 | Should-Be 'value2'
 
             Clear-TestEnvVars -VarNames @('VAR1', 'VAR2')
         }
@@ -735,9 +735,9 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:NAME | Should -Be $jose
-            $env:MESSAGE | Should -Be $hello
-            $env:EMOJI | Should -Be $emoji
+            $env:NAME | Should-Be $jose
+            $env:MESSAGE | Should-Be $hello
+            $env:EMOJI | Should-Be $emoji
 
             Clear-TestEnvVars -VarNames @('NAME', 'MESSAGE', 'EMOJI')
         }
@@ -762,21 +762,21 @@ ANOTHER_VALID=valid2
             New-TestEnvFile -Path $script:TestEnvFile -Content $content
 
             { Import-DotEnv -Path $script:TestEnvFile -Scope Process } | Should -Not -Throw
-            $env:SCOPE_VAR | Should -Be 'process_value'
+            $env:SCOPE_VAR | Should-Be 'process_value'
         }
 
         It 'Should throw error for User scope on non-Windows platforms' -Skip:($IsWindows -or $PSVersionTable.PSEdition -eq 'Desktop') {
             $content = 'SCOPE_VAR=user_value'
             New-TestEnvFile -Path $script:TestEnvFile -Content $content
 
-            { Import-DotEnv -Path $script:TestEnvFile -Scope User } | Should -Throw '*only supported on Windows*'
+            { Import-DotEnv -Path $script:TestEnvFile -Scope User } | Should-Throw '*only supported on Windows*'
         }
 
         It 'Should throw error for Machine scope on non-Windows platforms' -Skip:($IsWindows -or $PSVersionTable.PSEdition -eq 'Desktop') {
             $content = 'SCOPE_VAR=machine_value'
             New-TestEnvFile -Path $script:TestEnvFile -Content $content
 
-            { Import-DotEnv -Path $script:TestEnvFile -Scope Machine } | Should -Throw '*only supported on Windows*'
+            { Import-DotEnv -Path $script:TestEnvFile -Scope Machine } | Should-Throw '*only supported on Windows*'
         }
     }
 
@@ -804,8 +804,8 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VALID_VAR | Should -Be 'valid_value'
-            $env:ANOTHER_VALID | Should -Be 'valid2'
+            $env:VALID_VAR | Should-Be 'valid_value'
+            $env:ANOTHER_VALID | Should-Be 'valid2'
             # Invalid line should be skipped
         }
 
@@ -815,7 +815,7 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:KEY | Should -Be 'value=with=equals'
+            $env:KEY | Should-Be 'value=with=equals'
         }
 
         It 'Should handle unclosed double quotes gracefully' {
@@ -830,7 +830,7 @@ ANOTHER_VALID=after
             { Import-DotEnv -Path $script:TestEnvFile } | Should -Not -Throw
 
             # Valid variables before and after should still load
-            $env:VALID_VAR | Should -Be 'before'
+            $env:VALID_VAR | Should-Be 'before'
         }
 
         It 'Should handle mismatched quotes' {
@@ -851,8 +851,8 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VALID_VAR | Should -Be 'valid'
-            $env:ANOTHER_VALID | Should -Be 'valid2'
+            $env:VALID_VAR | Should-Be 'valid'
+            $env:ANOTHER_VALID | Should-Be 'valid2'
             # Variable with hyphen should be skipped (not valid env var name)
         }
 
@@ -866,8 +866,8 @@ ANOTHER_VALID=valid2
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:VALID_VAR | Should -Be 'valid'
-            $env:ANOTHER_VALID | Should -Be 'valid2'
+            $env:VALID_VAR | Should-Be 'valid'
+            $env:ANOTHER_VALID | Should-Be 'valid2'
         }
 
         It 'Should handle lowercase variable names' {
@@ -881,9 +881,9 @@ MixedCase_Var=mixed
             Import-DotEnv -Path $script:TestEnvFile
 
             # PowerShell environment variables are case-insensitive on Windows, case-sensitive on Unix
-            $env:lowercase_var | Should -Be 'lowercase'
-            $env:UPPERCASE_VAR | Should -Be 'uppercase'
-            $env:MixedCase_Var | Should -Be 'mixed'
+            $env:lowercase_var | Should-Be 'lowercase'
+            $env:UPPERCASE_VAR | Should-Be 'uppercase'
+            $env:MixedCase_Var | Should-Be 'mixed'
 
             Clear-TestEnvVars -VarNames @('lowercase_var', 'UPPERCASE_VAR', 'MixedCase_Var')
         }
@@ -910,7 +910,7 @@ MixedCase_Var=mixed
             Import-DotEnv -Path $script:TestEnvFile
 
             # Trimmed key should work
-            $env:KEY1 | Should -Be 'value'
+            $env:KEY1 | Should-Be 'value'
         }
 
         It 'Should handle tabs around equals sign' {
@@ -919,7 +919,7 @@ MixedCase_Var=mixed
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:KEY2 | Should -Be 'value'
+            $env:KEY2 | Should-Be 'value'
         }
 
         It 'Should handle mixed whitespace' {
@@ -928,7 +928,7 @@ MixedCase_Var=mixed
 
             Import-DotEnv -Path $script:TestEnvFile
 
-            $env:KEY3 | Should -Be 'value'
+            $env:KEY3 | Should-Be 'value'
         }
     }
 
@@ -957,12 +957,12 @@ PASSWORD=MyP@ssw0rd!
             $verboseOutput = Import-DotEnv -Path $script:TestEnvFile -Verbose 4>&1 | Out-String
 
             # Verbose output should contain "Parsing variable" or "Setting" messages with variable names
-            ($verboseOutput | Should -Match 'Parsing variable:|Setting environment variable:')
+            ($verboseOutput | Should-MatchString 'Parsing variable:|Setting environment variable:')
 
             # Verbose output should NOT contain the secret values
-            $verboseOutput | Should -Not -Match 'super_secret_12345'
-            $verboseOutput | Should -Not -Match 'token_abcdef67890'
-            $verboseOutput | Should -Not -Match 'MyP@ssw0rd!'
+            $verboseOutput | Should-NotMatchString 'super_secret_12345'
+            $verboseOutput | Should-NotMatchString 'token_abcdef67890'
+            $verboseOutput | Should-NotMatchString 'MyP@ssw0rd!'
         }
 
         It 'Should not leak values in PassThru output (only variable names)' {
@@ -975,15 +975,15 @@ API_TOKEN=another_secret
             $result = Import-DotEnv -Path $script:TestEnvFile -PassThru
 
             # Result should contain variable names
-            $result.Variables | Should -Contain 'SECRET_KEY'
-            $result.Variables | Should -Contain 'API_TOKEN'
+            $result.Variables | Should-ContainCollection 'SECRET_KEY'
+            $result.Variables | Should-ContainCollection 'API_TOKEN'
 
             # Convert result to string to check for leaks
             $resultString = $result | Out-String
 
             # Should NOT contain the secret values
-            $resultString | Should -Not -Match 'super_secret_value'
-            $resultString | Should -Not -Match 'another_secret'
+            $resultString | Should-NotMatchString 'super_secret_value'
+            $resultString | Should-NotMatchString 'another_secret'
         }
 
         It 'Should redact content in error messages' {
@@ -1008,8 +1008,8 @@ API_TOKEN=token_abcdef67890
             # Even if there's an error, secret values should not appear in error messages
             if ($errorOutput)
             {
-                $errorOutput | Should -Not -Match 'super_secret_12345'
-                $errorOutput | Should -Not -Match 'token_abcdef67890'
+                $errorOutput | Should-NotMatchString 'super_secret_12345'
+                $errorOutput | Should-NotMatchString 'token_abcdef67890'
             }
         }
     }
@@ -1034,7 +1034,7 @@ API_TOKEN=token_abcdef67890
             Import-DotEnv -Path @($file1, $file2)
 
             # First value should win (second should be skipped)
-            $env:SHARED_VAR | Should -Be 'first_value'
+            $env:SHARED_VAR | Should-Be 'first_value'
 
             Remove-Item -Path $file1, $file2 -Force
         }
@@ -1050,7 +1050,7 @@ API_TOKEN=token_abcdef67890
             Import-DotEnv -Path @($file1, $file2) -Force
 
             # Last value should win with Force
-            $env:SHARED_VAR | Should -Be 'second_value'
+            $env:SHARED_VAR | Should-Be 'second_value'
 
             Remove-Item -Path $file1, $file2 -Force
         }
@@ -1065,8 +1065,8 @@ API_TOKEN=token_abcdef67890
             Import-DotEnv -Path @($file1, $file2)
 
             $tracked = $env:__DOTENV_LOADED_VARS
-            $tracked | Should -Match 'FILE1_VAR'
-            $tracked | Should -Match 'FILE2_VAR'
+            $tracked | Should-MatchString 'FILE1_VAR'
+            $tracked | Should-MatchString 'FILE2_VAR'
 
             Remove-Item -Path $file1, $file2 -Force
         }
@@ -1096,7 +1096,7 @@ API_TOKEN=token_abcdef67890
             # Should still work
             { Import-DotEnv -Path $script:TestEnvFile } | Should -Not -Throw
 
-            $env:TEST_VAR1 | Should -Be 'value1'
+            $env:TEST_VAR1 | Should-Be 'value1'
         }
 
         It 'Should handle duplicate variable names in same file' {
@@ -1109,7 +1109,7 @@ TEST_VAR1=second_value
             Import-DotEnv -Path $script:TestEnvFile -Force
 
             # Last occurrence should win
-            $env:TEST_VAR1 | Should -Be 'second_value'
+            $env:TEST_VAR1 | Should-Be 'second_value'
         }
 
         It 'Should deduplicate tracking variable entries' {
@@ -1123,7 +1123,7 @@ TEST_VAR1=second_value
             $tracked = $env:__DOTENV_LOADED_VARS
             # Should only contain TEST_VAR1 once (deduplicated)
             $varCount = ($tracked -split '\|' | Where-Object { $_ -eq 'TEST_VAR1' }).Count
-            $varCount | Should -BeLessOrEqual 1
+            $varCount | Should-BeLessThanOrEqual 1
         }
     }
 
@@ -1166,16 +1166,16 @@ SHOW_VAR3=value3
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Count | Should -Be 3
+            $result.Count | Should-Be 3
 
             $var1 = $result | Where-Object { $_.Name -eq 'SHOW_VAR1' }
-            $var1.Value | Should -Be 'value1'
+            $var1.Value | Should-Be 'value1'
 
             $var2 = $result | Where-Object { $_.Name -eq 'SHOW_VAR2' }
-            $var2.Value | Should -Be 'value2'
+            $var2.Value | Should-Be 'value2'
 
             $var3 = $result | Where-Object { $_.Name -eq 'SHOW_VAR3' }
-            $var3.Value | Should -Be 'value3'
+            $var3.Value | Should-Be 'value3'
         }
 
         It 'Should return PSCustomObjects with Name and Value properties' {
@@ -1188,9 +1188,9 @@ SHOW_VAR2=another_value
 
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
-            $result | Should -BeOfType [PSCustomObject]
-            $result[0].PSObject.Properties.Name | Should -Contain 'Name'
-            $result[0].PSObject.Properties.Name | Should -Contain 'Value'
+            $result | Should-HaveType ([PSCustomObject])
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Name'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Value'
         }
 
         It 'Should show current values even if modified after loading' {
@@ -1204,7 +1204,7 @@ SHOW_VAR2=another_value
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
             $var1 = $result | Where-Object { $_.Name -eq 'SHOW_VAR1' }
-            $var1.Value | Should -Be 'modified_value'
+            $var1.Value | Should-Be 'modified_value'
         }
 
         It 'Should handle variables with special characters in values' {
@@ -1218,9 +1218,9 @@ SHOW_VAR3="special!@#$%"
 
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
-            ($result | Where-Object { $_.Name -eq 'SHOW_VAR1' }).Value | Should -Be 'value with spaces'
-            ($result | Where-Object { $_.Name -eq 'SHOW_VAR2' }).Value | Should -Be 'value=with=equals'
-            ($result | Where-Object { $_.Name -eq 'SHOW_VAR3' }).Value | Should -Be 'special!@#$%'
+            ($result | Where-Object { $_.Name -eq 'SHOW_VAR1' }).Value | Should-Be 'value with spaces'
+            ($result | Where-Object { $_.Name -eq 'SHOW_VAR2' }).Value | Should-Be 'value=with=equals'
+            ($result | Where-Object { $_.Name -eq 'SHOW_VAR3' }).Value | Should-Be 'special!@#$%'
         }
 
         It 'Should handle variables that were unset after loading' {
@@ -1237,7 +1237,7 @@ SHOW_VAR2=value2
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
             # Should still show both in tracking, but SHOW_VAR2 will have null/empty value
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
             ($result | Where-Object { $_.Name -eq 'SHOW_VAR2' }).Value | Should -BeNullOrEmpty
         }
 
@@ -1253,7 +1253,7 @@ SHOW_VAR1=regular_value
 
             # Verify that sensitive values ARE shown (this is expected behavior)
             $secret = $result | Where-Object { $_.Name -eq 'SECRET_KEY' }
-            $secret.Value | Should -Be 'super_secret_password'
+            $secret.Value | Should-Be 'super_secret_password'
         }
 
         It 'Should handle empty values' {
@@ -1267,7 +1267,7 @@ SHOW_VAR3=value3
 
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
-            $result.Count | Should -Be 3
+            $result.Count | Should-Be 3
             ($result | Where-Object { $_.Name -eq 'SHOW_VAR2' }).Value | Should -BeNullOrEmpty
         }
 
@@ -1283,9 +1283,9 @@ SHOW_VAR3=value3
 
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
-            ($result | Where-Object { $_.Name -eq 'SHOW_VAR1' }).Value | Should -Be $jose
-            ($result | Where-Object { $_.Name -eq 'SHOW_VAR2' }).Value | Should -Be $emoji
-            ($result | Where-Object { $_.Name -eq 'SHOW_VAR3' }).Value | Should -Be $chinese
+            ($result | Where-Object { $_.Name -eq 'SHOW_VAR1' }).Value | Should-Be $jose
+            ($result | Where-Object { $_.Name -eq 'SHOW_VAR2' }).Value | Should-Be $emoji
+            ($result | Where-Object { $_.Name -eq 'SHOW_VAR3' }).Value | Should-Be $chinese
         }
     }
 }

--- a/Tests/Unit/Developer/Import-DotEnv.Tests.ps1
+++ b/Tests/Unit/Developer/Import-DotEnv.Tests.ps1
@@ -1188,7 +1188,7 @@ SHOW_VAR2=another_value
 
             $result = Import-DotEnv -ShowLoadedWithValues -PassThru
 
-            $result | Should-HaveType ([PSCustomObject])
+            $result | ForEach-Object { $_ | Should-HaveType ([PSCustomObject]) }
             $result[0].PSObject.Properties.Name | Should-ContainCollection 'Name'
             $result[0].PSObject.Properties.Name | Should-ContainCollection 'Value'
         }
@@ -1289,4 +1289,3 @@ SHOW_VAR3=value3
         }
     }
 }
-

--- a/Tests/Unit/Developer/Invoke-BfgRepoCleaner.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-BfgRepoCleaner.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Invoke-BfgRepoCleaner' {
         It 'Throws when Docker is not installed' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
 
         It 'Throws when Docker daemon is not running' {
@@ -106,7 +106,7 @@ Describe 'Invoke-BfgRepoCleaner' {
                 }
             }
 
-            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' } | Should -Throw '*daemon is not running*'
+            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' } | Should-Throw '*daemon is not running*'
 
             Remove-Item -Path Function:\pwshDockerTestShimDaemonDown -ErrorAction SilentlyContinue
         }
@@ -130,8 +130,8 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Confirm:$false | Out-Null
 
-            $script:BfgShimInvocations.Count | Should -Be 1
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:BfgShimInvocations.Count | Should-Be 1
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
 
         It 'Skips Docker prerequisite checks when local BFG is available' {
@@ -145,7 +145,7 @@ Describe 'Invoke-BfgRepoCleaner' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
             { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Confirm:$false } | Should -Not -Throw
-            Should -Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
+            Should-Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
         }
 
         It 'Falls back to Docker when local BFG is not available' {
@@ -160,7 +160,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $script:BfgShimInvocations.Count | Should -Be 0
+            $script:BfgShimInvocations.Count | Should-Be 0
         }
 
         It 'Uses Docker when Runtime is explicitly set to Docker' {
@@ -182,7 +182,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $script:BfgShimInvocations.Count | Should -Be 0
+            $script:BfgShimInvocations.Count | Should-Be 0
         }
 
         It 'Uses local BFG when Runtime is explicitly set to Local' {
@@ -197,8 +197,8 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Runtime Local -Confirm:$false | Out-Null
 
-            $script:BfgShimInvocations.Count | Should -Be 1
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:BfgShimInvocations.Count | Should-Be 1
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
     }
 
@@ -209,7 +209,7 @@ Describe 'Invoke-BfgRepoCleaner' {
             @{ Value = 'abc' }
             @{ Value = '10T' }
         ) {
-            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan $Value } | Should -Throw
+            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan $Value } | Should-Throw
         }
 
         It 'Accepts valid StripBlobsBiggerThan format "<Value>"' -ForEach @(
@@ -230,25 +230,25 @@ Describe 'Invoke-BfgRepoCleaner' {
         }
 
         It 'Rejects StripBiggestBlobs less than 1' {
-            { Invoke-BfgRepoCleaner -StripBiggestBlobs 0 } | Should -Throw
+            { Invoke-BfgRepoCleaner -StripBiggestBlobs 0 } | Should-Throw
         }
 
         It 'Rejects empty DeleteFiles' {
-            { Invoke-BfgRepoCleaner -DeleteFiles '' } | Should -Throw
+            { Invoke-BfgRepoCleaner -DeleteFiles '' } | Should-Throw
         }
 
         It 'Rejects empty DeleteFolders' {
-            { Invoke-BfgRepoCleaner -DeleteFolders '' } | Should -Throw
+            { Invoke-BfgRepoCleaner -DeleteFolders '' } | Should-Throw
         }
 
         It 'Rejects invalid Runtime' {
-            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Runtime 'Container' } | Should -Throw
+            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Runtime 'Container' } | Should-Throw
         }
     }
 
     Context 'Explicit runtime prerequisites' {
         It 'Throws when Runtime is Local and local BFG is not installed' {
-            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Runtime Local -Confirm:$false } | Should -Throw 'BFG Repo-Cleaner is not installed or not available in PATH. Install BFG or use -Runtime Docker.'
+            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Runtime Local -Confirm:$false } | Should-Throw 'BFG Repo-Cleaner is not installed or not available in PATH. Install BFG or use -Runtime Docker.'
         }
 
         It 'Throws when Runtime is Docker and Docker is not installed even if local BFG is available' {
@@ -261,7 +261,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Runtime Docker -Confirm:$false } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Runtime Docker -Confirm:$false } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
     }
 
@@ -278,12 +278,12 @@ Describe 'Invoke-BfgRepoCleaner' {
         It 'Passes --strip-blobs-bigger-than with the correct size' {
             Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Confirm:$false | Out-Null
 
-            $script:DockerShimInvocations.Count | Should -BeGreaterThan 0
+            $script:DockerShimInvocations.Count | Should-BeGreaterThan 0
             # Find the 'run' invocation (skip the 'info' call)
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--strip-blobs-bigger-than'
-            $runCall | Should -Contain '100M'
+            $runCall | Should-ContainCollection '--strip-blobs-bigger-than'
+            $runCall | Should-ContainCollection '100M'
         }
 
         It 'Passes --strip-biggest-blobs with the correct count' {
@@ -291,8 +291,8 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--strip-biggest-blobs'
-            $runCall | Should -Contain '10'
+            $runCall | Should-ContainCollection '--strip-biggest-blobs'
+            $runCall | Should-ContainCollection '10'
         }
 
         It 'Passes --delete-files with the correct pattern' {
@@ -300,8 +300,8 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--delete-files'
-            $runCall | Should -Contain 'passwords.txt'
+            $runCall | Should-ContainCollection '--delete-files'
+            $runCall | Should-ContainCollection 'passwords.txt'
         }
 
         It 'Passes --delete-folders with the correct name' {
@@ -309,8 +309,8 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--delete-folders'
-            $runCall | Should -Contain '.secrets'
+            $runCall | Should-ContainCollection '--delete-folders'
+            $runCall | Should-ContainCollection '.secrets'
         }
 
         It 'Passes --no-blob-protection when NoBlobProtection is specified' {
@@ -318,7 +318,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--no-blob-protection'
+            $runCall | Should-ContainCollection '--no-blob-protection'
         }
 
         It 'Appends repository path as the last argument' {
@@ -326,7 +326,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall[-1] | Should -Be 'my-repo.git'
+            $runCall[-1] | Should-Be 'my-repo.git'
         }
 
         It 'Appends additional arguments' {
@@ -334,7 +334,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--private'
+            $runCall | Should-ContainCollection '--private'
         }
 
         It 'Uses correct image reference with default tag' {
@@ -342,7 +342,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'jonlabelle/bfg:latest'
+            $runCall | Should-ContainCollection 'jonlabelle/bfg:latest'
         }
 
         It 'Uses correct image reference with custom tag' {
@@ -350,7 +350,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'jonlabelle/bfg:1.15.0'
+            $runCall | Should-ContainCollection 'jonlabelle/bfg:1.15.0'
         }
 
         It 'Mounts the working directory as /work volume' {
@@ -358,7 +358,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '-v'
+            $runCall | Should-ContainCollection '-v'
             # Find the volume mount argument that contains :/work
             $volArg = $runCall | Where-Object { $_ -match ':/work$' }
             $volArg | Should -Not -BeNullOrEmpty
@@ -369,11 +369,11 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--delete-files'
-            $runCall | Should -Contain '*.env'
-            $runCall | Should -Contain '--delete-folders'
-            $runCall | Should -Contain 'node_modules'
-            $runCall[-1] | Should -Be 'my-repo.git'
+            $runCall | Should-ContainCollection '--delete-files'
+            $runCall | Should-ContainCollection '*.env'
+            $runCall | Should-ContainCollection '--delete-folders'
+            $runCall | Should-ContainCollection 'node_modules'
+            $runCall[-1] | Should-Be 'my-repo.git'
         }
 
         It 'Uses -i and --rm flags for docker run' {
@@ -381,8 +381,8 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '-i'
-            $runCall | Should -Contain '--rm'
+            $runCall | Should-ContainCollection '-i'
+            $runCall | Should-ContainCollection '--rm'
         }
     }
 
@@ -397,7 +397,7 @@ Describe 'Invoke-BfgRepoCleaner' {
         }
 
         It 'Throws when replace-text file does not exist' {
-            { Invoke-BfgRepoCleaner -ReplaceText 'nonexistent-file.txt' -Confirm:$false } | Should -Throw 'Replace-text file not found*'
+            { Invoke-BfgRepoCleaner -ReplaceText 'nonexistent-file.txt' -Confirm:$false } | Should-Throw 'Replace-text file not found*'
         }
 
         It 'Mounts replace-text file and passes --replace-text with container path' {
@@ -408,8 +408,8 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--replace-text'
-            $runCall | Should -Contain '/config/replacements.txt'
+            $runCall | Should-ContainCollection '--replace-text'
+            $runCall | Should-ContainCollection '/config/replacements.txt'
 
             # Verify the volume mount for the replace-text file
             $volArgs = @()
@@ -439,7 +439,7 @@ Describe 'Invoke-BfgRepoCleaner' {
             $result = @(Invoke-BfgRepoCleaner -StripBlobsBiggerThan '100M' -Confirm:$false)
 
             # The last element is the exit code (preceding elements are Docker output)
-            $result[-1] | Should -Be 0
+            $result[-1] | Should-Be 0
         }
 
         It 'Returns non-zero exit code on failure and writes warning' {
@@ -475,7 +475,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             # The result should contain a non-zero exit code and a warning
             $exitCode = $result | Where-Object { $_ -is [Int32] -or $_ -is [Int64] }
-            $exitCode | Should -Be 1
+            $exitCode | Should-Be 1
 
             Remove-Item -Path Function:\pwshDockerTestShimFail -ErrorAction SilentlyContinue
         }
@@ -515,7 +515,7 @@ Describe 'Invoke-BfgRepoCleaner' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--help'
+            $runCall | Should-ContainCollection '--help'
         }
     }
 }

--- a/Tests/Unit/Developer/Invoke-DockerAutoRun.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-DockerAutoRun.Tests.ps1
@@ -82,7 +82,7 @@ Describe 'Invoke-DockerAutoRun' {
 
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Invoke-DockerAutoRun -Path $script:TestDir } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Invoke-DockerAutoRun -Path $script:TestDir } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
 
         It 'Can generate a Dockerfile without Docker when -GenerateOnly is used' {
@@ -93,10 +93,10 @@ Describe 'Invoke-DockerAutoRun' {
 
             $result = Invoke-DockerAutoRun -Path $script:TestDir -GenerateOnly
 
-            Test-Path -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'Dockerfile') | Should -BeTrue
-            $result.BuildExecuted | Should -BeFalse
-            $result.RunExecuted | Should -BeFalse
-            $result.ProjectType | Should -Be 'Node'
+            Test-Path -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'Dockerfile') | Should-BeTruthy
+            $result.BuildExecuted | Should-BeFalsy
+            $result.RunExecuted | Should-BeFalsy
+            $result.ProjectType | Should-Be 'Node'
         }
     }
 
@@ -120,25 +120,25 @@ Describe 'Invoke-DockerAutoRun' {
             $result = Invoke-DockerAutoRun -Path $script:TestDir -ImageName 'test-image' -ContainerName 'test-container'
 
             $dockerfilePath = Join-Path -Path $script:TestDir -ChildPath 'Dockerfile'
-            $dockerfilePath | Should -Exist
-            (Get-Content -LiteralPath $dockerfilePath -Raw) | Should -Match 'FROM node:lts-alpine'
+            Test-Path -LiteralPath $dockerfilePath | Should-BeTruthy
+            (Get-Content -LiteralPath $dockerfilePath -Raw) | Should-MatchString 'FROM node:lts-alpine'
 
-            $result.ProjectType | Should -Be 'Node'
-            $result.DockerfileGenerated | Should -BeTrue
-            $result.Port | Should -Be 3000
-            $result.BuildExecuted | Should -BeTrue
-            $result.RunExecuted | Should -BeTrue
+            $result.ProjectType | Should-Be 'Node'
+            $result.DockerfileGenerated | Should-BeTruthy
+            $result.Port | Should-Be 3000
+            $result.BuildExecuted | Should-BeTruthy
+            $result.RunExecuted | Should-BeTruthy
 
             $buildCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'build' })
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'run' })
 
-            $buildCalls.Count | Should -Be 1
-            $runCalls.Count | Should -Be 1
-            $buildCalls[0] | Should -Contain '-t'
-            $buildCalls[0] | Should -Contain 'test-image'
-            $runCalls[0] | Should -Contain '--name'
-            $runCalls[0] | Should -Contain 'test-container'
-            $runCalls[0] | Should -Contain '3000:3000'
+            $buildCalls.Count | Should-Be 1
+            $runCalls.Count | Should-Be 1
+            $buildCalls[0] | Should-ContainCollection '-t'
+            $buildCalls[0] | Should-ContainCollection 'test-image'
+            $runCalls[0] | Should-ContainCollection '--name'
+            $runCalls[0] | Should-ContainCollection 'test-container'
+            $runCalls[0] | Should-ContainCollection '3000:3000'
         }
 
         It 'Uses existing Dockerfile without overwriting by default' {
@@ -153,13 +153,13 @@ CMD ["sh","-c","sleep 600"]
 
             $result = Invoke-DockerAutoRun -Path $script:TestDir -ImageName 'existing-file-image'
 
-            $result.ProjectType | Should -Be 'ExistingDockerfile'
-            $result.DockerfileGenerated | Should -BeFalse
-            $result.Port | Should -Be 9090
+            $result.ProjectType | Should-Be 'ExistingDockerfile'
+            $result.DockerfileGenerated | Should-BeFalsy
+            $result.Port | Should-Be 9090
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'run' })
-            $runCalls.Count | Should -Be 1
-            $runCalls[0] | Should -Contain '9090:9090'
+            $runCalls.Count | Should-Be 1
+            $runCalls[0] | Should-ContainCollection '9090:9090'
         }
 
         It 'Overwrites existing Dockerfile when -ForceDockerfile is specified' {
@@ -172,8 +172,8 @@ CMD ["sh","-c","sleep 600"]
             $result = Invoke-DockerAutoRun -Path $script:TestDir -ForceDockerfile -NoRun
             $dockerfileText = Get-Content -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'Dockerfile') -Raw
 
-            $result.DockerfileGenerated | Should -BeTrue
-            $dockerfileText | Should -Match 'FROM node:lts-alpine'
+            $result.DockerfileGenerated | Should-BeTruthy
+            $dockerfileText | Should-MatchString 'FROM node:lts-alpine'
         }
     }
 
@@ -195,20 +195,20 @@ CMD ["sh","-c","sleep 600"]
         It 'Builds but does not run when -NoRun is specified' {
             $result = Invoke-DockerAutoRun -Path $script:TestDir -NoRun
 
-            $result.BuildExecuted | Should -BeTrue
-            $result.RunExecuted | Should -BeFalse
+            $result.BuildExecuted | Should-BeTruthy
+            $result.RunExecuted | Should-BeFalsy
 
             $buildCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'build' })
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'run' })
-            $buildCalls.Count | Should -Be 1
-            $runCalls.Count | Should -Be 0
+            $buildCalls.Count | Should-Be 1
+            $runCalls.Count | Should-Be 0
         }
 
         It 'Throws when project type cannot be auto-detected' {
             Remove-Item -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'package.json') -Force -ErrorAction SilentlyContinue
             Remove-Item -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'index.js') -Force -ErrorAction SilentlyContinue
 
-            { Invoke-DockerAutoRun -Path $script:TestDir -GenerateOnly } | Should -Throw '*Unable to auto-detect project type*'
+            { Invoke-DockerAutoRun -Path $script:TestDir -GenerateOnly } | Should-Throw '*Unable to auto-detect project type*'
         }
     }
 
@@ -229,12 +229,12 @@ CMD ["sh","-c","sleep 600"]
             $result = Invoke-DockerAutoRun -Path $script:TestDir -GenerateOnly
 
             $ignorePath = Join-Path -Path $script:TestDir -ChildPath '.dockerignore'
-            $ignorePath | Should -Exist
-            $result.DockerIgnoreGenerated | Should -BeTrue
+            Test-Path -LiteralPath $ignorePath | Should-BeTruthy
+            $result.DockerIgnoreGenerated | Should-BeTruthy
 
             $ignoreContent = Get-Content -LiteralPath $ignorePath -Raw
-            $ignoreContent | Should -Match 'node_modules'
-            $ignoreContent | Should -Match '\.git'
+            $ignoreContent | Should-MatchString 'node_modules'
+            $ignoreContent | Should-MatchString '\.git'
         }
 
         It 'Generates project-specific .dockerignore for Python projects' {
@@ -244,11 +244,11 @@ CMD ["sh","-c","sleep 600"]
             Invoke-DockerAutoRun -Path $script:TestDir -GenerateOnly
 
             $ignorePath = Join-Path -Path $script:TestDir -ChildPath '.dockerignore'
-            $ignorePath | Should -Exist
+            Test-Path -LiteralPath $ignorePath | Should-BeTruthy
 
             $ignoreContent = Get-Content -LiteralPath $ignorePath -Raw
-            $ignoreContent | Should -Match '__pycache__'
-            $ignoreContent | Should -Match '\.venv'
+            $ignoreContent | Should-MatchString '__pycache__'
+            $ignoreContent | Should-MatchString '\.venv'
         }
 
         It 'Does not overwrite existing .dockerignore' {
@@ -258,8 +258,8 @@ CMD ["sh","-c","sleep 600"]
 
             $result = Invoke-DockerAutoRun -Path $script:TestDir -GenerateOnly
 
-            $result.DockerIgnoreGenerated | Should -BeFalse
-            (Get-Content -LiteralPath $ignorePath -Raw).Trim() | Should -Be 'custom-ignore'
+            $result.DockerIgnoreGenerated | Should-BeFalsy
+            (Get-Content -LiteralPath $ignorePath -Raw).Trim() | Should-Be 'custom-ignore'
         }
 
         It 'Skips .dockerignore generation when -NoDockerIgnore is specified' {
@@ -268,8 +268,8 @@ CMD ["sh","-c","sleep 600"]
             $result = Invoke-DockerAutoRun -Path $script:TestDir -GenerateOnly -NoDockerIgnore
 
             $ignorePath = Join-Path -Path $script:TestDir -ChildPath '.dockerignore'
-            $ignorePath | Should -Not -Exist
-            $result.DockerIgnoreGenerated | Should -BeFalse
+            Test-Path -LiteralPath $ignorePath | Should-BeFalsy
+            $result.DockerIgnoreGenerated | Should-BeFalsy
         }
     }
 
@@ -292,15 +292,15 @@ CMD ["sh","-c","sleep 600"]
         It 'Adds -i and -t flags when -Interactive is specified' {
             $result = Invoke-DockerAutoRun -Path $script:TestDir -Interactive -ImageName 'test-app'
 
-            $result.Interactive | Should -BeTrue
+            $result.Interactive | Should-BeTruthy
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'run' })
-            $runCalls.Count | Should -Be 1
-            $runCalls[0] | Should -Contain '-i'
-            $runCalls[0] | Should -Contain '-t'
+            $runCalls.Count | Should-Be 1
+            $runCalls[0] | Should-ContainCollection '-i'
+            $runCalls[0] | Should-ContainCollection '-t'
         }
 
         It 'Throws when -Interactive and -Detached are used together' {
-            { Invoke-DockerAutoRun -Path $script:TestDir -Interactive -Detached } | Should -Throw '*cannot be used together*'
+            { Invoke-DockerAutoRun -Path $script:TestDir -Interactive -Detached } | Should-Throw '*cannot be used together*'
         }
 
         It 'Passes --env-file when -EnvFile is specified' {
@@ -310,18 +310,18 @@ CMD ["sh","-c","sleep 600"]
             Invoke-DockerAutoRun -Path $script:TestDir -EnvFile $envFilePath -ImageName 'test-app'
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'run' })
-            $runCalls.Count | Should -Be 1
-            $runCalls[0] | Should -Contain '--env-file'
-            $runCalls[0] | Should -Contain $envFilePath
+            $runCalls.Count | Should-Be 1
+            $runCalls[0] | Should-ContainCollection '--env-file'
+            $runCalls[0] | Should-ContainCollection $envFilePath
         }
 
         It 'Passes --network when -Network is specified' {
             Invoke-DockerAutoRun -Path $script:TestDir -Network 'my-bridge' -ImageName 'test-app'
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'run' })
-            $runCalls.Count | Should -Be 1
-            $runCalls[0] | Should -Contain '--network'
-            $runCalls[0] | Should -Contain 'my-bridge'
+            $runCalls.Count | Should-Be 1
+            $runCalls[0] | Should-ContainCollection '--network'
+            $runCalls[0] | Should-ContainCollection 'my-bridge'
         }
     }
 
@@ -346,7 +346,7 @@ CMD ["sh","-c","sleep 600"]
             Invoke-DockerAutoRun -Path $script:TestDir -ImageName 'test-app' -ContainerName 'test-ctr' | Out-Null
 
             $psCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'ps' })
-            $psCalls.Count | Should -Be 1
+            $psCalls.Count | Should-Be 1
         }
 
         It 'Removes existing container when one is found with the same name' {
@@ -356,9 +356,9 @@ CMD ["sh","-c","sleep 600"]
             Invoke-DockerAutoRun -Path $script:TestDir -ImageName 'test-app' -ContainerName 'test-ctr' | Out-Null
 
             $rmCalls = @($script:DockerShimInvocations | Where-Object { $_.Count -gt 0 -and $_[0] -eq 'rm' })
-            $rmCalls.Count | Should -Be 1
-            $rmCalls[0] | Should -Contain '-f'
-            $rmCalls[0] | Should -Contain 'test-ctr'
+            $rmCalls.Count | Should-Be 1
+            $rmCalls[0] | Should-ContainCollection '-f'
+            $rmCalls[0] | Should-ContainCollection 'test-ctr'
         }
     }
 }

--- a/Tests/Unit/Developer/Invoke-GitPull.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-GitPull.Tests.ps1
@@ -45,19 +45,19 @@ Describe 'Invoke-GitPull' {
 
             $pathParam | Should -Not -BeNullOrEmpty
             $pathParam.Attributes | Where-Object { $_ -is [Parameter] } |
-            ForEach-Object { $_.ValueFromPipeline } | Should -Contain $true
+            ForEach-Object { $_.ValueFromPipeline } | Should-ContainCollection $true
         }
 
         It 'Should have Path parameter that accepts FullName property' {
             $command = Get-Command -Name 'Invoke-GitPull'
             $pathParam = $command.Parameters['Path']
 
-            $pathParam.Aliases | Should -Contain 'FullName'
+            $pathParam.Aliases | Should-ContainCollection 'FullName'
         }
 
         It 'Should have Recurse switch parameter' {
             $command = Get-Command -Name 'Invoke-GitPull'
-            $command.Parameters['Recurse'].SwitchParameter | Should -BeTrue
+            $command.Parameters['Recurse'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should have Depth parameter with valid range' {
@@ -65,44 +65,44 @@ Describe 'Invoke-GitPull' {
             $depthParam = $command.Parameters['Depth']
 
             $depthParam | Should -Not -BeNullOrEmpty
-            $depthParam.ParameterType | Should -Be ([Int])
+            $depthParam.ParameterType | Should-Be ([Int])
         }
 
         It 'Should have NoRebase switch parameter' {
             $command = Get-Command -Name 'Invoke-GitPull'
-            $command.Parameters['NoRebase'].SwitchParameter | Should -BeTrue
+            $command.Parameters['NoRebase'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should have Prune switch parameter' {
             $command = Get-Command -Name 'Invoke-GitPull'
-            $command.Parameters['Prune'].SwitchParameter | Should -BeTrue
+            $command.Parameters['Prune'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should have Force switch parameter' {
             $command = Get-Command -Name 'Invoke-GitPull'
-            $command.Parameters['Force'].SwitchParameter | Should -BeTrue
+            $command.Parameters['Force'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should have Branch string parameter' {
             $command = Get-Command -Name 'Invoke-GitPull'
             $command.Parameters['Branch'] | Should -Not -BeNullOrEmpty
-            $command.Parameters['Branch'].ParameterType | Should -Be ([String])
+            $command.Parameters['Branch'].ParameterType | Should-Be ([String])
         }
 
         It 'Should have DefaultBranch switch parameter' {
             $command = Get-Command -Name 'Invoke-GitPull'
-            $command.Parameters['DefaultBranch'].SwitchParameter | Should -BeTrue
+            $command.Parameters['DefaultBranch'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should have Checkout switch parameter' {
             $command = Get-Command -Name 'Invoke-GitPull'
-            $command.Parameters['Checkout'].SwitchParameter | Should -BeTrue
+            $command.Parameters['Checkout'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should support ShouldProcess (WhatIf/Confirm)' {
             $command = Get-Command -Name 'Invoke-GitPull'
-            $command.Parameters.ContainsKey('WhatIf') | Should -BeTrue
-            $command.Parameters.ContainsKey('Confirm') | Should -BeTrue
+            $command.Parameters.ContainsKey('WhatIf') | Should-BeTruthy
+            $command.Parameters.ContainsKey('Confirm') | Should-BeTruthy
         }
     }
 
@@ -113,8 +113,8 @@ Describe 'Invoke-GitPull' {
             # Should warn but not throw
             $result = Invoke-GitPull -Path $nonExistentPath -WarningAction SilentlyContinue
 
-            $result.RepositoriesSkipped | Should -Be 1
-            $result.RepositoriesProcessed | Should -Be 0
+            $result.RepositoriesSkipped | Should-Be 1
+            $result.RepositoriesProcessed | Should-Be 0
         }
 
         It 'Should handle file path (not directory) gracefully' {
@@ -125,8 +125,8 @@ Describe 'Invoke-GitPull' {
             {
                 $result = Invoke-GitPull -Path $filePath -WarningAction SilentlyContinue
 
-                $result.RepositoriesSkipped | Should -Be 1
-                $result.RepositoriesProcessed | Should -Be 0
+                $result.RepositoriesSkipped | Should-Be 1
+                $result.RepositoriesProcessed | Should-Be 0
             }
             finally
             {
@@ -142,8 +142,8 @@ Describe 'Invoke-GitPull' {
             {
                 $result = Invoke-GitPull -Path $nonGitDir
 
-                $result.RepositoriesSkipped | Should -Be 1
-                $result.RepositoriesProcessed | Should -Be 0
+                $result.RepositoriesSkipped | Should-Be 1
+                $result.RepositoriesProcessed | Should-Be 0
             }
             finally
             {
@@ -161,7 +161,7 @@ Describe 'Invoke-GitPull' {
             {
                 $result = Invoke-GitPull -Path @($dir1, $dir2)
 
-                $result.RepositoriesSkipped | Should -Be 2
+                $result.RepositoriesSkipped | Should-Be 2
             }
             finally
             {
@@ -180,12 +180,12 @@ Describe 'Invoke-GitPull' {
             {
                 $result = Invoke-GitPull -Path $nonGitDir
 
-                $result | Should -BeOfType [PSCustomObject]
-                $result.PSObject.Properties.Name | Should -Contain 'RepositoriesProcessed'
-                $result.PSObject.Properties.Name | Should -Contain 'RepositoriesUpdated'
-                $result.PSObject.Properties.Name | Should -Contain 'RepositoriesSkipped'
-                $result.PSObject.Properties.Name | Should -Contain 'RepositoriesFailed'
-                $result.PSObject.Properties.Name | Should -Contain 'Results'
+                $result | Should-HaveType ([PSCustomObject])
+                $result.PSObject.Properties.Name | Should-ContainCollection 'RepositoriesProcessed'
+                $result.PSObject.Properties.Name | Should-ContainCollection 'RepositoriesUpdated'
+                $result.PSObject.Properties.Name | Should-ContainCollection 'RepositoriesSkipped'
+                $result.PSObject.Properties.Name | Should-ContainCollection 'RepositoriesFailed'
+                $result.PSObject.Properties.Name | Should-ContainCollection 'Results'
             }
             finally
             {
@@ -202,7 +202,7 @@ Describe 'Invoke-GitPull' {
                 $result = Invoke-GitPull -Path $nonGitDir
 
                 # Results should be an array (possibly empty)
-                $result.Results.GetType().IsArray -or $result.Results.Count -eq 0 | Should -BeTrue
+                $result.Results.GetType().IsArray -or $result.Results.Count -eq 0 | Should-BeTruthy
             }
             finally
             {
@@ -255,7 +255,7 @@ Describe 'Invoke-GitPull' {
             {
                 $result = Invoke-GitPull -Path $emptyDir -Recurse
 
-                $result.RepositoriesProcessed | Should -Be 0
+                $result.RepositoriesProcessed | Should-Be 0
             }
             finally
             {
@@ -266,11 +266,11 @@ Describe 'Invoke-GitPull' {
 
     Context 'Branch Parameters' {
         It 'Should throw when -Branch and -DefaultBranch are both specified' {
-            { Invoke-GitPull -Branch 'main' -DefaultBranch } | Should -Throw '*Cannot use*'
+            { Invoke-GitPull -Branch 'main' -DefaultBranch } | Should-Throw '*Cannot use*'
         }
 
         It 'Should throw when -Checkout is used without -Branch or -DefaultBranch' {
-            { Invoke-GitPull -Checkout } | Should -Throw '*Checkout*requires*'
+            { Invoke-GitPull -Checkout } | Should-Throw '*Checkout*requires*'
         }
     }
 
@@ -282,7 +282,7 @@ Describe 'Invoke-GitPull' {
             # Re-dot-source the function to pick up the mock
             . "$PSScriptRoot/../../../Functions/Developer/Invoke-GitPull.ps1"
 
-            { Invoke-GitPull } | Should -Throw '*Git*not*'
+            { Invoke-GitPull } | Should-Throw '*Git*not*'
 
             # Restore the function
             . "$PSScriptRoot/../../../Functions/Developer/Invoke-GitPull.ps1"

--- a/Tests/Unit/Developer/Invoke-Magika.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-Magika.Tests.ps1
@@ -97,7 +97,7 @@ Describe 'Invoke-Magika' {
         It 'Throws when Docker is not installed' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Invoke-Magika -Path 'README.md' } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Invoke-Magika -Path 'README.md' } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
 
         It 'Throws when Docker daemon is not running' {
@@ -122,7 +122,7 @@ Describe 'Invoke-Magika' {
                 }
             }
 
-            { Invoke-Magika -Path 'README.md' } | Should -Throw '*daemon is not running*'
+            { Invoke-Magika -Path 'README.md' } | Should-Throw '*daemon is not running*'
 
             Remove-Item -Path Function:\pwshDockerTestShimDaemonDown -ErrorAction SilentlyContinue
         }
@@ -156,8 +156,8 @@ Describe 'Invoke-Magika' {
 
             Invoke-Magika -Path $script:SampleFile | Out-Null
 
-            $script:MagikaShimInvocations.Count | Should -Be 1
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 1
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
 
         It 'Skips Docker prerequisite checks when local Magika is available' {
@@ -171,7 +171,7 @@ Describe 'Invoke-Magika' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
             { Invoke-Magika -Path $script:SampleFile } | Should -Not -Throw
-            Should -Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
+            Should-Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
         }
 
         It 'Falls back to Docker when local Magika is not available' {
@@ -186,7 +186,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $script:MagikaShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 0
         }
 
         It 'Binds positional argument to Path' {
@@ -201,7 +201,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'sample.txt'
+            $runCall | Should-ContainCollection 'sample.txt'
         }
 
         It 'Uses Docker when Runtime is explicitly set to Docker' {
@@ -223,7 +223,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $script:MagikaShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 0
         }
 
         It 'Uses local Magika when Runtime is explicitly set to Local' {
@@ -238,8 +238,8 @@ Describe 'Invoke-Magika' {
 
             Invoke-Magika -Path $script:SampleFile -Runtime Local | Out-Null
 
-            $script:MagikaShimInvocations.Count | Should -Be 1
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 1
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
 
         It 'Passes --recursive to local Magika when Recurse is set' {
@@ -259,9 +259,9 @@ Describe 'Invoke-Magika' {
 
             Invoke-Magika -Path $script:SampleFile -Recurse | Out-Null
 
-            $script:MagikaShimInvocations.Count | Should -Be 1
-            $script:MagikaShimInvocations[0] | Should -Contain '--recursive'
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 1
+            $script:MagikaShimInvocations[0] | Should-ContainCollection '--recursive'
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
 
         It 'Passes translated --prediction-mode to local Magika when PredictionMode is set' {
@@ -281,10 +281,10 @@ Describe 'Invoke-Magika' {
 
             Invoke-Magika -Path $script:SampleFile -PredictionMode High | Out-Null
 
-            $script:MagikaShimInvocations.Count | Should -Be 1
-            $script:MagikaShimInvocations[0] | Should -Contain '--prediction-mode'
-            $script:MagikaShimInvocations[0] | Should -Contain 'HIGH_CONFIDENCE'
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 1
+            $script:MagikaShimInvocations[0] | Should-ContainCollection '--prediction-mode'
+            $script:MagikaShimInvocations[0] | Should-ContainCollection 'HIGH_CONFIDENCE'
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
 
         It 'Passes translated default --prediction-mode to local Magika when PredictionMode is omitted' {
@@ -304,10 +304,10 @@ Describe 'Invoke-Magika' {
 
             Invoke-Magika -Path $script:SampleFile | Out-Null
 
-            $script:MagikaShimInvocations.Count | Should -Be 1
-            $script:MagikaShimInvocations[0] | Should -Contain '--prediction-mode'
-            $script:MagikaShimInvocations[0] | Should -Contain 'HIGH_CONFIDENCE'
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 1
+            $script:MagikaShimInvocations[0] | Should-ContainCollection '--prediction-mode'
+            $script:MagikaShimInvocations[0] | Should-ContainCollection 'HIGH_CONFIDENCE'
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
 
         It 'Retries without --prediction-mode when local Magika runtime does not support it' {
@@ -328,40 +328,40 @@ Describe 'Invoke-Magika' {
             $script:MagikaShimRejectsPredictionMode = $true
 
             $result = @(Invoke-Magika -Path $script:SampleFile)
-            $result[-1] | Should -Be 0
+            $result[-1] | Should-Be 0
 
-            $script:MagikaShimInvocations.Count | Should -Be 2
-            $script:MagikaShimInvocations[0] | Should -Contain '--prediction-mode'
-            $script:MagikaShimInvocations[1] | Should -Not -Contain '--prediction-mode'
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:MagikaShimInvocations.Count | Should-Be 2
+            $script:MagikaShimInvocations[0] | Should-ContainCollection '--prediction-mode'
+            $script:MagikaShimInvocations[1] | Should-NotContainCollection '--prediction-mode'
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
     }
 
     Context 'Parameter validation' {
         It 'Rejects empty Path' {
-            { Invoke-Magika -Path '' } | Should -Throw
+            { Invoke-Magika -Path '' } | Should-Throw
         }
 
         It 'Rejects using Path and LiteralPath together' {
-            { Invoke-Magika -Path 'README.md' -LiteralPath 'README.md' } | Should -Throw
+            { Invoke-Magika -Path 'README.md' -LiteralPath 'README.md' } | Should-Throw
         }
 
         It 'Rejects empty ImageTag' {
-            { Invoke-Magika -Path 'README.md' -ImageTag '' } | Should -Throw
+            { Invoke-Magika -Path 'README.md' -ImageTag '' } | Should-Throw
         }
 
         It 'Rejects invalid Runtime' {
-            { Invoke-Magika -Path 'README.md' -Runtime 'Container' } | Should -Throw
+            { Invoke-Magika -Path 'README.md' -Runtime 'Container' } | Should-Throw
         }
 
         It 'Rejects invalid PredictionMode' {
-            { Invoke-Magika -Path 'README.md' -PredictionMode 'BEST_GUESS' } | Should -Throw
+            { Invoke-Magika -Path 'README.md' -PredictionMode 'BEST_GUESS' } | Should-Throw
         }
     }
 
     Context 'Explicit runtime prerequisites' {
         It 'Throws when Runtime is Local and local Magika is not installed' {
-            { Invoke-Magika -Path 'README.md' -Runtime Local } | Should -Throw 'Magika is not installed or not available in PATH. Install Magika or use -Runtime Docker.'
+            { Invoke-Magika -Path 'README.md' -Runtime Local } | Should-Throw 'Magika is not installed or not available in PATH. Install Magika or use -Runtime Docker.'
         }
 
         It 'Throws when Runtime is Docker and Docker is not installed even if local Magika is available' {
@@ -374,7 +374,7 @@ Describe 'Invoke-Magika' {
 
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Invoke-Magika -Path 'README.md' -Runtime Docker } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Invoke-Magika -Path 'README.md' -Runtime Docker } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
     }
 
@@ -402,8 +402,8 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '-i'
-            $runCall | Should -Contain '--rm'
+            $runCall | Should-ContainCollection '-i'
+            $runCall | Should-ContainCollection '--rm'
         }
 
         It 'Mounts the working directory as read-only /workspace volume' {
@@ -411,7 +411,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '-v'
+            $runCall | Should-ContainCollection '-v'
             $volArg = $runCall | Where-Object { $_ -match ':/workspace:ro$' }
             $volArg | Should -Not -BeNullOrEmpty
         }
@@ -421,8 +421,8 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '-w'
-            $runCall | Should -Contain '/workspace'
+            $runCall | Should-ContainCollection '-w'
+            $runCall | Should-ContainCollection '/workspace'
         }
 
         It 'Uses image entrypoint by default (no --entrypoint override)' {
@@ -430,7 +430,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Not -Contain '--entrypoint'
+            $runCall | Should-NotContainCollection '--entrypoint'
         }
 
         It 'Uses correct image reference with default tag' {
@@ -438,7 +438,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'jonlabelle/magika:latest'
+            $runCall | Should-ContainCollection 'jonlabelle/magika:latest'
         }
 
         It 'Uses correct image reference with custom tag' {
@@ -446,7 +446,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'jonlabelle/magika:0.6.0'
+            $runCall | Should-ContainCollection 'jonlabelle/magika:0.6.0'
         }
 
         It 'Appends additional arguments' {
@@ -454,7 +454,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--json'
+            $runCall | Should-ContainCollection '--json'
         }
 
         It 'Appends --recursive when Recurse is set' {
@@ -462,7 +462,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--recursive'
+            $runCall | Should-ContainCollection '--recursive'
         }
 
         It 'Appends translated --prediction-mode when PredictionMode is set' {
@@ -470,8 +470,8 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--prediction-mode'
-            $runCall | Should -Contain 'MEDIUM_CONFIDENCE'
+            $runCall | Should-ContainCollection '--prediction-mode'
+            $runCall | Should-ContainCollection 'MEDIUM_CONFIDENCE'
         }
 
         It 'Appends translated default --prediction-mode when PredictionMode is omitted' {
@@ -479,20 +479,20 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--prediction-mode'
-            $runCall | Should -Contain 'HIGH_CONFIDENCE'
+            $runCall | Should-ContainCollection '--prediction-mode'
+            $runCall | Should-ContainCollection 'HIGH_CONFIDENCE'
         }
 
         It 'Retries without --prediction-mode when Docker runtime does not support it' {
             $script:DockerShimRejectsPredictionMode = $true
 
             $result = @(Invoke-Magika -Path $script:SampleFile)
-            $result[-1] | Should -Be 0
+            $result[-1] | Should-Be 0
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 2
-            $runCalls[0] | Should -Contain '--prediction-mode'
-            $runCalls[1] | Should -Not -Contain '--prediction-mode'
+            $runCalls.Count | Should-Be 2
+            $runCalls[0] | Should-ContainCollection '--prediction-mode'
+            $runCalls[1] | Should-NotContainCollection '--prediction-mode'
         }
 
         It 'Warns when explicit PredictionMode is unsupported by Docker runtime' {
@@ -500,11 +500,11 @@ Describe 'Invoke-Magika' {
 
             $result = @(Invoke-Magika -Path $script:SampleFile -PredictionMode Medium 3>&1)
             $exitCode = $result | Where-Object { $_ -is [Int32] -or $_ -is [Int64] }
-            $exitCode | Should -Be 0
+            $exitCode | Should-Be 0
 
             $warnings = @($result | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
-            $warnings.Count | Should -BeGreaterThan 0
-            $warnings[0].Message | Should -BeLike '*does not support*--prediction-mode*'
+            $warnings.Count | Should-BeGreaterThan 0
+            $warnings[0].Message | Should-BeLikeString '*does not support*--prediction-mode*'
         }
 
         It 'Includes normalized relative path in docker args' {
@@ -512,7 +512,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'sample.txt'
+            $runCall | Should-ContainCollection 'sample.txt'
         }
 
         It 'Defaults to current directory when no path is provided' {
@@ -520,7 +520,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '.'
+            $runCall | Should-ContainCollection '.'
         }
 
         It 'Expands wildcard Path patterns to matching files' {
@@ -532,8 +532,8 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'a.txt'
-            $runCall | Should -Contain 'b.txt'
+            $runCall | Should-ContainCollection 'a.txt'
+            $runCall | Should-ContainCollection 'b.txt'
         }
 
         It 'Treats wildcard characters literally with LiteralPath' {
@@ -544,7 +544,7 @@ Describe 'Invoke-Magika' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain $specialName
+            $runCall | Should-ContainCollection $specialName
         }
     }
 
@@ -573,7 +573,7 @@ Describe 'Invoke-Magika' {
 
             try
             {
-                { Invoke-Magika -Path $outsideFile } | Should -Throw '*outside the current working directory*'
+                { Invoke-Magika -Path $outsideFile } | Should-Throw '*outside the current working directory*'
             }
             finally
             {
@@ -606,8 +606,8 @@ Describe 'Invoke-Magika' {
             {
                 { Invoke-Magika -Path $outsideFile } | Should -Not -Throw
 
-                $script:MagikaShimInvocations.Count | Should -Be 1
-                $script:MagikaShimInvocations[0] | Should -Contain $outsideFile
+                $script:MagikaShimInvocations.Count | Should-Be 1
+                $script:MagikaShimInvocations[0] | Should-ContainCollection $outsideFile
             }
             finally
             {
@@ -641,7 +641,7 @@ Describe 'Invoke-Magika' {
         It 'Returns exit code 0 on success' {
             $result = @(Invoke-Magika -Path $script:SampleFile)
 
-            $result[-1] | Should -Be 0
+            $result[-1] | Should-Be 0
         }
 
         It 'Returns non-zero exit code on failure and writes warning' {
@@ -674,11 +674,11 @@ Describe 'Invoke-Magika' {
             $result = @(Invoke-Magika -Path $script:SampleFile 3>&1)
 
             $exitCode = $result | Where-Object { $_ -is [Int32] -or $_ -is [Int64] }
-            $exitCode | Should -Be 2
+            $exitCode | Should-Be 2
 
             $warnings = @($result | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
-            $warnings.Count | Should -BeGreaterThan 0
-            $warnings[0].Message | Should -BeLike '*Magika failed*'
+            $warnings.Count | Should-BeGreaterThan 0
+            $warnings[0].Message | Should-BeLikeString '*Magika failed*'
 
             Remove-Item -Path Function:\pwshDockerTestShimFail -ErrorAction SilentlyContinue
         }
@@ -706,7 +706,7 @@ Describe 'Invoke-Magika' {
             Get-ChildItem -Path $script:TestDir -Filter '*.txt' | Invoke-Magika | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 1
+            $runCalls.Count | Should-Be 1
         }
 
         It 'Processes multiple files from pipeline' {
@@ -716,7 +716,7 @@ Describe 'Invoke-Magika' {
             Get-ChildItem -Path $script:TestDir -Filter '*.txt' | Invoke-Magika | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 2
+            $runCalls.Count | Should-Be 2
         }
     }
 }

--- a/Tests/Unit/Developer/Invoke-SqlFluff.Tests.ps1
+++ b/Tests/Unit/Developer/Invoke-SqlFluff.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Invoke-SqlFluff' {
         It 'Throws when Docker is not installed' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Invoke-SqlFluff -Mode lint -Path 'test.sql' } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Invoke-SqlFluff -Mode lint -Path 'test.sql' } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
 
         It 'Throws when Docker daemon is not running' {
@@ -106,7 +106,7 @@ Describe 'Invoke-SqlFluff' {
                 }
             }
 
-            { Invoke-SqlFluff -Mode lint -Path 'test.sql' } | Should -Throw '*daemon is not running*'
+            { Invoke-SqlFluff -Mode lint -Path 'test.sql' } | Should-Throw '*daemon is not running*'
 
             Remove-Item -Path Function:\pwshDockerTestShimDaemonDown -ErrorAction SilentlyContinue
         }
@@ -140,8 +140,8 @@ Describe 'Invoke-SqlFluff' {
 
             Invoke-SqlFluff -Mode lint -Path $script:SqlFile | Out-Null
 
-            $script:SqlFluffShimInvocations.Count | Should -Be 1
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:SqlFluffShimInvocations.Count | Should-Be 1
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
 
         It 'Skips Docker prerequisite checks when local SQLFluff is available' {
@@ -155,7 +155,7 @@ Describe 'Invoke-SqlFluff' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
             { Invoke-SqlFluff -Mode lint -Path $script:SqlFile } | Should -Not -Throw
-            Should -Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
+            Should-Invoke -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -Times 0 -Exactly
         }
 
         It 'Falls back to Docker when local SQLFluff is not available' {
@@ -170,7 +170,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $script:SqlFluffShimInvocations.Count | Should -Be 0
+            $script:SqlFluffShimInvocations.Count | Should-Be 0
         }
 
         It 'Uses Docker when Runtime is explicitly set to Docker' {
@@ -192,7 +192,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $script:SqlFluffShimInvocations.Count | Should -Be 0
+            $script:SqlFluffShimInvocations.Count | Should-Be 0
         }
 
         It 'Uses local SQLFluff when Runtime is explicitly set to Local' {
@@ -207,8 +207,8 @@ Describe 'Invoke-SqlFluff' {
 
             Invoke-SqlFluff -Mode lint -Path $script:SqlFile -Runtime Local | Out-Null
 
-            $script:SqlFluffShimInvocations.Count | Should -Be 1
-            $script:DockerShimInvocations.Count | Should -Be 0
+            $script:SqlFluffShimInvocations.Count | Should-Be 1
+            $script:DockerShimInvocations.Count | Should-Be 0
         }
     }
 
@@ -218,7 +218,7 @@ Describe 'Invoke-SqlFluff' {
             @{ Value = 'analyze' }
             @{ Value = '' }
         ) {
-            { Invoke-SqlFluff -Mode $Value -Path 'test.sql' } | Should -Throw
+            { Invoke-SqlFluff -Mode $Value -Path 'test.sql' } | Should-Throw
         }
 
         It 'Accepts valid Mode "<Value>"' -ForEach @(
@@ -248,25 +248,25 @@ Describe 'Invoke-SqlFluff' {
         }
 
         It 'Rejects empty Path' {
-            { Invoke-SqlFluff -Mode lint -Path '' } | Should -Throw
+            { Invoke-SqlFluff -Mode lint -Path '' } | Should-Throw
         }
 
         It 'Rejects using Path and LiteralPath together' {
-            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -LiteralPath 'test.sql' } | Should -Throw
+            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -LiteralPath 'test.sql' } | Should-Throw
         }
 
         It 'Rejects empty ImageTag' {
-            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -ImageTag '' } | Should -Throw
+            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -ImageTag '' } | Should-Throw
         }
 
         It 'Rejects invalid Runtime' {
-            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -Runtime 'Container' } | Should -Throw
+            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -Runtime 'Container' } | Should-Throw
         }
     }
 
     Context 'Explicit runtime prerequisites' {
         It 'Throws when Runtime is Local and local SQLFluff is not installed' {
-            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -Runtime Local } | Should -Throw 'SQLFluff is not installed or not available in PATH. Install SQLFluff or use -Runtime Docker.'
+            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -Runtime Local } | Should-Throw 'SQLFluff is not installed or not available in PATH. Install SQLFluff or use -Runtime Docker.'
         }
 
         It 'Throws when Runtime is Docker and Docker is not installed even if local SQLFluff is available' {
@@ -279,7 +279,7 @@ Describe 'Invoke-SqlFluff' {
 
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -Runtime Docker } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Invoke-SqlFluff -Mode lint -Path 'test.sql' -Runtime Docker } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
     }
 
@@ -312,7 +312,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain $Mode
+            $runCall | Should-ContainCollection $Mode
         }
 
         It 'Uses -i and --rm flags for docker run' {
@@ -320,8 +320,8 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '-i'
-            $runCall | Should -Contain '--rm'
+            $runCall | Should-ContainCollection '-i'
+            $runCall | Should-ContainCollection '--rm'
         }
 
         It 'Mounts the working directory as /sql volume' {
@@ -329,7 +329,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '-v'
+            $runCall | Should-ContainCollection '-v'
             $volArg = $runCall | Where-Object { $_ -match ':/sql$' }
             $volArg | Should -Not -BeNullOrEmpty
         }
@@ -339,7 +339,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'sqlfluff/sqlfluff:latest'
+            $runCall | Should-ContainCollection 'sqlfluff/sqlfluff:latest'
         }
 
         It 'Uses correct image reference with custom tag' {
@@ -347,7 +347,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'sqlfluff/sqlfluff:3.0.0'
+            $runCall | Should-ContainCollection 'sqlfluff/sqlfluff:3.0.0'
         }
 
         It 'Passes --dialect with the correct value' {
@@ -355,8 +355,8 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--dialect'
-            $runCall | Should -Contain 'tsql'
+            $runCall | Should-ContainCollection '--dialect'
+            $runCall | Should-ContainCollection 'tsql'
         }
 
         It 'Defaults to --dialect ansi when no config file and no dialect are provided' {
@@ -373,8 +373,8 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--dialect'
-            $runCall | Should -Contain 'ansi'
+            $runCall | Should-ContainCollection '--dialect'
+            $runCall | Should-ContainCollection 'ansi'
         }
 
         It 'Appends additional arguments' {
@@ -382,8 +382,8 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--exclude-rules'
-            $runCall | Should -Contain 'LT01'
+            $runCall | Should-ContainCollection '--exclude-rules'
+            $runCall | Should-ContainCollection 'LT01'
         }
 
         It 'Includes relative SQL file path in docker args' {
@@ -391,7 +391,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain 'query.sql'
+            $runCall | Should-ContainCollection 'query.sql'
         }
     }
 
@@ -422,8 +422,8 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain '--config'
-            $runCall | Should -Contain '/config/.sqlfluff'
+            $runCall | Should-ContainCollection '--config'
+            $runCall | Should-ContainCollection '/config/.sqlfluff'
 
             # Verify the volume mount for the config file
             $volArgs = @()
@@ -446,17 +446,17 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Not -Contain '--dialect'
+            $runCall | Should-NotContainCollection '--dialect'
         }
 
         It 'Throws when explicitly specified config file does not exist' {
-            { Invoke-SqlFluff -Mode lint -Path $script:SqlFile -ConfigPath '/nonexistent/.sqlfluff' } | Should -Throw 'Config file not found*'
+            { Invoke-SqlFluff -Mode lint -Path $script:SqlFile -ConfigPath '/nonexistent/.sqlfluff' } | Should-Throw 'Config file not found*'
         }
 
         It 'Throws when explicitly specified config path does not exist' {
             $missingConfig = Join-Path -Path $script:TestDir -ChildPath 'no-such-dir/.sqlfluff'
 
-            { Invoke-SqlFluff -Mode lint -Path $script:SqlFile -ConfigPath $missingConfig } | Should -Throw 'Config file not found*'
+            { Invoke-SqlFluff -Mode lint -Path $script:SqlFile -ConfigPath $missingConfig } | Should-Throw 'Config file not found*'
         }
 
         It 'Runs without --config when default config is not found' {
@@ -479,7 +479,7 @@ Describe 'Invoke-SqlFluff' {
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             if ($runCall)
             {
-                $runCall | Should -Not -Contain '--config'
+                $runCall | Should-NotContainCollection '--config'
             }
         }
     }
@@ -507,7 +507,7 @@ Describe 'Invoke-SqlFluff' {
             Invoke-SqlFluff -Mode lint | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 2
+            $runCalls.Count | Should-Be 2
         }
 
         It 'Warns when no *.sql files are found in working directory' {
@@ -515,8 +515,8 @@ Describe 'Invoke-SqlFluff' {
             $result = Invoke-SqlFluff -Mode lint 3>&1
 
             $warnings = @($result | Where-Object { $_ -is [System.Management.Automation.WarningRecord] })
-            $warnings.Count | Should -BeGreaterThan 0
-            $warnings[0].Message | Should -BeLike '*No *.sql files found*'
+            $warnings.Count | Should-BeGreaterThan 0
+            $warnings[0].Message | Should-BeLikeString '*No *.sql files found*'
         }
 
         It 'Expands directories to contained *.sql files' {
@@ -527,7 +527,7 @@ Describe 'Invoke-SqlFluff' {
             Invoke-SqlFluff -Mode lint -Path $subDir | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 1
+            $runCalls.Count | Should-Be 1
         }
 
         It 'Discovers files recursively with -Recurse' {
@@ -539,7 +539,7 @@ Describe 'Invoke-SqlFluff' {
             Invoke-SqlFluff -Mode lint -Recurse | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 2
+            $runCalls.Count | Should-Be 2
         }
 
         It 'Expands wildcard Path patterns to matching SQL files' {
@@ -550,7 +550,7 @@ Describe 'Invoke-SqlFluff' {
             Invoke-SqlFluff -Mode lint -Path '*.sql' | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 2
+            $runCalls.Count | Should-Be 2
         }
 
         It 'Expands wildcard Path patterns recursively with -Recurse' {
@@ -562,7 +562,7 @@ Describe 'Invoke-SqlFluff' {
             Invoke-SqlFluff -Mode lint -Path '*.sql' -Recurse | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 2
+            $runCalls.Count | Should-Be 2
         }
 
         It 'Treats wildcard characters literally with LiteralPath' {
@@ -573,7 +573,7 @@ Describe 'Invoke-SqlFluff' {
 
             $runCall = $script:DockerShimInvocations | Where-Object { $_ -contains 'run' } | Select-Object -First 1
             $runCall | Should -Not -BeNullOrEmpty
-            $runCall | Should -Contain $specialName
+            $runCall | Should-ContainCollection $specialName
         }
     }
 
@@ -599,7 +599,7 @@ Describe 'Invoke-SqlFluff' {
         It 'Returns exit code 0 on success' {
             $result = @(Invoke-SqlFluff -Mode lint -Path $script:SqlFile)
 
-            $result[-1] | Should -Be 0
+            $result[-1] | Should-Be 0
         }
 
         It 'Returns non-zero exit code on lint violations and writes warning' {
@@ -632,7 +632,7 @@ Describe 'Invoke-SqlFluff' {
             $result = @(Invoke-SqlFluff -Mode lint -Path $script:SqlFile 3>&1)
 
             $exitCode = $result | Where-Object { $_ -is [Int32] -or $_ -is [Int64] }
-            $exitCode | Should -Be 1
+            $exitCode | Should-Be 1
 
             Remove-Item -Path Function:\pwshDockerTestShimFail -ErrorAction SilentlyContinue
         }
@@ -675,7 +675,7 @@ Describe 'Invoke-SqlFluff' {
             Invoke-SqlFluff -Mode lint -Path $script:SqlFile | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 1
+            $runCalls.Count | Should-Be 1
         }
     }
 
@@ -701,7 +701,7 @@ Describe 'Invoke-SqlFluff' {
             Get-ChildItem -Path $script:TestDir -Filter '*.sql' | Invoke-SqlFluff -Mode lint | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 1
+            $runCalls.Count | Should-Be 1
         }
 
         It 'Processes multiple files from pipeline' {
@@ -711,7 +711,7 @@ Describe 'Invoke-SqlFluff' {
             Get-ChildItem -Path $script:TestDir -Filter '*.sql' | Invoke-SqlFluff -Mode lint | Out-Null
 
             $runCalls = @($script:DockerShimInvocations | Where-Object { $_ -contains 'run' })
-            $runCalls.Count | Should -Be 2
+            $runCalls.Count | Should-Be 2
         }
     }
 }

--- a/Tests/Unit/Developer/Remove-DockerArtifact.Tests.ps1
+++ b/Tests/Unit/Developer/Remove-DockerArtifact.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Remove-DockerArtifact' {
         It 'Throws when Docker is not available' -Skip:(-not $script:dockerAvailable) {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Remove-DockerArtifact } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Remove-DockerArtifact } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
     }
 
@@ -54,16 +54,16 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact
 
-            $result.ContainersPruned | Should -BeFalse
-            $result.VolumesPruned | Should -BeFalse
-            $result.BuildHistoryPruned | Should -BeFalse
-            $result.ImageMode | Should -Be 'AllUnused'
-            $result.TotalSpaceFreed | Should -Be '650.00 MB'
+            $result.ContainersPruned | Should-BeFalsy
+            $result.VolumesPruned | Should-BeFalsy
+            $result.BuildHistoryPruned | Should-BeFalsy
+            $result.ImageMode | Should-Be 'AllUnused'
+            $result.TotalSpaceFreed | Should-Be '650.00 MB'
 
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
         }
 
         It 'Uses docker system prune when stopped containers are included' -Skip:(-not $script:dockerAvailable) {
@@ -71,17 +71,17 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact -IncludeStoppedContainers -IncludeVolumes
 
-            $result.ContainersPruned | Should -BeTrue
-            $result.VolumesPruned | Should -BeTrue
-            $result.BuildHistoryPruned | Should -BeFalse
-            $result.TotalSpaceFreed | Should -Be '2.00 GB'
+            $result.ContainersPruned | Should-BeTruthy
+            $result.VolumesPruned | Should-BeTruthy
+            $result.BuildHistoryPruned | Should-BeFalsy
+            $result.TotalSpaceFreed | Should-Be '2.00 GB'
 
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
         }
 
         It 'Uses all cleanup categories when -All is specified' -Skip:(-not $script:dockerAvailable) {
@@ -91,22 +91,22 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact -All
 
-            $result.ContainersPruned | Should -BeTrue
-            $result.VolumesPruned | Should -BeTrue
-            $result.BuildHistoryPruned | Should -BeTrue
-            $result.TotalSpaceFreed | Should -Be '2.00 GB'
+            $result.ContainersPruned | Should-BeTruthy
+            $result.VolumesPruned | Should-BeTruthy
+            $result.BuildHistoryPruned | Should-BeTruthy
+            $result.TotalSpaceFreed | Should-Be '2.00 GB'
 
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 1
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 1
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 1
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 1
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 1
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'volume' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
 
         It 'Throws when -All and -DanglingImagesOnly are used together' -Skip:(-not $script:dockerAvailable) {
-            { Remove-DockerArtifact -All -DanglingImagesOnly } | Should -Throw 'The -All and -DanglingImagesOnly parameters cannot be used together.'
+            { Remove-DockerArtifact -All -DanglingImagesOnly } | Should-Throw 'The -All and -DanglingImagesOnly parameters cannot be used together.'
         }
 
         It 'Prunes Docker Desktop build history when requested' -Skip:(-not $script:dockerAvailable) {
@@ -118,10 +118,10 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact -IncludeBuildHistory
 
-            $result.BuildHistoryPruned | Should -BeTrue
-            $result.TotalSpaceFreed | Should -Be '200.00 MB'
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' -and $args -contains '--all' } -Times 1
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' -and $args -contains '--all' } -Times 1
+            $result.BuildHistoryPruned | Should-BeTruthy
+            $result.TotalSpaceFreed | Should-Be '200.00 MB'
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' -and $args -contains '--all' } -Times 1
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' -and $args -contains '--all' } -Times 1
         }
 
         It 'Respects -DanglingImagesOnly for targeted prunes' -Skip:(-not $script:dockerAvailable) {
@@ -131,8 +131,8 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact -DanglingImagesOnly
 
-            $result.ImageMode | Should -Be 'DanglingOnly'
-            Should -Invoke -CommandName docker -ParameterFilter { $args -contains '--all' } -Times 0 -Exactly
+            $result.ImageMode | Should-Be 'DanglingOnly'
+            Should-Invoke -CommandName docker -ParameterFilter { $args -contains '--all' } -Times 0 -Exactly
         }
 
         It 'Honors -WhatIf and does not invoke Docker commands' -Skip:(-not $script:dockerAvailable) {
@@ -147,13 +147,13 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact -IncludeStoppedContainers -IncludeBuildHistory -WhatIf
 
-            $result.TotalSpaceFreed | Should -Be '0 bytes'
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            $result.TotalSpaceFreed | Should-Be '0 bytes'
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'network' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'builder' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'history' -and $args[2] -eq 'rm' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'buildx' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'system' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
     }
 
@@ -182,8 +182,8 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact
 
-            $result.TotalSpaceFreed | Should -Be '1.20 GB'
-            $result.EstimatedReclaimable | Should -Be 'Not calculated (use -WhatIf to preview)'
+            $result.TotalSpaceFreed | Should-Be '1.20 GB'
+            $result.EstimatedReclaimable | Should-Be 'Not calculated (use -WhatIf to preview)'
         }
 
         It 'Estimates reclaimable space from unused images when no preview is available' -Skip:(-not $script:dockerAvailable) {
@@ -196,8 +196,8 @@ Describe 'Remove-DockerArtifact' {
 
             $result = Remove-DockerArtifact -WhatIf
 
-            $result.EstimatedReclaimable | Should -Be '400.00 MB'
-            $result.TotalSpaceFreed | Should -Be '0 bytes'
+            $result.EstimatedReclaimable | Should-Be '400.00 MB'
+            $result.TotalSpaceFreed | Should-Be '0 bytes'
         }
     }
 }

--- a/Tests/Unit/Developer/Remove-PythonArtifact.Tests.ps1
+++ b/Tests/Unit/Developer/Remove-PythonArtifact.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Remove-PythonArtifact' {
 
     Context 'Parameter validation' {
         It 'Should throw when Path is empty' {
-            { Remove-PythonArtifact -Path '' } | Should -Throw
+            { Remove-PythonArtifact -Path '' } | Should-Throw
         }
 
         It 'Should write an error for a non-existent path' {
@@ -52,8 +52,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
-            $result.DirsRemoved | Should -Be 1
+            Test-Path -Path $dir.FullName | Should-BeFalsy
+            $result.DirsRemoved | Should-Be 1
         }
 
         It 'Should remove .pytest_cache directory' {
@@ -61,8 +61,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
-            $result.DirsRemoved | Should -Be 1
+            Test-Path -Path $dir.FullName | Should-BeFalsy
+            $result.DirsRemoved | Should-Be 1
         }
 
         It 'Should remove .mypy_cache directory' {
@@ -70,7 +70,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove .ruff_cache directory' {
@@ -78,7 +78,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove .venv directory' {
@@ -86,7 +86,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove venv directory' {
@@ -94,7 +94,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove .tox directory' {
@@ -102,7 +102,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove .nox directory' {
@@ -110,7 +110,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove htmlcov directory' {
@@ -118,7 +118,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove dist directory' {
@@ -126,7 +126,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove build directory' {
@@ -134,7 +134,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
+            Test-Path -Path $dir.FullName | Should-BeFalsy
         }
 
         It 'Should remove *.egg-info directories' {
@@ -142,8 +142,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            Test-Path -Path $dir.FullName | Should -BeFalse
-            $result.DirsRemoved | Should -Be 1
+            Test-Path -Path $dir.FullName | Should-BeFalsy
+            $result.DirsRemoved | Should-Be 1
         }
 
         It 'Should remove multiple artifact directories and count them correctly' {
@@ -153,7 +153,7 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            $result.DirsRemoved | Should -Be 3
+            $result.DirsRemoved | Should-Be 3
         }
 
         It 'Should not remove non-artifact directories' {
@@ -161,7 +161,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $srcDir.FullName | Should -BeTrue
+            Test-Path -Path $srcDir.FullName | Should-BeTruthy
         }
     }
 
@@ -171,8 +171,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            Test-Path -Path $file.FullName | Should -BeFalse
-            $result.FilesRemoved | Should -Be 1
+            Test-Path -Path $file.FullName | Should-BeFalsy
+            $result.FilesRemoved | Should-Be 1
         }
 
         It 'Should remove .pyo files' {
@@ -180,7 +180,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $file.FullName | Should -BeFalse
+            Test-Path -Path $file.FullName | Should-BeFalsy
         }
 
         It 'Should remove .coverage file' {
@@ -188,7 +188,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $file.FullName | Should -BeFalse
+            Test-Path -Path $file.FullName | Should-BeFalsy
         }
 
         It 'Should remove .coverage.* parallel-mode files' {
@@ -196,7 +196,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $file.FullName | Should -BeFalse
+            Test-Path -Path $file.FullName | Should-BeFalsy
         }
 
         It 'Should remove coverage.xml file' {
@@ -204,7 +204,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $file.FullName | Should -BeFalse
+            Test-Path -Path $file.FullName | Should-BeFalsy
         }
 
         It 'Should remove .pdm-python file' {
@@ -212,7 +212,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $file.FullName | Should -BeFalse
+            Test-Path -Path $file.FullName | Should-BeFalsy
         }
 
         It 'Should not remove non-artifact Python source files' {
@@ -220,7 +220,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $file.FullName | Should -BeTrue
+            Test-Path -Path $file.FullName | Should-BeTruthy
         }
 
         It 'Should remove both artifact directories and files in the same run' {
@@ -229,8 +229,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            $result.DirsRemoved | Should -Be 1
-            $result.FilesRemoved | Should -Be 1
+            $result.DirsRemoved | Should-Be 1
+            $result.FilesRemoved | Should-Be 1
         }
     }
 
@@ -241,7 +241,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot | Out-Null
 
-            Test-Path -Path $nestedCache.FullName | Should -BeTrue
+            Test-Path -Path $nestedCache.FullName | Should-BeTruthy
         }
 
         It 'Should remove nested artifacts with -Recurse' {
@@ -250,8 +250,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot -Recurse
 
-            Test-Path -Path $nestedCache.FullName | Should -BeFalse
-            $result.DirsRemoved | Should -Be 1
+            Test-Path -Path $nestedCache.FullName | Should-BeFalsy
+            $result.DirsRemoved | Should-Be 1
         }
 
         It 'Should remove nested artifact files with -Recurse' {
@@ -260,8 +260,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot -Recurse
 
-            Test-Path -Path $nestedFile.FullName | Should -BeFalse
-            $result.FilesRemoved | Should -Be 1
+            Test-Path -Path $nestedFile.FullName | Should-BeFalsy
+            $result.FilesRemoved | Should-Be 1
         }
 
         It 'Should not recurse into artifact directories' {
@@ -272,8 +272,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot -Recurse
 
-            Test-Path -Path $cacheDir.FullName | Should -BeFalse
-            $result.DirsRemoved | Should -Be 1
+            Test-Path -Path $cacheDir.FullName | Should-BeFalsy
+            $result.DirsRemoved | Should-Be 1
         }
 
         It 'Should preserve non-artifact parent directories when recursing' {
@@ -282,7 +282,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot -Recurse | Out-Null
 
-            Test-Path -Path $subDir.FullName | Should -BeTrue
+            Test-Path -Path $subDir.FullName | Should-BeTruthy
         }
     }
 
@@ -292,7 +292,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot -WhatIf | Out-Null
 
-            Test-Path -Path $dir.FullName | Should -BeTrue
+            Test-Path -Path $dir.FullName | Should-BeTruthy
         }
 
         It 'Should not remove files when -WhatIf is specified' {
@@ -300,7 +300,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot -WhatIf | Out-Null
 
-            Test-Path -Path $file.FullName | Should -BeTrue
+            Test-Path -Path $file.FullName | Should-BeTruthy
         }
 
         It 'Should report zero removals when -WhatIf is specified' {
@@ -309,8 +309,8 @@ Describe 'Remove-PythonArtifact' {
 
             $result = Remove-PythonArtifact -Path $script:TestRoot -WhatIf
 
-            $result.DirsRemoved | Should -Be 0
-            $result.FilesRemoved | Should -Be 0
+            $result.DirsRemoved | Should-Be 0
+            $result.FilesRemoved | Should-Be 0
         }
     }
 
@@ -321,7 +321,7 @@ Describe 'Remove-PythonArtifact' {
 
             Remove-PythonArtifact -Path $script:TestRoot -Recurse -ExcludeDirectory @('vendor') | Out-Null
 
-            Test-Path -Path $nestedCache.FullName | Should -BeTrue
+            Test-Path -Path $nestedCache.FullName | Should-BeTruthy
         }
     }
 
@@ -330,30 +330,30 @@ Describe 'Remove-PythonArtifact' {
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
             $result | Should -Not -BeNullOrEmpty
-            $result.PSObject.Properties.Name | Should -Contain 'DirsRemoved'
-            $result.PSObject.Properties.Name | Should -Contain 'FilesRemoved'
-            $result.PSObject.Properties.Name | Should -Contain 'TotalSpaceFreed'
-            $result.PSObject.Properties.Name | Should -Contain 'Errors'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'DirsRemoved'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FilesRemoved'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'TotalSpaceFreed'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Errors'
         }
 
         It 'Should report zero removals for a directory with no artifacts' {
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            $result.DirsRemoved | Should -Be 0
-            $result.FilesRemoved | Should -Be 0
-            $result.Errors | Should -Be 0
+            $result.DirsRemoved | Should-Be 0
+            $result.FilesRemoved | Should-Be 0
+            $result.Errors | Should-Be 0
         }
 
         It 'Should report TotalSpaceFreed as a string when -NoSizeCalculation is specified' {
             $result = Remove-PythonArtifact -Path $script:TestRoot -NoSizeCalculation
 
-            $result.TotalSpaceFreed | Should -Be 'Not calculated (use without -NoSizeCalculation for details)'
+            $result.TotalSpaceFreed | Should-Be 'Not calculated (use without -NoSizeCalculation for details)'
         }
 
         It 'Should report TotalSpaceFreed as bytes string when no artifacts removed' {
             $result = Remove-PythonArtifact -Path $script:TestRoot
 
-            $result.TotalSpaceFreed | Should -Be '0 bytes'
+            $result.TotalSpaceFreed | Should-Be '0 bytes'
         }
     }
 }

--- a/Tests/Unit/Developer/Update-DockerImage.Tests.ps1
+++ b/Tests/Unit/Developer/Update-DockerImage.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Update-DockerImage' {
         It 'Throws when Docker is not available' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'docker' } -MockWith { $null }
 
-            { Update-DockerImage } | Should -Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
+            { Update-DockerImage } | Should-Throw 'Docker is not installed or not available in PATH. Please install Docker and try again.'
         }
     }
 
@@ -56,9 +56,9 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.Eligible | Should -Be 1
-            $result.Results.Count | Should -Be 1
-            $result.Results[0].Image | Should -Be 'nginx:latest'
+            $result.Eligible | Should-Be 1
+            $result.Results.Count | Should-Be 1
+            $result.Results[0].Image | Should-Be 'nginx:latest'
         }
 
         It 'Skips images with <none> tag' -Skip:(-not $script:dockerAvailable) {
@@ -72,8 +72,8 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.Eligible | Should -Be 1
-            $result.Results[0].Image | Should -Be 'alpine:3.18'
+            $result.Eligible | Should-Be 1
+            $result.Results[0].Image | Should-Be 'alpine:3.18'
         }
 
         It 'Deduplicates images with the same Repository:Tag' -Skip:(-not $script:dockerAvailable) {
@@ -88,7 +88,7 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.Eligible | Should -Be 2
+            $result.Eligible | Should-Be 2
         }
 
         It 'Applies -Filter to select matching images only' -Skip:(-not $script:dockerAvailable) {
@@ -103,8 +103,8 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage -Filter 'mcr.microsoft.com/*'
 
-            $result.Eligible | Should -Be 2
-            $result.Results | ForEach-Object { $_.Image | Should -BeLike 'mcr.microsoft.com/*' }
+            $result.Eligible | Should-Be 2
+            $result.Results | ForEach-Object { $_.Image | Should-BeLikeString 'mcr.microsoft.com/*' }
         }
 
         It 'Applies -ExcludeFilter to skip matching images' -Skip:(-not $script:dockerAvailable) {
@@ -119,8 +119,8 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage -ExcludeFilter '*dev*'
 
-            $result.Eligible | Should -Be 2
-            $result.Results | ForEach-Object { $_.Image | Should -Not -BeLike '*dev*' }
+            $result.Eligible | Should-Be 2
+            $result.Results | ForEach-Object { $_.Image | Should-NotBeLikeString '*dev*' }
         }
     }
 
@@ -153,11 +153,11 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.Updated | Should -Be 1
-            $result.Failed | Should -Be 0
-            $result.Results[0].Status | Should -Be 'Success'
-            $result.Results[0].Message | Should -Be 'Updated'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*nginx:latest*' } -Times 1
+            $result.Updated | Should-Be 1
+            $result.Failed | Should-Be 0
+            $result.Results[0].Status | Should-Be 'Success'
+            $result.Results[0].Message | Should-Be 'Updated'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*nginx:latest*' } -Times 1
         }
 
         It 'Detects already up-to-date images' -Skip:(-not $script:dockerAvailable) {
@@ -172,9 +172,9 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.Updated | Should -Be 1
-            $result.Results[0].Status | Should -Be 'Success'
-            $result.Results[0].Message | Should -Be 'Already up to date'
+            $result.Updated | Should-Be 1
+            $result.Results[0].Status | Should-Be 'Success'
+            $result.Results[0].Message | Should-Be 'Already up to date'
         }
 
         It 'Reports failure when pull fails' -Skip:(-not $script:dockerAvailable) {
@@ -188,8 +188,8 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.Failed | Should -Be 1
-            $result.Results[0].Status | Should -Be 'Failed'
+            $result.Failed | Should-Be 1
+            $result.Results[0].Status | Should-Be 'Failed'
         }
 
         It 'Returns correct summary counts' -Skip:(-not $script:dockerAvailable) {
@@ -204,11 +204,11 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.TotalImages | Should -Be 3
-            $result.Eligible | Should -Be 2
-            $result.Updated | Should -Be 2
-            $result.Skipped | Should -Be 1
-            $result.Failed | Should -Be 0
+            $result.TotalImages | Should-Be 3
+            $result.Eligible | Should-Be 2
+            $result.Updated | Should-Be 2
+            $result.Skipped | Should-Be 1
+            $result.Failed | Should-Be 0
         }
 
         It 'Returns empty results when no images exist' -Skip:(-not $script:dockerAvailable) {
@@ -216,11 +216,11 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.TotalImages | Should -Be 0
-            $result.Eligible | Should -Be 0
-            $result.Updated | Should -Be 0
-            $result.Failed | Should -Be 0
-            $result.Results.Count | Should -Be 0
+            $result.TotalImages | Should-Be 0
+            $result.Eligible | Should-Be 0
+            $result.Updated | Should-Be 0
+            $result.Failed | Should-Be 0
+            $result.Results.Count | Should-Be 0
         }
     }
 
@@ -258,11 +258,11 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage -PruneDanglingImages
 
-            $result.DanglingPruneRequested | Should -BeTrue
-            $result.DanglingPruneSucceeded | Should -BeTrue
+            $result.DanglingPruneRequested | Should-BeTruthy
+            $result.DanglingPruneSucceeded | Should-BeTruthy
             $result.DanglingPruneError | Should -BeNullOrEmpty
 
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' -and $args -contains '--force' } -Times 1
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' -and $args -contains '--force' } -Times 1
         }
 
         It 'Does not prune dangling images by default' -Skip:(-not $script:dockerAvailable) {
@@ -280,11 +280,11 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage
 
-            $result.DanglingPruneRequested | Should -BeFalse
-            $result.DanglingPruneSucceeded | Should -BeFalse
-            $result.DanglingPruneError | Should -Be $null
+            $result.DanglingPruneRequested | Should-BeFalsy
+            $result.DanglingPruneSucceeded | Should-BeFalsy
+            $result.DanglingPruneError | Should-Be $null
 
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
 
         It 'Honors -WhatIf and skips dangling prune' -Skip:(-not $script:dockerAvailable) {
@@ -301,12 +301,12 @@ Describe 'Update-DockerImage' {
 
             $result = Update-DockerImage -PruneDanglingImages -WhatIf
 
-            $result.DanglingPruneRequested | Should -BeTrue
-            $result.DanglingPruneSucceeded | Should -BeFalse
-            $result.DanglingPruneError | Should -Be $null
+            $result.DanglingPruneRequested | Should-BeTruthy
+            $result.DanglingPruneSucceeded | Should-BeFalsy
+            $result.DanglingPruneError | Should-Be $null
 
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'pull' } -Times 0 -Exactly
-            Should -Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'pull' } -Times 0 -Exactly
+            Should-Invoke -CommandName docker -ParameterFilter { $args[0] -eq 'image' -and $args[1] -eq 'prune' } -Times 0 -Exactly
         }
     }
 }

--- a/Tests/Unit/Developer/Update-DotNetTool.Tests.ps1
+++ b/Tests/Unit/Developer/Update-DotNetTool.Tests.ps1
@@ -130,7 +130,7 @@ Describe 'Update-DotNetTool' {
         It 'Throws when dotnet is not available' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'dotnet' } -MockWith { $null }
 
-            { Update-DotNetTool -Path $script:TestDir } | Should -Throw 'dotnet CLI is not installed or not available in PATH. Install the .NET SDK and try again.'
+            { Update-DotNetTool -Path $script:TestDir } | Should-Throw 'dotnet CLI is not installed or not available in PATH. Install the .NET SDK and try again.'
         }
     }
 
@@ -143,19 +143,19 @@ Describe 'Update-DotNetTool' {
 
             $result = Update-DotNetTool -Path $script:TestDir
 
-            $result.Scope | Should -Be 'Local'
-            $result.ManifestPath | Should -Be $manifestPath
-            $result.ToolsFound | Should -Be 1
-            $result.Updated | Should -Be 1
+            $result.Scope | Should-Be 'Local'
+            $result.ManifestPath | Should-Be $manifestPath
+            $result.ToolsFound | Should-Be 1
+            $result.Updated | Should-Be 1
 
             $listCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'list' } | Select-Object -First 1
             $updateCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Select-Object -First 1
 
-            $listCall | Should -Contain '--local'
-            $updateCall | Should -Contain '--local'
-            $updateCall | Should -Contain '--tool-manifest'
-            $updateCall | Should -Contain $manifestPath
-            $updateCall | Should -Not -Contain '--global'
+            $listCall | Should-ContainCollection '--local'
+            $updateCall | Should-ContainCollection '--local'
+            $updateCall | Should-ContainCollection '--tool-manifest'
+            $updateCall | Should-ContainCollection $manifestPath
+            $updateCall | Should-NotContainCollection '--global'
         }
 
         It 'Finds a local manifest in a parent directory' {
@@ -168,25 +168,25 @@ Describe 'Update-DotNetTool' {
 
             $result = Update-DotNetTool -Path $childDir
 
-            $result.Scope | Should -Be 'Local'
-            $result.ManifestPath | Should -Be $manifestPath
-            $result.WorkingDirectory | Should -Be $childDir
+            $result.Scope | Should-Be 'Local'
+            $result.ManifestPath | Should-Be $manifestPath
+            $result.WorkingDirectory | Should-Be $childDir
         }
 
         It 'Updates global tools when no local manifest exists' {
             $result = Update-DotNetTool -Path $script:TestDir
 
-            $result.Scope | Should -Be 'Global'
+            $result.Scope | Should-Be 'Global'
             $result.ManifestPath | Should -BeNullOrEmpty
-            $result.ToolsFound | Should -Be 1
-            $result.Updated | Should -Be 1
+            $result.ToolsFound | Should-Be 1
+            $result.Updated | Should-Be 1
 
             $listCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'list' } | Select-Object -First 1
             $updateCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Select-Object -First 1
 
-            $listCall | Should -Contain '--global'
-            $updateCall | Should -Contain '--global'
-            $updateCall | Should -Not -Contain '--local'
+            $listCall | Should-ContainCollection '--global'
+            $updateCall | Should-ContainCollection '--global'
+            $updateCall | Should-NotContainCollection '--local'
         }
 
         It 'Uses global tools when global scope is explicitly requested and a local manifest exists' {
@@ -196,16 +196,16 @@ Describe 'Update-DotNetTool' {
 
             $result = Update-DotNetTool -Path $script:TestDir -Scope Global
 
-            $result.Scope | Should -Be 'Global'
+            $result.Scope | Should-Be 'Global'
             $result.ManifestPath | Should -BeNullOrEmpty
 
             $updateCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Select-Object -First 1
-            $updateCall | Should -Contain '--global'
-            $updateCall | Should -Not -Contain '--local'
+            $updateCall | Should-ContainCollection '--global'
+            $updateCall | Should-NotContainCollection '--local'
         }
 
         It 'Writes an error when local scope is requested without a local manifest' {
-            { Update-DotNetTool -Path $script:TestDir -Scope Local -ErrorAction Stop } | Should -Throw
+            { Update-DotNetTool -Path $script:TestDir -Scope Local -ErrorAction Stop } | Should-Throw
         }
     }
 
@@ -215,11 +215,11 @@ Describe 'Update-DotNetTool' {
 
             $result = Update-DotNetTool -Path $script:TestDir
 
-            $result.ToolsFound | Should -Be 0
-            $result.Updated | Should -Be 0
-            $result.Failed | Should -Be 0
+            $result.ToolsFound | Should-Be 0
+            $result.Updated | Should-Be 0
+            $result.Failed | Should-Be 0
             $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Should -BeNullOrEmpty
-            Should -Invoke -CommandName Write-Host -ParameterFilter {
+            Should-Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'No .NET global tools found to update.'
             } -Times 1
         }
@@ -229,15 +229,15 @@ Describe 'Update-DotNetTool' {
 
             $result = Update-DotNetTool -Path $script:TestDir
 
-            $result.ToolsFound | Should -Be 2
-            $result.Updated | Should -Be 2
-            $result.Failed | Should -Be 0
+            $result.ToolsFound | Should-Be 2
+            $result.Updated | Should-Be 2
+            $result.Failed | Should-Be 0
 
             $updateCalls = @($script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' })
-            $updateCalls.Count | Should -Be 2
-            ($updateCalls | ForEach-Object { $_[2] }) | Should -Contain 'dotnetsay'
-            ($updateCalls | ForEach-Object { $_[2] }) | Should -Contain 'csharpier'
-            Should -Invoke -CommandName Write-Host -ParameterFilter {
+            $updateCalls.Count | Should-Be 2
+            ($updateCalls | ForEach-Object { $_[2] }) | Should-ContainCollection 'dotnetsay'
+            ($updateCalls | ForEach-Object { $_[2] }) | Should-ContainCollection 'csharpier'
+            Should-Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'Updated 2 of 2 .NET global tool(s).'
             } -Times 1
         }
@@ -251,13 +251,13 @@ Describe 'Update-DotNetTool' {
 
             $result = Update-DotNetTool -Path $script:TestDir -WarningAction SilentlyContinue
 
-            $result.ToolsFound | Should -Be 2
-            $result.Updated | Should -Be 1
-            $result.Failed | Should -Be 1
-            $result.ExitCode | Should -Be 1
+            $result.ToolsFound | Should-Be 2
+            $result.Updated | Should-Be 1
+            $result.Failed | Should-Be 1
+            $result.ExitCode | Should-Be 1
 
-            ($result.Results | Where-Object { $_.PackageId -eq 'dotnetsay' }).Status | Should -Be 'Failed'
-            ($result.Results | Where-Object { $_.PackageId -eq 'csharpier' }).Status | Should -Be 'Success'
+            ($result.Results | Where-Object { $_.PackageId -eq 'dotnetsay' }).Status | Should-Be 'Failed'
+            ($result.Results | Where-Object { $_.PackageId -eq 'csharpier' }).Status | Should-Be 'Success'
         }
 
         It 'Passes update options through to dotnet' {
@@ -265,15 +265,15 @@ Describe 'Update-DotNetTool' {
 
             $updateCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Select-Object -First 1
 
-            $updateCall | Should -Contain '--prerelease'
-            $updateCall | Should -Contain '--interactive'
-            $updateCall | Should -Contain '--ignore-failed-sources'
-            $updateCall | Should -Contain '--no-http-cache'
-            $updateCall | Should -Contain '--disable-parallel'
-            $updateCall | Should -Contain '--framework'
-            $updateCall | Should -Contain 'net8.0'
-            $updateCall | Should -Contain '--verbosity'
-            $updateCall | Should -Contain 'minimal'
+            $updateCall | Should-ContainCollection '--prerelease'
+            $updateCall | Should-ContainCollection '--interactive'
+            $updateCall | Should-ContainCollection '--ignore-failed-sources'
+            $updateCall | Should-ContainCollection '--no-http-cache'
+            $updateCall | Should-ContainCollection '--disable-parallel'
+            $updateCall | Should-ContainCollection '--framework'
+            $updateCall | Should-ContainCollection 'net8.0'
+            $updateCall | Should-ContainCollection '--verbosity'
+            $updateCall | Should-ContainCollection 'minimal'
         }
 
         It 'Falls back to table output when JSON list parsing fails' {
@@ -285,8 +285,8 @@ Describe 'Update-DotNetTool' {
 
             $result = Update-DotNetTool -Path $script:TestDir
 
-            $result.ToolsFound | Should -Be 1
-            $result.Results[0].PackageId | Should -Be 'dotnetsay'
+            $result.ToolsFound | Should-Be 1
+            $result.Results[0].PackageId | Should-Be 'dotnetsay'
         }
     }
 
@@ -296,8 +296,8 @@ Describe 'Update-DotNetTool' {
 
             $result = @(Update-DotNetTool -Path $script:TestDir -Scope Global -ListOutdated)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter {
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'No .NET global tools found to check.'
             } -Times 1
         }
@@ -319,11 +319,11 @@ Describe 'Update-DotNetTool' {
 
             $result = @(Update-DotNetTool -Path $script:TestDir -Scope Global -ListOutdated)
 
-            $result.Count | Should -Be 1
-            $result[0].Scope | Should -Be 'Global'
-            $result[0].PackageId | Should -Be 'csharpier'
-            $result[0].CurrentVersion | Should -Be '1.2.5'
-            $result[0].LatestVersion | Should -Be '1.2.6'
+            $result.Count | Should-Be 1
+            $result[0].Scope | Should-Be 'Global'
+            $result[0].PackageId | Should-Be 'csharpier'
+            $result[0].CurrentVersion | Should-Be '1.2.5'
+            $result[0].LatestVersion | Should-Be '1.2.6'
             $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Should -BeNullOrEmpty
         }
 
@@ -342,20 +342,20 @@ Describe 'Update-DotNetTool' {
 
             $result = @(Update-DotNetTool -Path $script:TestDir -Scope Local -ListOutdated)
 
-            $result.Count | Should -Be 1
-            $result[0].Scope | Should -Be 'Local'
-            $result[0].ManifestPath | Should -Be $manifestPath
-            $result[0].PackageId | Should -Be 'dotnetsay'
+            $result.Count | Should-Be 1
+            $result[0].Scope | Should-Be 'Local'
+            $result[0].ManifestPath | Should-Be $manifestPath
+            $result[0].PackageId | Should-Be 'dotnetsay'
 
             $listCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'list' } | Select-Object -First 1
-            $listCall | Should -Contain '--local'
+            $listCall | Should-ContainCollection '--local'
         }
 
         It 'Passes prerelease through to dotnet tool search in list-outdated mode' {
             $null = Update-DotNetTool -Path $script:TestDir -Scope Global -ListOutdated -Prerelease
 
             $searchCall = $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'search' } | Select-Object -First 1
-            $searchCall | Should -Contain '--prerelease'
+            $searchCall | Should-ContainCollection '--prerelease'
         }
 
         It 'Writes a message when no outdated tools are found' {
@@ -369,8 +369,8 @@ Describe 'Update-DotNetTool' {
 
             $result = @(Update-DotNetTool -Path $script:TestDir -Scope Global -ListOutdated)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter {
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter {
                 $Object -eq 'No outdated .NET global tools found.'
             } -Times 1
         }
@@ -391,11 +391,11 @@ Describe 'Update-DotNetTool' {
 
             $result = @(Update-DotNetTool -Path $script:TestDir -Scope Global -ListOutdated -WarningAction Stop)
 
-            $result.Count | Should -Be 1
-            $result[0].PackageId | Should -Be 'csharpier'
-            $result[0].CurrentVersion | Should -Be '1.2.5'
-            $result[0].LatestVersion | Should -Be '1.2.6'
-            Should -Invoke -CommandName Invoke-RestMethod -ParameterFilter {
+            $result.Count | Should-Be 1
+            $result[0].PackageId | Should-Be 'csharpier'
+            $result[0].CurrentVersion | Should-Be '1.2.5'
+            $result[0].LatestVersion | Should-Be '1.2.6'
+            Should-Invoke -CommandName Invoke-RestMethod -ParameterFilter {
                 $Uri -eq 'https://api.nuget.org/v3-flatcontainer/csharpier/index.json'
             } -Times 1
         }
@@ -405,17 +405,17 @@ Describe 'Update-DotNetTool' {
         It 'Skips update commands when WhatIf is specified' {
             $result = Update-DotNetTool -Path $script:TestDir -WhatIf
 
-            $result.ToolsFound | Should -Be 1
-            $result.Updated | Should -Be 0
-            $result.Skipped | Should -Be 1
-            $result.Results[0].Status | Should -Be 'Skipped'
+            $result.ToolsFound | Should-Be 1
+            $result.Updated | Should-Be 0
+            $result.Skipped | Should-Be 1
+            $result.Results[0].Status | Should-Be 'Skipped'
             $script:DotNetInvocations | Where-Object { $_[0] -eq 'tool' -and $_[1] -eq 'update' } | Should -BeNullOrEmpty
         }
 
         It 'Writes an error for an invalid path' {
             $missingPath = Join-Path -Path $script:TestDir -ChildPath 'missing'
 
-            { Update-DotNetTool -Path $missingPath -ErrorAction Stop } | Should -Throw
+            { Update-DotNetTool -Path $missingPath -ErrorAction Stop } | Should-Throw
         }
     }
 }

--- a/Tests/Unit/Invoke-DockerTests.Tests.ps1
+++ b/Tests/Unit/Invoke-DockerTests.Tests.ps1
@@ -96,37 +96,37 @@ Describe 'Invoke-DockerTests.ps1' -Tag 'Unit' {
 
     It 'passes timing summary options through to Invoke-Tests.ps1' {
         $output = & $script:PowerShellExecutable -NoProfile -File $script:FakeProject.InvokeDockerTestsPath -TestType Unit -OutputFormat Normal -ShowTimingSummary -TimingSummaryTop 5 -TimingSummaryTitle 'Docker timings' -TimingSummaryOutputPath 'docker-timings.md' 2>&1
-        $LASTEXITCODE | Should -Be 0
-        ($output -join [Environment]::NewLine) | Should -Match '=== Running PSScriptAnalyzer ==='
-        ($output -join [Environment]::NewLine) | Should -Match '=== Running Pester tests ==='
+        $LASTEXITCODE | Should-Be 0
+        ($output -join [Environment]::NewLine) | Should-MatchString '=== Running PSScriptAnalyzer ==='
+        ($output -join [Environment]::NewLine) | Should-MatchString '=== Running Pester tests ==='
 
         $invokeTestsRecord = Get-Content -LiteralPath $script:FakeProject.InvokeTestsRecordPath -Raw | ConvertFrom-Json
-        $invokeTestsRecord.TestType | Should -Be 'Unit'
-        $invokeTestsRecord.OutputFormat | Should -Be 'Normal'
-        $invokeTestsRecord.ShowTimingSummary | Should -BeTrue
-        $invokeTestsRecord.TimingSummaryTop | Should -Be 5
-        $invokeTestsRecord.TimingSummaryTitle | Should -Be 'Docker timings'
-        $invokeTestsRecord.TimingSummaryOutputPath | Should -Be 'docker-timings.md'
-        $invokeTestsRecord.WorkingDirectory | Should -Be $script:FakeProject.RootPath
+        $invokeTestsRecord.TestType | Should-Be 'Unit'
+        $invokeTestsRecord.OutputFormat | Should-Be 'Normal'
+        $invokeTestsRecord.ShowTimingSummary | Should-BeTruthy
+        $invokeTestsRecord.TimingSummaryTop | Should-Be 5
+        $invokeTestsRecord.TimingSummaryTitle | Should-Be 'Docker timings'
+        $invokeTestsRecord.TimingSummaryOutputPath | Should-Be 'docker-timings.md'
+        $invokeTestsRecord.WorkingDirectory | Should-Be $script:FakeProject.RootPath
     }
 
     It 'keeps the timing summary disabled by default' {
         $null = & $script:PowerShellExecutable -NoProfile -File $script:FakeProject.InvokeDockerTestsPath
-        $LASTEXITCODE | Should -Be 0
+        $LASTEXITCODE | Should-Be 0
 
         $invokeTestsRecord = Get-Content -LiteralPath $script:FakeProject.InvokeTestsRecordPath -Raw | ConvertFrom-Json
-        $invokeTestsRecord.TestType | Should -Be 'All'
-        $invokeTestsRecord.OutputFormat | Should -Be 'Detailed'
-        $invokeTestsRecord.ShowTimingSummary | Should -BeFalse
-        $invokeTestsRecord.TimingSummaryTop | Should -Be 10
-        $invokeTestsRecord.TimingSummaryTitle | Should -Be 'Pester timing summary'
-        $invokeTestsRecord.TimingSummaryOutputPath | Should -Be ''
+        $invokeTestsRecord.TestType | Should-Be 'All'
+        $invokeTestsRecord.OutputFormat | Should-Be 'Detailed'
+        $invokeTestsRecord.ShowTimingSummary | Should-BeFalsy
+        $invokeTestsRecord.TimingSummaryTop | Should-Be 10
+        $invokeTestsRecord.TimingSummaryTitle | Should-Be 'Pester timing summary'
+        $invokeTestsRecord.TimingSummaryOutputPath | Should-Be ''
     }
 
     It 'propagates the Invoke-Tests.ps1 exit code' {
         $env:FAKE_INVOKE_TESTS_EXIT_CODE = '7'
 
         $null = & $script:PowerShellExecutable -NoProfile -File $script:FakeProject.InvokeDockerTestsPath
-        $LASTEXITCODE | Should -Be 7
+        $LASTEXITCODE | Should-Be 7
     }
 }

--- a/Tests/Unit/Invoke-Tests.Tests.ps1
+++ b/Tests/Unit/Invoke-Tests.Tests.ps1
@@ -160,16 +160,16 @@ Describe 'Invoke-Tests.ps1 timing summary' -Tag 'Unit' {
         $env:PSModulePath = $script:FakeProject.ModuleRootPath
 
         $null = & $script:PowerShellExecutable -NoProfile -File $script:FakeProject.InvokeTestsPath -TestType Unit -OutputFormat Normal -ShowTimingSummary -TimingSummaryTop 1 -TimingSummaryTitle 'Local timings' -TimingSummaryOutputPath $summaryPath
-        $LASTEXITCODE | Should -Be 0
+        $LASTEXITCODE | Should-Be 0
 
-        Test-Path -LiteralPath $summaryPath | Should -BeTrue
+        Test-Path -LiteralPath $summaryPath | Should-BeTruthy
         $summary = Get-Content -LiteralPath $summaryPath -Raw
-        $summary | Should -Match '### Local timings'
-        $summary | Should -Match '#### Slowest test files \(top 1\)'
-        $summary | Should -Match 'Tests/Unit/Slow.Tests.ps1'
-        $summary | Should -Not -Match 'Tests/Unit/Fast.Tests.ps1'
-        $summary | Should -Match 'Slow case'
-        $summary | Should -Not -Match 'Fast case'
+        $summary | Should-MatchString '### Local timings'
+        $summary | Should-MatchString '#### Slowest test files \(top 1\)'
+        $summary | Should-MatchString 'Tests/Unit/Slow.Tests.ps1'
+        $summary | Should-NotMatchString 'Tests/Unit/Fast.Tests.ps1'
+        $summary | Should-MatchString 'Slow case'
+        $summary | Should-NotMatchString 'Fast case'
     }
 
     It 'does not write a timing summary unless ShowTimingSummary is specified' {
@@ -177,9 +177,9 @@ Describe 'Invoke-Tests.ps1 timing summary' -Tag 'Unit' {
         $env:PSModulePath = $script:FakeProject.ModuleRootPath
 
         $null = & $script:PowerShellExecutable -NoProfile -File $script:FakeProject.InvokeTestsPath -TestType Unit -OutputFormat Normal -TimingSummaryOutputPath $summaryPath
-        $LASTEXITCODE | Should -Be 0
+        $LASTEXITCODE | Should-Be 0
 
-        Test-Path -LiteralPath $summaryPath | Should -BeFalse
+        Test-Path -LiteralPath $summaryPath | Should-BeFalsy
     }
 
     It 'uses the latest installed Pester 6 version and ignores Pester 7' {
@@ -195,9 +195,9 @@ Describe 'Invoke-Tests.ps1 timing summary' -Tag 'Unit' {
         try
         {
             $null = & $script:PowerShellExecutable -NoProfile -File $script:FakeProject.InvokeTestsPath -TestType Unit -OutputFormat Normal
-            $LASTEXITCODE | Should -Be 0
+            $LASTEXITCODE | Should-Be 0
 
-            (Get-Content -LiteralPath $versionOutputPath -Raw).Trim() | Should -Be '6.99.0'
+            (Get-Content -LiteralPath $versionOutputPath -Raw).Trim() | Should-Be '6.99.0'
         }
         finally
         {

--- a/Tests/Unit/MediaProcessing/Get-ImageMetadata.Tests.ps1
+++ b/Tests/Unit/MediaProcessing/Get-ImageMetadata.Tests.ps1
@@ -46,47 +46,47 @@ Describe 'Get-ImageMetadata' -Tag 'Unit' {
     Context 'Parameter Validation' {
         It 'Should have Recurse parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('Recurse') | Should -Be $true
+            $command.Parameters.ContainsKey('Recurse') | Should-Be $true
         }
 
         It 'Should have Exclude parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('Exclude') | Should -Be $true
+            $command.Parameters.ContainsKey('Exclude') | Should-Be $true
         }
 
         It 'Should have Filter parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('Filter') | Should -Be $true
+            $command.Parameters.ContainsKey('Filter') | Should-Be $true
         }
 
         It 'Should have ExifToolPath parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('ExifToolPath') | Should -Be $true
+            $command.Parameters.ContainsKey('ExifToolPath') | Should-Be $true
         }
 
         It 'Should have Tag parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('Tag') | Should -Be $true
+            $command.Parameters.ContainsKey('Tag') | Should-Be $true
         }
 
         It 'Should have Flatten parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('Flatten') | Should -Be $true
+            $command.Parameters.ContainsKey('Flatten') | Should-Be $true
         }
 
         It 'Should have NoEmptyProperties parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('NoEmptyProperties') | Should -Be $true
+            $command.Parameters.ContainsKey('NoEmptyProperties') | Should-Be $true
         }
 
         It 'Should have Numeric parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('Numeric') | Should -Be $true
+            $command.Parameters.ContainsKey('Numeric') | Should-Be $true
         }
 
         It 'Should have IncludeRawExifToolData parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters.ContainsKey('IncludeRawExifToolData') | Should -Be $true
+            $command.Parameters.ContainsKey('IncludeRawExifToolData') | Should-Be $true
         }
 
         It 'Should accept Path parameter from pipeline and by property name' {
@@ -102,46 +102,46 @@ Describe 'Get-ImageMetadata' -Tag 'Unit' {
             $command = Get-Command Get-ImageMetadata
             $aliases = $command.Parameters['Path'].Aliases
 
-            $aliases | Should -Contain 'FilePath'
-            $aliases | Should -Contain 'FullName'
-            $aliases | Should -Contain 'Directory'
+            $aliases | Should-ContainCollection 'FilePath'
+            $aliases | Should-ContainCollection 'FullName'
+            $aliases | Should-ContainCollection 'Directory'
         }
 
         It 'Should include Tags alias for Tag' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters['Tag'].Aliases | Should -Contain 'Tags'
+            $command.Parameters['Tag'].Aliases | Should-ContainCollection 'Tags'
         }
     }
 
     Context 'Parameter Types' {
         It 'Should have Recurse as Switch parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters['Recurse'].ParameterType.Name | Should -Be 'SwitchParameter'
+            $command.Parameters['Recurse'].ParameterType.Name | Should-Be 'SwitchParameter'
         }
 
         It 'Should have Exclude as String array parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters['Exclude'].ParameterType.Name | Should -Be 'String[]'
+            $command.Parameters['Exclude'].ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have Filter as String array parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters['Filter'].ParameterType.Name | Should -Be 'String[]'
+            $command.Parameters['Filter'].ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have Tag as String array parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters['Tag'].ParameterType.Name | Should -Be 'String[]'
+            $command.Parameters['Tag'].ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have Flatten as Switch parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters['Flatten'].ParameterType.Name | Should -Be 'SwitchParameter'
+            $command.Parameters['Flatten'].ParameterType.Name | Should-Be 'SwitchParameter'
         }
 
         It 'Should have Numeric as Switch parameter' {
             $command = Get-Command Get-ImageMetadata
-            $command.Parameters['Numeric'].ParameterType.Name | Should -Be 'SwitchParameter'
+            $command.Parameters['Numeric'].ParameterType.Name | Should-Be 'SwitchParameter'
         }
     }
 
@@ -160,11 +160,11 @@ Describe 'Get-ImageMetadata' -Tag 'Unit' {
             }
 
             $exception | Should -Not -BeNullOrEmpty
-            $exception.Message | Should -BeLike '*Install-PlatformPackage.ps1*'
-            $exception.Message | Should -Not -BeLike '*. ./Functions/SystemAdministration/Install-PlatformPackage.ps1*'
-            $exception.Message | Should -Not -BeLike '*-PackageManager*'
-            $exception.Message | Should -Not -BeLike '*-Id*'
-            $exception.Message | Should -Match '(-Name OliverBetz\.ExifTool|-Name exiftool|-Name libimage-exiftool-perl)'
+            $exception.Message | Should-BeLikeString '*Install-PlatformPackage.ps1*'
+            $exception.Message | Should-NotBeLikeString '*. ./Functions/SystemAdministration/Install-PlatformPackage.ps1*'
+            $exception.Message | Should-NotBeLikeString '*-PackageManager*'
+            $exception.Message | Should-NotBeLikeString '*-Id*'
+            $exception.Message | Should-MatchString '(-Name OliverBetz\.ExifTool|-Name exiftool|-Name libimage-exiftool-perl)'
         }
     }
 
@@ -190,36 +190,36 @@ Describe 'Get-ImageMetadata' -Tag 'Unit' {
         It 'Should inspect image files non-recursively by default' {
             $results = @(Get-ImageMetadata -Path $script:TestRoot -ExifToolPath $script:FakeExifTool.Path)
 
-            $results.Count | Should -Be 2
-            $results.Name | Should -Contain 'photo1.jpg'
-            $results.Name | Should -Contain 'photo2.png'
-            $results.Name | Should -Not -Contain 'photo3.jpg'
-            $results.Name | Should -Not -Contain 'notes.txt'
+            $results.Count | Should-Be 2
+            $results.Name | Should-ContainCollection 'photo1.jpg'
+            $results.Name | Should-ContainCollection 'photo2.png'
+            $results.Name | Should-NotContainCollection 'photo3.jpg'
+            $results.Name | Should-NotContainCollection 'notes.txt'
         }
 
         It 'Should inspect recursively when -Recurse is specified' {
             $results = @(Get-ImageMetadata -Path $script:TestRoot -Recurse -ExifToolPath $script:FakeExifTool.Path)
 
-            $results.Name | Should -Contain 'photo1.jpg'
-            $results.Name | Should -Contain 'photo2.png'
-            $results.Name | Should -Contain 'photo3.jpg'
-            $results.Name | Should -Not -Contain 'hidden.jpg'
+            $results.Name | Should-ContainCollection 'photo1.jpg'
+            $results.Name | Should-ContainCollection 'photo2.png'
+            $results.Name | Should-ContainCollection 'photo3.jpg'
+            $results.Name | Should-NotContainCollection 'hidden.jpg'
         }
 
         It 'Should respect Exclude parameter when using -Recurse' {
             $results = @(Get-ImageMetadata -Path $script:TestRoot -Recurse -Exclude @('.git', 'SubDirectory') -ExifToolPath $script:FakeExifTool.Path)
 
-            $results.Name | Should -Contain 'photo1.jpg'
-            $results.Name | Should -Contain 'photo2.png'
-            $results.Name | Should -Not -Contain 'photo3.jpg'
-            $results.Name | Should -Not -Contain 'hidden.jpg'
+            $results.Name | Should-ContainCollection 'photo1.jpg'
+            $results.Name | Should-ContainCollection 'photo2.png'
+            $results.Name | Should-NotContainCollection 'photo3.jpg'
+            $results.Name | Should-NotContainCollection 'hidden.jpg'
         }
 
         It 'Should honor custom Filter' {
             $results = @(Get-ImageMetadata -Path $script:TestRoot -Filter '*.png' -ExifToolPath $script:FakeExifTool.Path)
 
-            $results.Count | Should -Be 1
-            $results.Name | Should -Contain 'photo2.png'
+            $results.Count | Should-Be 1
+            $results.Name | Should-ContainCollection 'photo2.png'
         }
     }
 
@@ -240,14 +240,14 @@ Describe 'Get-ImageMetadata' -Tag 'Unit' {
         It 'Should accept an individual image file path' {
             $result = @(Get-ImageMetadata -Path $script:TestImageFile -ExifToolPath $script:FakeExifTool.Path)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'single-photo.jpg'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'single-photo.jpg'
         }
 
         It 'Should warn when an individual file does not match supported filters' {
             $result = @(Get-ImageMetadata -Path $script:TestNonImageFile -ExifToolPath $script:FakeExifTool.Path -WarningAction SilentlyContinue -WarningVariable warnings)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
             $warnings | Should -Not -BeNullOrEmpty
         }
 
@@ -256,15 +256,15 @@ Describe 'Get-ImageMetadata' -Tag 'Unit' {
 
             $null = Get-ImageMetadata -Path $missingPath -ExifToolPath $script:FakeExifTool.Path -ErrorAction SilentlyContinue -ErrorVariable errors
 
-            $errors.Count | Should -BeGreaterThan 0
-            $errors[0].Exception.Message | Should -BeLike '*not found*'
+            $errors.Count | Should-BeGreaterThan 0
+            $errors[0].Exception.Message | Should-BeLikeString '*not found*'
         }
 
         It 'Should accept image files from the pipeline' {
             $result = @(Get-Item -LiteralPath $script:TestImageFile | Get-ImageMetadata -ExifToolPath $script:FakeExifTool.Path)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'single-photo.jpg'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'single-photo.jpg'
         }
     }
 
@@ -283,49 +283,49 @@ Describe 'Get-ImageMetadata' -Tag 'Unit' {
             $result = Get-ImageMetadata -Path $script:SampleImage -ExifToolPath $script:FakeExifTool.Path
 
             $loggedArgs = Get-Content -LiteralPath $script:FakeExifTool.LogPath
-            $loggedArgs | Should -Contain '-j'
-            $loggedArgs | Should -Contain '-a'
-            $loggedArgs | Should -Contain '-G1'
-            $loggedArgs | Should -Contain '-struct'
-            $loggedArgs | Should -Contain '-all:all'
-            $loggedArgs | Should -Contain $script:SampleImage
-            $result.Metadata.Keys | Should -Contain 'EXIF:Make'
-            $result.Metadata['EXIF:Make'] | Should -Be 'Test Camera'
-            $result.MetadataTags | Should -Contain 'EXIF:Make'
-            $result.MetadataTags | Should -Contain 'XMP:Title'
-            $result.TagCount | Should -Be $result.MetadataTags.Count
+            $loggedArgs | Should-ContainCollection '-j'
+            $loggedArgs | Should-ContainCollection '-a'
+            $loggedArgs | Should-ContainCollection '-G1'
+            $loggedArgs | Should-ContainCollection '-struct'
+            $loggedArgs | Should-ContainCollection '-all:all'
+            $loggedArgs | Should-ContainCollection $script:SampleImage
+            $result.Metadata.Keys | Should-ContainCollection 'EXIF:Make'
+            $result.Metadata['EXIF:Make'] | Should-Be 'Test Camera'
+            $result.MetadataTags | Should-ContainCollection 'EXIF:Make'
+            $result.MetadataTags | Should-ContainCollection 'XMP:Title'
+            $result.TagCount | Should-Be $result.MetadataTags.Count
         }
 
         It 'Should call ExifTool with selected tags and numeric output' {
             $result = Get-ImageMetadata -Path $script:SampleImage -Tag 'EXIF:Make', 'GPS:all' -Numeric -NoEmptyProperties -IncludeRawExifToolData -ExifToolPath $script:FakeExifTool.Path
 
             $loggedArgs = Get-Content -LiteralPath $script:FakeExifTool.LogPath
-            $loggedArgs | Should -Contain '-EXIF:Make'
-            $loggedArgs | Should -Contain '-GPS:all'
-            $loggedArgs | Should -Contain '-n'
-            $loggedArgs | Should -Not -Contain '-all:all'
-            $result.Metadata.Keys | Should -Contain 'EXIF:Make'
-            $result.Metadata.Keys | Should -Not -Contain 'EXIF:Model'
-            $result.RawExifToolData.PSObject.Properties.Name | Should -Contain 'EXIF:Make'
+            $loggedArgs | Should-ContainCollection '-EXIF:Make'
+            $loggedArgs | Should-ContainCollection '-GPS:all'
+            $loggedArgs | Should-ContainCollection '-n'
+            $loggedArgs | Should-NotContainCollection '-all:all'
+            $result.Metadata.Keys | Should-ContainCollection 'EXIF:Make'
+            $result.Metadata.Keys | Should-NotContainCollection 'EXIF:Model'
+            $result.RawExifToolData.PSObject.Properties.Name | Should-ContainCollection 'EXIF:Make'
         }
 
         It 'Should not add a second dash to tag arguments that already include one' {
             $null = Get-ImageMetadata -Path $script:SampleImage -Tag '-DateTimeOriginal' -ExifToolPath $script:FakeExifTool.Path
 
             $loggedArgs = Get-Content -LiteralPath $script:FakeExifTool.LogPath
-            $loggedArgs | Should -Contain '-DateTimeOriginal'
-            $loggedArgs | Should -Not -Contain '--DateTimeOriginal'
+            $loggedArgs | Should-ContainCollection '-DateTimeOriginal'
+            $loggedArgs | Should-NotContainCollection '--DateTimeOriginal'
         }
 
         It 'Should return flattened metadata rows when Flatten is specified' {
             $rows = @(Get-ImageMetadata -Path $script:SampleImage -Flatten -NoEmptyProperties -ExifToolPath $script:FakeExifTool.Path)
             $makeRow = $rows | Where-Object { $_.MetadataName -eq 'EXIF:Make' }
 
-            $rows.MetadataName | Should -Contain 'EXIF:Make'
-            $rows.MetadataName | Should -Not -Contain 'EXIF:Model'
-            $makeRow.Group | Should -Be 'EXIF'
-            $makeRow.Tag | Should -Be 'Make'
-            $makeRow.Value | Should -Be 'Test Camera'
+            $rows.MetadataName | Should-ContainCollection 'EXIF:Make'
+            $rows.MetadataName | Should-NotContainCollection 'EXIF:Model'
+            $makeRow.Group | Should-Be 'EXIF'
+            $makeRow.Tag | Should-Be 'Make'
+            $makeRow.Value | Should-Be 'Test Camera'
         }
     }
 }

--- a/Tests/Unit/MediaProcessing/Get-MediaInfo.Tests.ps1
+++ b/Tests/Unit/MediaProcessing/Get-MediaInfo.Tests.ps1
@@ -12,28 +12,28 @@ Describe 'Get-MediaInfo' -Tag 'Unit' {
     Context 'Parameter Validation' {
         It 'Should have Recurse parameter' {
             $command = Get-Command Get-MediaInfo
-            $command.Parameters.ContainsKey('Recurse') | Should -Be $true
+            $command.Parameters.ContainsKey('Recurse') | Should-Be $true
         }
 
         It 'Should not have NoRecursion parameter' {
             $command = Get-Command Get-MediaInfo
-            $command.Parameters.ContainsKey('NoRecursion') | Should -Be $false
+            $command.Parameters.ContainsKey('NoRecursion') | Should-Be $false
         }
 
         It 'Should have Exclude parameter' {
             $command = Get-Command Get-MediaInfo
-            $command.Parameters.ContainsKey('Exclude') | Should -Be $true
+            $command.Parameters.ContainsKey('Exclude') | Should-Be $true
         }
 
         It 'Should have Filter parameter' {
             $command = Get-Command Get-MediaInfo
-            $command.Parameters.ContainsKey('Filter') | Should -Be $true
+            $command.Parameters.ContainsKey('Filter') | Should-Be $true
         }
 
         It 'Should have default Path value' {
             $command = Get-Command Get-MediaInfo
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Where({$_ -is [System.Management.Automation.ParameterAttribute]})[0].Mandatory | Should -Be $false
+            $pathParam.Attributes.Where({$_ -is [System.Management.Automation.ParameterAttribute]})[0].Mandatory | Should-Be $false
         }
     }
 
@@ -42,13 +42,13 @@ Describe 'Get-MediaInfo' -Tag 'Unit' {
             $command = Get-Command Get-MediaInfo
             $excludeParam = $command.Parameters['Exclude']
             # The default value should be set in the param block
-            $excludeParam.ParameterType.Name | Should -Be 'String[]'
+            $excludeParam.ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have Filter as String array parameter' {
             $command = Get-Command Get-MediaInfo
             $filterParam = $command.Parameters['Filter']
-            $filterParam.ParameterType.Name | Should -Be 'String[]'
+            $filterParam.ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should default Filter to the supported media file patterns' {
@@ -68,7 +68,7 @@ Describe 'Get-MediaInfo' -Tag 'Unit' {
 
             foreach ($filter in $expectedFilters)
             {
-                $defaultValueText | Should -Match ([regex]::Escape("'$filter'"))
+                $defaultValueText | Should-MatchString ([regex]::Escape("'$filter'"))
             }
         }
 
@@ -109,10 +109,10 @@ Describe 'Get-MediaInfo' -Tag 'Unit' {
             $results = @(Get-MediaInfo -Path $testRoot -Filter '*.avi', '*.mp4' -FFprobePath $script:fakeFFprobePath)
             $resultNames = @($results.Name)
 
-            $resultNames.Count | Should -Be 2
-            $resultNames | Should -Contain 'video1.mp4'
-            $resultNames | Should -Contain 'video2.avi'
-            $resultNames | Should -Not -Contain 'video2.mkv'
+            $resultNames.Count | Should-Be 2
+            $resultNames | Should-ContainCollection 'video1.mp4'
+            $resultNames | Should-ContainCollection 'video2.avi'
+            $resultNames | Should-NotContainCollection 'video2.mkv'
         }
 
         It 'Should search non-recursively by default' -Skip:(-not $script:HasFFprobe) {

--- a/Tests/Unit/MediaProcessing/Invoke-FFmpeg.Tests.ps1
+++ b/Tests/Unit/MediaProcessing/Invoke-FFmpeg.Tests.ps1
@@ -12,33 +12,33 @@ Describe 'Invoke-FFmpeg' -Tag 'Unit' {
     Context 'Parameter Validation' {
         It 'Should have Recurse parameter' {
             $command = Get-Command Invoke-FFmpeg
-            $command.Parameters.ContainsKey('Recurse') | Should -Be $true
+            $command.Parameters.ContainsKey('Recurse') | Should-Be $true
         }
 
         It 'Should not have NoRecursion parameter' {
             $command = Get-Command Invoke-FFmpeg
-            $command.Parameters.ContainsKey('NoRecursion') | Should -Be $false
+            $command.Parameters.ContainsKey('NoRecursion') | Should-Be $false
         }
 
         It 'Should have Exclude parameter' {
             $command = Get-Command Invoke-FFmpeg
-            $command.Parameters.ContainsKey('Exclude') | Should -Be $true
+            $command.Parameters.ContainsKey('Exclude') | Should-Be $true
         }
 
         It 'Should have Filter parameter' {
             $command = Get-Command Invoke-FFmpeg
-            $command.Parameters.ContainsKey('Filter') | Should -Be $true
+            $command.Parameters.ContainsKey('Filter') | Should-Be $true
         }
 
         It 'Should not have Extension parameter' {
             $command = Get-Command Invoke-FFmpeg
-            $command.Parameters.ContainsKey('Extension') | Should -Be $false
+            $command.Parameters.ContainsKey('Extension') | Should-Be $false
         }
 
         It 'Should have default Path value' {
             $command = Get-Command Invoke-FFmpeg
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Where({$_ -is [System.Management.Automation.ParameterAttribute]})[0].Mandatory | Should -Be $false
+            $pathParam.Attributes.Where({$_ -is [System.Management.Automation.ParameterAttribute]})[0].Mandatory | Should-Be $false
         }
     }
 
@@ -46,19 +46,19 @@ Describe 'Invoke-FFmpeg' -Tag 'Unit' {
         It 'Should have Recurse as Switch parameter' {
             $command = Get-Command Invoke-FFmpeg
             $recurseParam = $command.Parameters['Recurse']
-            $recurseParam.ParameterType.Name | Should -Be 'SwitchParameter'
+            $recurseParam.ParameterType.Name | Should-Be 'SwitchParameter'
         }
 
         It 'Should have Exclude as String array parameter' {
             $command = Get-Command Invoke-FFmpeg
             $excludeParam = $command.Parameters['Exclude']
-            $excludeParam.ParameterType.Name | Should -Be 'String[]'
+            $excludeParam.ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have Filter as String array parameter' {
             $command = Get-Command Invoke-FFmpeg
             $filterParam = $command.Parameters['Filter']
-            $filterParam.ParameterType.Name | Should -Be 'String[]'
+            $filterParam.ParameterType.Name | Should-Be 'String[]'
         }
     }
 
@@ -71,7 +71,7 @@ Describe 'Invoke-FFmpeg' -Tag 'Unit' {
                     $node.Name.VariablePath.UserPath -eq 'Filter'
                 }, $true)
 
-            $parameterAst.DefaultValue.Extent.Text | Should -Be "@('*.mkv')"
+            $parameterAst.DefaultValue.Extent.Text | Should-Be "@('*.mkv')"
         }
     }
 
@@ -94,9 +94,9 @@ Describe 'Invoke-FFmpeg' -Tag 'Unit' {
             $null = Invoke-FFmpeg -Path $script:filterTestRoot -Filter '*.avi', '*.mov' -FFmpegPath $script:fakeFFmpegPath -WhatIf -InformationVariable information
             $messages = ($information | ForEach-Object { $_.MessageData }) -join [Environment]::NewLine
 
-            $messages | Should -Match "Processing: 'filtered-video.avi'"
-            $messages | Should -Match "Processing: 'secondary-video.mov'"
-            $messages | Should -Not -Match 'default-video.mkv'
+            $messages | Should-MatchString "Processing: 'filtered-video.avi'"
+            $messages | Should-MatchString "Processing: 'secondary-video.mov'"
+            $messages | Should-NotMatchString 'default-video.mkv'
         }
     }
 
@@ -266,8 +266,8 @@ Describe 'Invoke-FFmpeg' -Tag 'Unit' {
 
             $loggedArgs = Get-Content -Path $script:ffmpegLogPath
             $loggedArgs | Should -Not -BeNullOrEmpty
-            ($loggedArgs -join ' ') | Should -Match '-c:s(?::0)? (copy|mov_text)'
-            ($loggedArgs -join ' ') | Should -Match '-map (0:2|0:s\\?)'
+            ($loggedArgs -join ' ') | Should-MatchString '-c:s(?::0)? (copy|mov_text)'
+            ($loggedArgs -join ' ') | Should-MatchString '-map (0:2|0:s\\?)'
         }
     }
 }

--- a/Tests/Unit/MediaProcessing/Remove-ImageMetadata.Tests.ps1
+++ b/Tests/Unit/MediaProcessing/Remove-ImageMetadata.Tests.ps1
@@ -10,82 +10,82 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
     Context 'Parameter Validation' {
         It 'Should have Recurse parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('Recurse') | Should -Be $true
+            $command.Parameters.ContainsKey('Recurse') | Should-Be $true
         }
 
         It 'Should have Exclude parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('Exclude') | Should -Be $true
+            $command.Parameters.ContainsKey('Exclude') | Should-Be $true
         }
 
         It 'Should have Filter parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('Filter') | Should -Be $true
+            $command.Parameters.ContainsKey('Filter') | Should-Be $true
         }
 
         It 'Should have ExifToolPath parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('ExifToolPath') | Should -Be $true
+            $command.Parameters.ContainsKey('ExifToolPath') | Should-Be $true
         }
 
         It 'Should have ImageMagickPath parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('ImageMagickPath') | Should -Be $true
+            $command.Parameters.ContainsKey('ImageMagickPath') | Should-Be $true
         }
 
         It 'Should have OutputPath parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('OutputPath') | Should -Be $true
+            $command.Parameters.ContainsKey('OutputPath') | Should-Be $true
         }
 
         It 'Should have Force parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('Force') | Should -Be $true
+            $command.Parameters.ContainsKey('Force') | Should-Be $true
         }
 
         It 'Should have KeepBackup parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('KeepBackup') | Should -Be $true
+            $command.Parameters.ContainsKey('KeepBackup') | Should-Be $true
         }
 
         It 'Should have PreserveFileTimestamp parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('PreserveFileTimestamp') | Should -Be $true
+            $command.Parameters.ContainsKey('PreserveFileTimestamp') | Should-Be $true
         }
 
         It 'Should have ResetFileTimestamp parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('ResetFileTimestamp') | Should -Be $true
+            $command.Parameters.ContainsKey('ResetFileTimestamp') | Should-Be $true
         }
 
         It 'Should have ResetTimestamp parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('ResetTimestamp') | Should -Be $true
+            $command.Parameters.ContainsKey('ResetTimestamp') | Should-Be $true
         }
 
         It 'Should have Paranoid parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('Paranoid') | Should -Be $true
+            $command.Parameters.ContainsKey('Paranoid') | Should-Be $true
         }
 
         It 'Should have Verify parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('Verify') | Should -Be $true
+            $command.Parameters.ContainsKey('Verify') | Should-Be $true
         }
 
         It 'Should have PassThru parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters.ContainsKey('PassThru') | Should -Be $true
+            $command.Parameters.ContainsKey('PassThru') | Should-Be $true
         }
 
         It 'Should scope Force to OutputPath parameter sets' {
             $command = Get-Command Remove-ImageMetadata
             $parameterSetNames = @($command.Parameters['Force'].ParameterSets.Keys)
 
-            $parameterSetNames | Should -Contain 'Output'
-            $parameterSetNames | Should -Contain 'OutputParanoid'
-            $parameterSetNames | Should -Not -Contain 'InPlace'
-            $parameterSetNames | Should -Not -Contain 'InPlaceParanoid'
+            $parameterSetNames | Should-ContainCollection 'Output'
+            $parameterSetNames | Should-ContainCollection 'OutputParanoid'
+            $parameterSetNames | Should-NotContainCollection 'InPlace'
+            $parameterSetNames | Should-NotContainCollection 'InPlaceParanoid'
         }
 
         It 'Should keep timestamp preservation and reset options in separate parameter sets' {
@@ -100,8 +100,8 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $command = Get-Command Remove-ImageMetadata
             $parameterSetNames = @($command.Parameters['ResetTimestamp'].ParameterSets.Keys)
 
-            $parameterSetNames | Should -Contain 'InPlaceResetTimestamp'
-            $parameterSetNames | Should -Contain 'OutputResetTimestamp'
+            $parameterSetNames | Should-ContainCollection 'InPlaceResetTimestamp'
+            $parameterSetNames | Should-ContainCollection 'OutputResetTimestamp'
             @($parameterSetNames | Where-Object { $_ -notmatch 'ResetTimestamp$' }) | Should -BeNullOrEmpty
         }
 
@@ -109,8 +109,8 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $command = Get-Command Remove-ImageMetadata
             $parameterSetNames = @($command.Parameters['ImageMagickPath'].ParameterSets.Keys)
 
-            $parameterSetNames | Should -Contain 'InPlaceParanoid'
-            $parameterSetNames | Should -Contain 'OutputParanoid'
+            $parameterSetNames | Should-ContainCollection 'InPlaceParanoid'
+            $parameterSetNames | Should-ContainCollection 'OutputParanoid'
             @($parameterSetNames | Where-Object { $_ -notmatch 'Paranoid' }) | Should -BeNullOrEmpty
         }
     }
@@ -118,37 +118,37 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
     Context 'Parameter Types' {
         It 'Should have Recurse as Switch parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters['Recurse'].ParameterType.Name | Should -Be 'SwitchParameter'
+            $command.Parameters['Recurse'].ParameterType.Name | Should-Be 'SwitchParameter'
         }
 
         It 'Should have Exclude as String array parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters['Exclude'].ParameterType.Name | Should -Be 'String[]'
+            $command.Parameters['Exclude'].ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have Filter as String array parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters['Filter'].ParameterType.Name | Should -Be 'String[]'
+            $command.Parameters['Filter'].ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have OutputPath as String parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters['OutputPath'].ParameterType.Name | Should -Be 'String'
+            $command.Parameters['OutputPath'].ParameterType.Name | Should-Be 'String'
         }
 
         It 'Should have ResetTimestamp as DateTime parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters['ResetTimestamp'].ParameterType.Name | Should -Be 'DateTime'
+            $command.Parameters['ResetTimestamp'].ParameterType.Name | Should-Be 'DateTime'
         }
 
         It 'Should have Paranoid as Switch parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters['Paranoid'].ParameterType.Name | Should -Be 'SwitchParameter'
+            $command.Parameters['Paranoid'].ParameterType.Name | Should-Be 'SwitchParameter'
         }
 
         It 'Should have Verify as Switch parameter' {
             $command = Get-Command Remove-ImageMetadata
-            $command.Parameters['Verify'].ParameterType.Name | Should -Be 'SwitchParameter'
+            $command.Parameters['Verify'].ParameterType.Name | Should-Be 'SwitchParameter'
         }
 
         It 'Should support pipeline input for Path' {
@@ -162,9 +162,9 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
         It 'Should include file and directory aliases for Path' {
             $command = Get-Command Remove-ImageMetadata
             $aliases = $command.Parameters['Path'].Aliases
-            $aliases | Should -Contain 'FilePath'
-            $aliases | Should -Contain 'FullName'
-            $aliases | Should -Contain 'Directory'
+            $aliases | Should-ContainCollection 'FilePath'
+            $aliases | Should-ContainCollection 'FullName'
+            $aliases | Should-ContainCollection 'Directory'
         }
     }
 
@@ -194,11 +194,11 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             }
 
             $exception | Should -Not -BeNullOrEmpty
-            $exception.Message | Should -BeLike '*Install-PlatformPackage.ps1*'
-            $exception.Message | Should -Not -BeLike '*. ./Functions/SystemAdministration/Install-PlatformPackage.ps1*'
-            $exception.Message | Should -Not -BeLike '*-PackageManager*'
-            $exception.Message | Should -Not -BeLike '*-Id*'
-            $exception.Message | Should -Match '(-Name OliverBetz\.ExifTool|-Name exiftool|-Name libimage-exiftool-perl)'
+            $exception.Message | Should-BeLikeString '*Install-PlatformPackage.ps1*'
+            $exception.Message | Should-NotBeLikeString '*. ./Functions/SystemAdministration/Install-PlatformPackage.ps1*'
+            $exception.Message | Should-NotBeLikeString '*-PackageManager*'
+            $exception.Message | Should-NotBeLikeString '*-Id*'
+            $exception.Message | Should-MatchString '(-Name OliverBetz\.ExifTool|-Name exiftool|-Name libimage-exiftool-perl)'
         }
 
         It 'Should include an Install-PlatformPackage hint when ImageMagick is missing' {
@@ -215,11 +215,11 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             }
 
             $exception | Should -Not -BeNullOrEmpty
-            $exception.Message | Should -BeLike '*Install-PlatformPackage.ps1*'
-            $exception.Message | Should -Not -BeLike '*. ./Functions/SystemAdministration/Install-PlatformPackage.ps1*'
-            $exception.Message | Should -Not -BeLike '*-PackageManager*'
-            $exception.Message | Should -Not -BeLike '*-Id*'
-            $exception.Message | Should -Match '(-Name ImageMagick\.ImageMagick|-Name imagemagick)'
+            $exception.Message | Should-BeLikeString '*Install-PlatformPackage.ps1*'
+            $exception.Message | Should-NotBeLikeString '*. ./Functions/SystemAdministration/Install-PlatformPackage.ps1*'
+            $exception.Message | Should-NotBeLikeString '*-PackageManager*'
+            $exception.Message | Should-NotBeLikeString '*-Id*'
+            $exception.Message | Should-MatchString '(-Name ImageMagick\.ImageMagick|-Name imagemagick)'
         }
     }
 
@@ -243,35 +243,35 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
         It 'Should process image files non-recursively by default with -WhatIf' {
             $results = Remove-ImageMetadata -Path $script:TestRoot -WhatIf -PassThru
 
-            $results.Count | Should -Be 2
-            $results.Name | Should -Contain 'photo1.jpg'
-            $results.Name | Should -Contain 'photo2.png'
-            $results.Name | Should -Not -Contain 'photo3.jpg'
-            $results.Name | Should -Not -Contain 'notes.txt'
+            $results.Count | Should-Be 2
+            $results.Name | Should-ContainCollection 'photo1.jpg'
+            $results.Name | Should-ContainCollection 'photo2.png'
+            $results.Name | Should-NotContainCollection 'photo3.jpg'
+            $results.Name | Should-NotContainCollection 'notes.txt'
         }
 
         It 'Should process recursively when -Recurse is specified with -WhatIf' {
             $results = Remove-ImageMetadata -Path $script:TestRoot -Recurse -WhatIf -PassThru
 
-            $results.Name | Should -Contain 'photo1.jpg'
-            $results.Name | Should -Contain 'photo2.png'
-            $results.Name | Should -Contain 'photo3.jpg'
+            $results.Name | Should-ContainCollection 'photo1.jpg'
+            $results.Name | Should-ContainCollection 'photo2.png'
+            $results.Name | Should-ContainCollection 'photo3.jpg'
         }
 
         It 'Should respect Exclude parameter when using -Recurse with -WhatIf' {
             $results = Remove-ImageMetadata -Path $script:TestRoot -Recurse -Exclude @('.git', 'SubDirectory') -WhatIf -PassThru
 
-            $results.Name | Should -Contain 'photo1.jpg'
-            $results.Name | Should -Contain 'photo2.png'
-            $results.Name | Should -Not -Contain 'photo3.jpg'
-            $results.Name | Should -Not -Contain 'hidden.jpg'
+            $results.Name | Should-ContainCollection 'photo1.jpg'
+            $results.Name | Should-ContainCollection 'photo2.png'
+            $results.Name | Should-NotContainCollection 'photo3.jpg'
+            $results.Name | Should-NotContainCollection 'hidden.jpg'
         }
 
         It 'Should honor custom Filter with -WhatIf' {
             $results = @(Remove-ImageMetadata -Path $script:TestRoot -Filter '*.png' -WhatIf -PassThru)
 
-            $results.Count | Should -Be 1
-            $results.Name | Should -Contain 'photo2.png'
+            $results.Count | Should-Be 1
+            $results.Name | Should-ContainCollection 'photo2.png'
         }
     }
 
@@ -301,15 +301,15 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
 
             $null = Remove-ImageMetadata -Path $missingPath -WhatIf -ErrorAction SilentlyContinue -ErrorVariable errors
 
-            $errors.Count | Should -BeGreaterThan 0
-            $errors[0].Exception.Message | Should -BeLike '*not found*'
+            $errors.Count | Should-BeGreaterThan 0
+            $errors[0].Exception.Message | Should-BeLikeString '*not found*'
         }
 
         It 'Should accept image files from the pipeline with -WhatIf' {
             $result = @(Get-Item -LiteralPath $script:TestImageFile | Remove-ImageMetadata -WhatIf -PassThru)
 
-            $result.Count | Should -Be 1
-            $result.Name | Should -Be 'single-photo.jpg'
+            $result.Count | Should-Be 1
+            $result.Name | Should-Be 'single-photo.jpg'
         }
     }
 
@@ -365,30 +365,30 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $result = Remove-ImageMetadata -Path $script:SampleImage -ExifToolPath $script:FakeExifToolPath -PassThru
 
             $loggedArgs = Get-Content -LiteralPath $script:ExifToolLogPath
-            $loggedArgs | Should -Contain '-overwrite_original'
-            $loggedArgs | Should -Contain '-all='
-            $loggedArgs | Should -Contain $script:SampleImage
-            $result.MetadataRemoved | Should -Be $true
-            $result.ExitCode | Should -Be 0
-            $result.RemovedMetadataTagCount | Should -Be 2
-            $result.RemovedMetadataTags | Should -Contain 'EXIF:Make'
-            $result.RemovedMetadataTags | Should -Contain 'XMP:Title'
+            $loggedArgs | Should-ContainCollection '-overwrite_original'
+            $loggedArgs | Should-ContainCollection '-all='
+            $loggedArgs | Should-ContainCollection $script:SampleImage
+            $result.MetadataRemoved | Should-Be $true
+            $result.ExitCode | Should-Be 0
+            $result.RemovedMetadataTagCount | Should-Be 2
+            $result.RemovedMetadataTags | Should-ContainCollection 'EXIF:Make'
+            $result.RemovedMetadataTags | Should-ContainCollection 'XMP:Title'
         }
 
         It 'Should omit overwrite_original when KeepBackup is specified' {
             Remove-ImageMetadata -Path $script:SampleImage -ExifToolPath $script:FakeExifToolPath -KeepBackup | Out-Null
 
             $loggedArgs = Get-Content -LiteralPath $script:ExifToolLogPath
-            $loggedArgs | Should -Not -Contain '-overwrite_original'
-            $loggedArgs | Should -Contain '-all='
+            $loggedArgs | Should-NotContainCollection '-overwrite_original'
+            $loggedArgs | Should-ContainCollection '-all='
         }
 
         It 'Should pass -P when PreserveFileTimestamp is specified' {
             Remove-ImageMetadata -Path $script:SampleImage -ExifToolPath $script:FakeExifToolPath -PreserveFileTimestamp | Out-Null
 
             $loggedArgs = Get-Content -LiteralPath $script:ExifToolLogPath
-            $loggedArgs | Should -Contain '-P'
-            $loggedArgs | Should -Contain '-all='
+            $loggedArgs | Should-ContainCollection '-P'
+            $loggedArgs | Should-ContainCollection '-all='
         }
     }
 
@@ -449,12 +449,12 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
         It 'Should write sanitized copies to OutputPath without modifying the source path' {
             $result = Remove-ImageMetadata -Path $script:PrivacySourceImage -OutputPath $script:PrivacyOutputDir -ExifToolPath $script:PrivacyFakeExifToolPath -PassThru
 
-            Test-Path -LiteralPath $script:PrivacyOutputImage | Should -Be $true
-            Test-Path -LiteralPath $script:PrivacySourceImage | Should -Be $true
-            $result.SourcePath | Should -Be $script:PrivacySourceImage
-            $result.Path | Should -Be $script:PrivacyOutputImage
-            $result.OutputCopied | Should -Be $true
-            $result.MetadataRemoved | Should -Be $true
+            Test-Path -LiteralPath $script:PrivacyOutputImage | Should-Be $true
+            Test-Path -LiteralPath $script:PrivacySourceImage | Should-Be $true
+            $result.SourcePath | Should-Be $script:PrivacySourceImage
+            $result.Path | Should-Be $script:PrivacyOutputImage
+            $result.OutputCopied | Should-Be $true
+            $result.MetadataRemoved | Should-Be $true
         }
 
         It 'Should not overwrite an existing OutputPath target unless Force is specified' {
@@ -463,9 +463,9 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
 
             $null = Remove-ImageMetadata -Path $script:PrivacySourceImage -OutputPath $script:PrivacyOutputDir -ExifToolPath $script:PrivacyFakeExifToolPath -PassThru -ErrorAction SilentlyContinue -ErrorVariable errors
 
-            $errors.Count | Should -BeGreaterThan 0
-            $errors[0].Exception.Message | Should -BeLike '*already exists*'
-            Get-Content -LiteralPath $script:PrivacyOutputImage | Should -Be 'existing clean image'
+            $errors.Count | Should-BeGreaterThan 0
+            $errors[0].Exception.Message | Should-BeLikeString '*already exists*'
+            Get-Content -LiteralPath $script:PrivacyOutputImage | Should-Be 'existing clean image'
         }
 
         It 'Should overwrite an existing OutputPath target when Force is specified' {
@@ -474,9 +474,9 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
 
             $result = Remove-ImageMetadata -Path $script:PrivacySourceImage -OutputPath $script:PrivacyOutputDir -ExifToolPath $script:PrivacyFakeExifToolPath -Force -PassThru
 
-            Get-Content -LiteralPath $script:PrivacyOutputImage | Should -Be 'source image bytes'
-            $result.MetadataRemoved | Should -Be $true
-            $result.OutputCopied | Should -Be $true
+            Get-Content -LiteralPath $script:PrivacyOutputImage | Should-Be 'source image bytes'
+            $result.MetadataRemoved | Should-Be $true
+            $result.OutputCopied | Should-Be $true
         }
 
         It 'Should reset filesystem timestamps when ResetFileTimestamp is specified' {
@@ -485,33 +485,33 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $result = Remove-ImageMetadata -Path $script:PrivacySourceImage -OutputPath $script:PrivacyOutputDir -ExifToolPath $script:PrivacyFakeExifToolPath -ResetFileTimestamp -ResetTimestamp $resetTimestamp -PassThru
             $outputFile = Get-Item -LiteralPath $script:PrivacyOutputImage
 
-            $result.TimestampReset | Should -Be $true
-            $outputFile.LastWriteTimeUtc.ToString('o') | Should -Be $resetTimestamp.ToString('o')
+            $result.TimestampReset | Should-Be $true
+            $outputFile.LastWriteTimeUtc.ToString('o') | Should-Be $resetTimestamp.ToString('o')
         }
 
         It 'Should reject conflicting timestamp options' {
             { Remove-ImageMetadata -Path $script:PrivacySourceImage -ExifToolPath $script:PrivacyFakeExifToolPath -PreserveFileTimestamp -ResetFileTimestamp } |
-            Should -Throw
+            Should-Throw
         }
 
         It 'Should re-encode through ImageMagick in Paranoid mode' {
             $result = Remove-ImageMetadata -Path $script:PrivacySourceImage -OutputPath $script:PrivacyOutputDir -ExifToolPath $script:PrivacyFakeExifToolPath -ImageMagickPath $script:PrivacyFakeImageMagickPath -Paranoid -PassThru
 
-            Test-Path -LiteralPath $script:PrivacyOutputImage | Should -Be $true
+            Test-Path -LiteralPath $script:PrivacyOutputImage | Should-Be $true
             $imageMagickArgs = Get-Content -LiteralPath $script:PrivacyImageMagickLogPath
-            $imageMagickArgs | Should -Contain $script:PrivacySourceImage
-            $imageMagickArgs | Should -Contain '-strip'
-            $result.Paranoid | Should -Be $true
-            $result.MetadataRemoved | Should -Be $true
+            $imageMagickArgs | Should-ContainCollection $script:PrivacySourceImage
+            $imageMagickArgs | Should-ContainCollection '-strip'
+            $result.Paranoid | Should-Be $true
+            $result.MetadataRemoved | Should-Be $true
         }
 
         It 'Should re-encode in place through ImageMagick in Paranoid mode without Force' {
             $result = Remove-ImageMetadata -Path $script:PrivacySourceImage -ExifToolPath $script:PrivacyFakeExifToolPath -ImageMagickPath $script:PrivacyFakeImageMagickPath -Paranoid -PassThru
 
-            Get-Content -LiteralPath $script:PrivacySourceImage | Should -Be 're-encoded image bytes'
-            $result.Path | Should -Be $script:PrivacySourceImage
-            $result.Paranoid | Should -Be $true
-            $result.MetadataRemoved | Should -Be $true
+            Get-Content -LiteralPath $script:PrivacySourceImage | Should-Be 're-encoded image bytes'
+            $result.Path | Should-Be $script:PrivacySourceImage
+            $result.Paranoid | Should-Be $true
+            $result.MetadataRemoved | Should-Be $true
         }
 
         It 'Should surface remaining metadata tag values when output-path verification is incomplete' {
@@ -529,13 +529,13 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $result = Remove-ImageMetadata -Path $script:PrivacySourceImage -OutputPath $script:PrivacyOutputDir -ExifToolPath $script:PrivacyFakeExifToolPath -Verify -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Verified | Should -Be $false
-            $result.Path | Should -Be $script:PrivacyOutputImage
-            $result.OutputCopied | Should -Be $true
-            $result.RemainingMetadataTags | Should -Contain '[EXIF] Make = Test Camera'
-            $result.RemainingMetadataTags | Should -Contain '[XMP] Title = Private Album'
-            Should -Invoke -CommandName Get-ImageMetadata -Times 1 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
-            Should -Invoke -CommandName Get-ImageMetadata -Times 2 -Exactly -ParameterFilter { $Path -eq $script:PrivacyOutputImage }
+            $result.Verified | Should-Be $false
+            $result.Path | Should-Be $script:PrivacyOutputImage
+            $result.OutputCopied | Should-Be $true
+            $result.RemainingMetadataTags | Should-ContainCollection '[EXIF] Make = Test Camera'
+            $result.RemainingMetadataTags | Should-ContainCollection '[XMP] Title = Private Album'
+            Should-Invoke -CommandName Get-ImageMetadata -Times 1 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
+            Should-Invoke -CommandName Get-ImageMetadata -Times 2 -Exactly -ParameterFilter { $Path -eq $script:PrivacyOutputImage }
         }
 
         It 'Should surface remaining metadata tag values when in-place verification is incomplete' {
@@ -553,12 +553,12 @@ Describe 'Remove-ImageMetadata' -Tag 'Unit' {
             $result = Remove-ImageMetadata -Path $script:PrivacySourceImage -ExifToolPath $script:PrivacyFakeExifToolPath -Verify -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Verified | Should -Be $false
-            $result.Path | Should -Be $script:PrivacySourceImage
-            $result.OutputCopied | Should -Be $false
-            $result.RemainingMetadataTags | Should -Contain '[GPS] GPSLatitude = 41.88'
-            $result.RemainingMetadataTags | Should -Contain '[IPTC] Keywords = private, home'
-            Should -Invoke -CommandName Get-ImageMetadata -Times 3 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
+            $result.Verified | Should-Be $false
+            $result.Path | Should-Be $script:PrivacySourceImage
+            $result.OutputCopied | Should-Be $false
+            $result.RemainingMetadataTags | Should-ContainCollection '[GPS] GPSLatitude = 41.88'
+            $result.RemainingMetadataTags | Should-ContainCollection '[IPTC] Keywords = private, home'
+            Should-Invoke -CommandName Get-ImageMetadata -Times 3 -Exactly -ParameterFilter { $Path -eq $script:PrivacySourceImage }
         }
     }
 }

--- a/Tests/Unit/MediaProcessing/Rename-VideoSeasonFile.Tests.ps1
+++ b/Tests/Unit/MediaProcessing/Rename-VideoSeasonFile.Tests.ps1
@@ -9,17 +9,17 @@ Describe 'Rename-VideoSeasonFile' -Tag 'Unit' {
     Context 'Parameter Validation' {
         It 'Should have Recurse parameter' {
             $command = Get-Command Rename-VideoSeasonFile
-            $command.Parameters.ContainsKey('Recurse') | Should -Be $true
+            $command.Parameters.ContainsKey('Recurse') | Should-Be $true
         }
 
         It 'Should have Exclude parameter' {
             $command = Get-Command Rename-VideoSeasonFile
-            $command.Parameters.ContainsKey('Exclude') | Should -Be $true
+            $command.Parameters.ContainsKey('Exclude') | Should-Be $true
         }
 
         It 'Should have PassThru parameter' {
             $command = Get-Command Rename-VideoSeasonFile
-            $command.Parameters.ContainsKey('PassThru') | Should -Be $true
+            $command.Parameters.ContainsKey('PassThru') | Should-Be $true
         }
     }
 
@@ -27,19 +27,19 @@ Describe 'Rename-VideoSeasonFile' -Tag 'Unit' {
         It 'Should have Recurse as Switch parameter' {
             $command = Get-Command Rename-VideoSeasonFile
             $recurseParam = $command.Parameters['Recurse']
-            $recurseParam.ParameterType.Name | Should -Be 'SwitchParameter'
+            $recurseParam.ParameterType.Name | Should-Be 'SwitchParameter'
         }
 
         It 'Should have Exclude as String array parameter' {
             $command = Get-Command Rename-VideoSeasonFile
             $excludeParam = $command.Parameters['Exclude']
-            $excludeParam.ParameterType.Name | Should -Be 'String[]'
+            $excludeParam.ParameterType.Name | Should-Be 'String[]'
         }
 
         It 'Should have Filter as String array parameter' {
             $command = Get-Command Rename-VideoSeasonFile
             $filterParam = $command.Parameters['Filter']
-            $filterParam.ParameterType.Name | Should -Be 'String[]'
+            $filterParam.ParameterType.Name | Should-Be 'String[]'
         }
     }
 
@@ -136,8 +136,8 @@ Describe 'Rename-VideoSeasonFile' -Tag 'Unit' {
             # Should handle gracefully by producing appropriate error message
             $ErrorActionPreference = 'SilentlyContinue'
             $null = Rename-VideoSeasonFile -Path $nonExistentFile -WhatIf -ErrorVariable errors 2>&1
-            $errors.Count | Should -BeGreaterThan 0
-            $errors[0].Exception.Message | Should -BeLike '*not found*'
+            $errors.Count | Should-BeGreaterThan 0
+            $errors[0].Exception.Message | Should-BeLikeString '*not found*'
         }
 
         It 'Should support pipeline input for individual files' {
@@ -156,8 +156,8 @@ Describe 'Rename-VideoSeasonFile' -Tag 'Unit' {
 
             # Check for aliases that support file input
             $aliases = $pathParam.Aliases
-            $aliases | Should -Contain 'FilePath'
-            $aliases | Should -Contain 'FullName'
+            $aliases | Should-ContainCollection 'FilePath'
+            $aliases | Should-ContainCollection 'FullName'
         }
     }
 }

--- a/Tests/Unit/NetworkAndDns/ConvertTo-CidrNotation.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/ConvertTo-CidrNotation.Tests.ps1
@@ -20,120 +20,120 @@ Describe 'ConvertTo-CidrNotation' {
     Context 'Conversion from PrefixLength' {
         It 'Should convert /24 correctly' {
             $result = ConvertTo-CidrNotation -PrefixLength 24
-            $result.PrefixLength | Should -Be 24
-            $result.SubnetMask | Should -Be '255.255.255.0'
-            $result.WildcardMask | Should -Be '0.0.0.255'
+            $result.PrefixLength | Should-Be 24
+            $result.SubnetMask | Should-Be '255.255.255.0'
+            $result.WildcardMask | Should-Be '0.0.0.255'
         }
 
         It 'Should convert /16 correctly' {
             $result = ConvertTo-CidrNotation -PrefixLength 16
-            $result.PrefixLength | Should -Be 16
-            $result.SubnetMask | Should -Be '255.255.0.0'
-            $result.WildcardMask | Should -Be '0.0.255.255'
+            $result.PrefixLength | Should-Be 16
+            $result.SubnetMask | Should-Be '255.255.0.0'
+            $result.WildcardMask | Should-Be '0.0.255.255'
         }
 
         It 'Should convert /8 correctly' {
             $result = ConvertTo-CidrNotation -PrefixLength 8
-            $result.PrefixLength | Should -Be 8
-            $result.SubnetMask | Should -Be '255.0.0.0'
-            $result.WildcardMask | Should -Be '0.255.255.255'
+            $result.PrefixLength | Should-Be 8
+            $result.SubnetMask | Should-Be '255.0.0.0'
+            $result.WildcardMask | Should-Be '0.255.255.255'
         }
 
         It 'Should convert /32 (host route) correctly' {
             $result = ConvertTo-CidrNotation -PrefixLength 32
-            $result.PrefixLength | Should -Be 32
-            $result.SubnetMask | Should -Be '255.255.255.255'
-            $result.WildcardMask | Should -Be '0.0.0.0'
+            $result.PrefixLength | Should-Be 32
+            $result.SubnetMask | Should-Be '255.255.255.255'
+            $result.WildcardMask | Should-Be '0.0.0.0'
         }
 
         It 'Should convert /0 (default route) correctly' {
             $result = ConvertTo-CidrNotation -PrefixLength 0
-            $result.PrefixLength | Should -Be 0
-            $result.SubnetMask | Should -Be '0.0.0.0'
-            $result.WildcardMask | Should -Be '255.255.255.255'
+            $result.PrefixLength | Should-Be 0
+            $result.SubnetMask | Should-Be '0.0.0.0'
+            $result.WildcardMask | Should-Be '255.255.255.255'
         }
 
         It 'Should convert /26 correctly' {
             $result = ConvertTo-CidrNotation -PrefixLength 26
-            $result.PrefixLength | Should -Be 26
-            $result.SubnetMask | Should -Be '255.255.255.192'
-            $result.WildcardMask | Should -Be '0.0.0.63'
+            $result.PrefixLength | Should-Be 26
+            $result.SubnetMask | Should-Be '255.255.255.192'
+            $result.WildcardMask | Should-Be '0.0.0.63'
         }
     }
 
     Context 'Conversion from SubnetMask' {
         It 'Should convert 255.255.255.0 to /24' {
             $result = ConvertTo-CidrNotation -SubnetMask '255.255.255.0'
-            $result.PrefixLength | Should -Be 24
-            $result.SubnetMask | Should -Be '255.255.255.0'
-            $result.WildcardMask | Should -Be '0.0.0.255'
+            $result.PrefixLength | Should-Be 24
+            $result.SubnetMask | Should-Be '255.255.255.0'
+            $result.WildcardMask | Should-Be '0.0.0.255'
         }
 
         It 'Should convert 255.255.0.0 to /16' {
             $result = ConvertTo-CidrNotation -SubnetMask '255.255.0.0'
-            $result.PrefixLength | Should -Be 16
+            $result.PrefixLength | Should-Be 16
         }
 
         It 'Should convert 255.255.255.252 to /30' {
             $result = ConvertTo-CidrNotation -SubnetMask '255.255.255.252'
-            $result.PrefixLength | Should -Be 30
-            $result.WildcardMask | Should -Be '0.0.0.3'
+            $result.PrefixLength | Should-Be 30
+            $result.WildcardMask | Should-Be '0.0.0.3'
         }
 
         It 'Should reject non-contiguous subnet masks' {
-            { ConvertTo-CidrNotation -SubnetMask '255.0.255.0' } | Should -Throw
+            { ConvertTo-CidrNotation -SubnetMask '255.0.255.0' } | Should-Throw
         }
     }
 
     Context 'Conversion from WildcardMask' {
         It 'Should convert 0.0.0.255 to /24' {
             $result = ConvertTo-CidrNotation -WildcardMask '0.0.0.255'
-            $result.PrefixLength | Should -Be 24
-            $result.SubnetMask | Should -Be '255.255.255.0'
+            $result.PrefixLength | Should-Be 24
+            $result.SubnetMask | Should-Be '255.255.255.0'
         }
 
         It 'Should convert 0.0.0.63 to /26' {
             $result = ConvertTo-CidrNotation -WildcardMask '0.0.0.63'
-            $result.PrefixLength | Should -Be 26
-            $result.SubnetMask | Should -Be '255.255.255.192'
+            $result.PrefixLength | Should-Be 26
+            $result.SubnetMask | Should-Be '255.255.255.192'
         }
 
         It 'Should reject non-contiguous wildcard masks' {
-            { ConvertTo-CidrNotation -WildcardMask '0.255.0.255' } | Should -Throw
+            { ConvertTo-CidrNotation -WildcardMask '0.255.0.255' } | Should-Throw
         }
     }
 
     Context 'Pipeline input' {
         It 'Should accept prefix lengths from the pipeline' {
             $results = 8, 16, 24 | ConvertTo-CidrNotation
-            @($results).Count | Should -Be 3
-            $results[0].PrefixLength | Should -Be 8
-            $results[1].PrefixLength | Should -Be 16
-            $results[2].PrefixLength | Should -Be 24
+            @($results).Count | Should-Be 3
+            $results[0].PrefixLength | Should-Be 8
+            $results[1].PrefixLength | Should-Be 16
+            $results[2].PrefixLength | Should-Be 24
         }
 
         It 'Should accept PrefixLength by property name from the pipeline' {
             $result = [pscustomobject]@{ PrefixLength = 27 } | ConvertTo-CidrNotation
 
-            $result.PrefixLength | Should -Be 27
-            $result.SubnetMask | Should -Be '255.255.255.224'
-            $result.WildcardMask | Should -Be '0.0.0.31'
+            $result.PrefixLength | Should-Be 27
+            $result.SubnetMask | Should-Be '255.255.255.224'
+            $result.WildcardMask | Should-Be '0.0.0.31'
         }
 
         It 'Should accept SubnetMask by property name from the pipeline' {
             $result = [pscustomobject]@{ SubnetMask = '255.255.255.240' } | ConvertTo-CidrNotation
 
-            $result.PrefixLength | Should -Be 28
-            $result.SubnetMask | Should -Be '255.255.255.240'
-            $result.WildcardMask | Should -Be '0.0.0.15'
+            $result.PrefixLength | Should-Be 28
+            $result.SubnetMask | Should-Be '255.255.255.240'
+            $result.WildcardMask | Should-Be '0.0.0.15'
         }
 
         It 'Should accept WildcardMask by property name from the pipeline' {
             $result = [pscustomobject]@{ WildcardMask = '0.0.0.7' } | ConvertTo-CidrNotation
 
-            $result.PrefixLength | Should -Be 29
-            $result.SubnetMask | Should -Be '255.255.255.248'
-            $result.WildcardMask | Should -Be '0.0.0.7'
+            $result.PrefixLength | Should-Be 29
+            $result.SubnetMask | Should-Be '255.255.255.248'
+            $result.WildcardMask | Should-Be '0.0.0.7'
         }
     }
 
@@ -143,29 +143,29 @@ Describe 'ConvertTo-CidrNotation' {
             $fromMask = ConvertTo-CidrNotation -SubnetMask '255.255.255.0'
             $fromWildcard = ConvertTo-CidrNotation -WildcardMask '0.0.0.255'
 
-            $fromPrefix.PrefixLength | Should -Be $fromMask.PrefixLength
-            $fromPrefix.PrefixLength | Should -Be $fromWildcard.PrefixLength
-            $fromPrefix.SubnetMask | Should -Be $fromMask.SubnetMask
-            $fromPrefix.WildcardMask | Should -Be $fromWildcard.WildcardMask
+            $fromPrefix.PrefixLength | Should-Be $fromMask.PrefixLength
+            $fromPrefix.PrefixLength | Should-Be $fromWildcard.PrefixLength
+            $fromPrefix.SubnetMask | Should-Be $fromMask.SubnetMask
+            $fromPrefix.WildcardMask | Should-Be $fromWildcard.WildcardMask
         }
     }
 
     Context 'Parameter validation' {
         It 'Should reject prefix lengths outside 0-32 range' {
-            { ConvertTo-CidrNotation -PrefixLength 33 } | Should -Throw
-            { ConvertTo-CidrNotation -PrefixLength -1 } | Should -Throw
+            { ConvertTo-CidrNotation -PrefixLength 33 } | Should-Throw
+            { ConvertTo-CidrNotation -PrefixLength -1 } | Should-Throw
         }
 
         It 'Should reject invalid subnet mask format' {
-            { ConvertTo-CidrNotation -SubnetMask 'not-an-ip' } | Should -Throw
+            { ConvertTo-CidrNotation -SubnetMask 'not-an-ip' } | Should-Throw
         }
 
         It 'Should reject IPv6 subnet masks' {
-            { ConvertTo-CidrNotation -SubnetMask 'ffff:ffff:ffff:ffff::' } | Should -Throw
+            { ConvertTo-CidrNotation -SubnetMask 'ffff:ffff:ffff:ffff::' } | Should-Throw
         }
 
         It 'Should reject IPv6 wildcard masks' {
-            { ConvertTo-CidrNotation -WildcardMask '::ffff' } | Should -Throw
+            { ConvertTo-CidrNotation -WildcardMask '::ffff' } | Should-Throw
         }
     }
 }

--- a/Tests/Unit/NetworkAndDns/Get-DnsRecord.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Get-DnsRecord.Tests.ps1
@@ -39,10 +39,10 @@ Describe 'Get-DnsRecord' {
                 & $script:GetDnsRecordImplementation -Name 'example.test' -Server google -Timeout 23
             )
 
-            @($results).Count | Should -Be $expectedTypes.Count
-            ($results.Type -join ',') | Should -Be ($expectedTypes -join ',')
+            @($results).Count | Should-Be $expectedTypes.Count
+            ($results.Type -join ',') | Should-Be ($expectedTypes -join ',')
 
-            Should -Invoke -CommandName Get-DnsRecord -Times $expectedTypes.Count -Exactly -ParameterFilter {
+            Should-Invoke -CommandName Get-DnsRecord -Times $expectedTypes.Count -Exactly -ParameterFilter {
                 $Name -eq 'example.test' -and
                 $Type -in $expectedTypes -and
                 $Server -eq 'google' -and
@@ -63,11 +63,11 @@ Describe 'Get-DnsRecord' {
                 & $script:GetDnsRecordImplementation -Name $Address -Type ANY -UseDNS -ErrorAction Stop
             )
 
-            @($results).Count | Should -Be 1
-            $results[0].Name | Should -Be $Address
-            $results[0].Type | Should -Be $ExpectedType
+            @($results).Count | Should-Be 1
+            $results[0].Name | Should-Be $Address
+            $results[0].Type | Should-Be $ExpectedType
             $results[0].TTL | Should -BeNullOrEmpty
-            $results[0].Data | Should -Be $Address
+            $results[0].Data | Should-Be $Address
         }
 
         It 'Warns and returns before resolving an unsupported native record type' {
@@ -83,9 +83,9 @@ Describe 'Get-DnsRecord' {
                     -ErrorAction Stop
             )
 
-            @($results).Count | Should -Be 0
-            @($warnings).Count | Should -Be 1
-            $warnings[0].Message | Should -Be 'Native DNS resolution only supports A, AAAA, and ANY records. Use DNS-over-HTTPS (default) for MX records.'
+            @($results).Count | Should-Be 0
+            @($warnings).Count | Should-Be 1
+            $warnings[0].Message | Should-Be 'Native DNS resolution only supports A, AAAA, and ANY records. Use DNS-over-HTTPS (default) for MX records.'
         }
     }
 }

--- a/Tests/Unit/NetworkAndDns/Get-IPSubnet.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Get-IPSubnet.Tests.ps1
@@ -29,19 +29,19 @@ Describe 'Get-IPSubnet' {
             $result | Should -Not -BeNullOrEmpty
 
             # Verify all expected properties from the example documentation
-            $result.IP | Should -Be '192.168.0.0'
-            $result.Mask | Should -Be '255.255.255.0'
-            $result.PrefixLength | Should -Be 24
-            $result.WildCard | Should -Be '0.0.0.255'
-            $result.IPcount | Should -Be 256
-            $result.Subnet | Should -Be '192.168.0.0'
-            $result.Broadcast | Should -Be '192.168.0.255'
-            $result.CIDR | Should -Be '192.168.0.0/24'
-            $result.ToDecimal | Should -Be 3232235520
-            $result.IPBin | Should -Be '11000000.10101000.00000000.00000000'
-            $result.MaskBin | Should -Be '11111111.11111111.11111111.00000000'
-            $result.SubnetBin | Should -Be '11000000.10101000.00000000.00000000'
-            $result.BroadcastBin | Should -Be '11000000.10101000.00000000.11111111'
+            $result.IP | Should-Be '192.168.0.0'
+            $result.Mask | Should-Be '255.255.255.0'
+            $result.PrefixLength | Should-Be 24
+            $result.WildCard | Should-Be '0.0.0.255'
+            $result.IPcount | Should-Be 256
+            $result.Subnet | Should-Be '192.168.0.0'
+            $result.Broadcast | Should-Be '192.168.0.255'
+            $result.CIDR | Should-Be '192.168.0.0/24'
+            $result.ToDecimal | Should-Be 3232235520
+            $result.IPBin | Should-Be '11000000.10101000.00000000.00000000'
+            $result.MaskBin | Should-Be '11111111.11111111.11111111.00000000'
+            $result.SubnetBin | Should-Be '11000000.10101000.00000000.00000000'
+            $result.BroadcastBin | Should-Be '11000000.10101000.00000000.11111111'
         }
     }
 
@@ -52,19 +52,19 @@ Describe 'Get-IPSubnet' {
             $result | Should -Not -BeNullOrEmpty
 
             # Should produce same results as CIDR example above
-            $result.IP | Should -Be '192.168.0.0'
-            $result.Mask | Should -Be '255.255.255.0'
-            $result.PrefixLength | Should -Be 24
-            $result.WildCard | Should -Be '0.0.0.255'
-            $result.IPcount | Should -Be 256
-            $result.Subnet | Should -Be '192.168.0.0'
-            $result.Broadcast | Should -Be '192.168.0.255'
-            $result.CIDR | Should -Be '192.168.0.0/24'
-            $result.ToDecimal | Should -Be 3232235520
-            $result.IPBin | Should -Be '11000000.10101000.00000000.00000000'
-            $result.MaskBin | Should -Be '11111111.11111111.11111111.00000000'
-            $result.SubnetBin | Should -Be '11000000.10101000.00000000.00000000'
-            $result.BroadcastBin | Should -Be '11000000.10101000.00000000.11111111'
+            $result.IP | Should-Be '192.168.0.0'
+            $result.Mask | Should-Be '255.255.255.0'
+            $result.PrefixLength | Should-Be 24
+            $result.WildCard | Should-Be '0.0.0.255'
+            $result.IPcount | Should-Be 256
+            $result.Subnet | Should-Be '192.168.0.0'
+            $result.Broadcast | Should-Be '192.168.0.255'
+            $result.CIDR | Should-Be '192.168.0.0/24'
+            $result.ToDecimal | Should-Be 3232235520
+            $result.IPBin | Should-Be '11000000.10101000.00000000.00000000'
+            $result.MaskBin | Should-Be '11111111.11111111.11111111.00000000'
+            $result.SubnetBin | Should-Be '11000000.10101000.00000000.00000000'
+            $result.BroadcastBin | Should-Be '11000000.10101000.00000000.11111111'
         }
     }
 
@@ -74,48 +74,48 @@ Describe 'Get-IPSubnet' {
             $result | Should -Not -BeNullOrEmpty
 
             # Verify results match the example
-            $result.IP | Should -Be '192.168.3.0'
-            $result.Mask | Should -Be '255.255.254.0'
-            $result.PrefixLength | Should -Be 23
-            $result.WildCard | Should -Be '0.0.1.255'
-            $result.IPcount | Should -Be 512
-            $result.Subnet | Should -Be '192.168.2.0'
-            $result.Broadcast | Should -Be '192.168.3.255'
-            $result.CIDR | Should -Be '192.168.2.0/23'
-            $result.ToDecimal | Should -Be 3232236288
-            $result.IPBin | Should -Be '11000000.10101000.00000011.00000000'
-            $result.MaskBin | Should -Be '11111111.11111111.11111110.00000000'
-            $result.SubnetBin | Should -Be '11000000.10101000.00000010.00000000'
-            $result.BroadcastBin | Should -Be '11000000.10101000.00000011.11111111'
+            $result.IP | Should-Be '192.168.3.0'
+            $result.Mask | Should-Be '255.255.254.0'
+            $result.PrefixLength | Should-Be 23
+            $result.WildCard | Should-Be '0.0.1.255'
+            $result.IPcount | Should-Be 512
+            $result.Subnet | Should-Be '192.168.2.0'
+            $result.Broadcast | Should-Be '192.168.3.255'
+            $result.CIDR | Should-Be '192.168.2.0/23'
+            $result.ToDecimal | Should-Be 3232236288
+            $result.IPBin | Should-Be '11000000.10101000.00000011.00000000'
+            $result.MaskBin | Should-Be '11111111.11111111.11111110.00000000'
+            $result.SubnetBin | Should-Be '11000000.10101000.00000010.00000000'
+            $result.BroadcastBin | Should-Be '11000000.10101000.00000011.11111111'
         }
     }
 
     Context 'Additional subnet examples' {
         It 'Should calculate /8 network (Class A) correctly' {
             $result = Get-IPSubnet -CIDR '10.0.0.0/8'
-            $result.Mask | Should -Be '255.0.0.0'
-            $result.IPcount | Should -Be 16777216  # 2^24
-            $result.Subnet | Should -Be '10.0.0.0'
-            $result.Broadcast | Should -Be '10.255.255.255'
-            $result.WildCard | Should -Be '0.255.255.255'
+            $result.Mask | Should-Be '255.0.0.0'
+            $result.IPcount | Should-Be 16777216  # 2^24
+            $result.Subnet | Should-Be '10.0.0.0'
+            $result.Broadcast | Should-Be '10.255.255.255'
+            $result.WildCard | Should-Be '0.255.255.255'
         }
 
         It 'Should calculate /16 network (Class B) correctly' {
             $result = Get-IPSubnet -CIDR '172.16.0.0/16'
-            $result.Mask | Should -Be '255.255.0.0'
-            $result.IPcount | Should -Be 65536  # 2^16
-            $result.Subnet | Should -Be '172.16.0.0'
-            $result.Broadcast | Should -Be '172.16.255.255'
-            $result.WildCard | Should -Be '0.0.255.255'
+            $result.Mask | Should-Be '255.255.0.0'
+            $result.IPcount | Should-Be 65536  # 2^16
+            $result.Subnet | Should-Be '172.16.0.0'
+            $result.Broadcast | Should-Be '172.16.255.255'
+            $result.WildCard | Should-Be '0.0.255.255'
         }
 
         It 'Should calculate /28 network correctly' {
             $result = Get-IPSubnet -CIDR '192.168.1.16/28'
-            $result.Mask | Should -Be '255.255.255.240'
-            $result.IPcount | Should -Be 16
-            $result.Subnet | Should -Be '192.168.1.16'
-            $result.Broadcast | Should -Be '192.168.1.31'
-            $result.WildCard | Should -Be '0.0.0.15'
+            $result.Mask | Should-Be '255.255.255.240'
+            $result.IPcount | Should-Be 16
+            $result.Subnet | Should-Be '192.168.1.16'
+            $result.Broadcast | Should-Be '192.168.1.31'
+            $result.WildCard | Should-Be '0.0.0.15'
         }
 
         It 'Should handle subnet calculation for arbitrary IP in range' {
@@ -124,10 +124,10 @@ Describe 'Get-IPSubnet' {
             $result2 = Get-IPSubnet -CIDR '192.168.100.60/28'
 
             # Both should resolve to the same subnet
-            $result1.Subnet | Should -Be '192.168.100.48'
-            $result2.Subnet | Should -Be '192.168.100.48'
-            $result1.Broadcast | Should -Be '192.168.100.63'
-            $result2.Broadcast | Should -Be '192.168.100.63'
+            $result1.Subnet | Should-Be '192.168.100.48'
+            $result2.Subnet | Should-Be '192.168.100.48'
+            $result1.Broadcast | Should-Be '192.168.100.63'
+            $result2.Broadcast | Should-Be '192.168.100.63'
         }
 
         It 'Should calculate VLSM subnets correctly' {
@@ -135,50 +135,50 @@ Describe 'Get-IPSubnet' {
             $subnet2 = Get-IPSubnet -CIDR '192.168.1.128/25'
 
             # First half
-            $subnet1.Subnet | Should -Be '192.168.1.0'
-            $subnet1.Broadcast | Should -Be '192.168.1.127'
-            $subnet1.IPcount | Should -Be 128
+            $subnet1.Subnet | Should-Be '192.168.1.0'
+            $subnet1.Broadcast | Should-Be '192.168.1.127'
+            $subnet1.IPcount | Should-Be 128
 
             # Second half
-            $subnet2.Subnet | Should -Be '192.168.1.128'
-            $subnet2.Broadcast | Should -Be '192.168.1.255'
-            $subnet2.IPcount | Should -Be 128
+            $subnet2.Subnet | Should-Be '192.168.1.128'
+            $subnet2.Broadcast | Should-Be '192.168.1.255'
+            $subnet2.IPcount | Should-Be 128
         }
     }
 
     Context 'Common subnet calculations' {
         It 'Should calculate /8 network correctly' {
             $result = Get-IPSubnet -CIDR '10.0.0.0/8'
-            $result.Mask | Should -Be '255.0.0.0'
-            $result.IPcount | Should -Be 16777216  # 2^24
-            $result.Subnet | Should -Be '10.0.0.0'
-            $result.Broadcast | Should -Be '10.255.255.255'
+            $result.Mask | Should-Be '255.0.0.0'
+            $result.IPcount | Should-Be 16777216  # 2^24
+            $result.Subnet | Should-Be '10.0.0.0'
+            $result.Broadcast | Should-Be '10.255.255.255'
         }
 
         It 'Should calculate /16 network correctly' {
             $result = Get-IPSubnet -CIDR '172.16.0.0/16'
-            $result.Mask | Should -Be '255.255.0.0'
-            $result.IPcount | Should -Be 65536  # 2^16
-            $result.Subnet | Should -Be '172.16.0.0'
-            $result.Broadcast | Should -Be '172.16.255.255'
+            $result.Mask | Should-Be '255.255.0.0'
+            $result.IPcount | Should-Be 65536  # 2^16
+            $result.Subnet | Should-Be '172.16.0.0'
+            $result.Broadcast | Should-Be '172.16.255.255'
         }
 
         It 'Should calculate /30 network correctly (point-to-point)' {
             $result = Get-IPSubnet -CIDR '192.168.1.0/30'
-            $result.Mask | Should -Be '255.255.255.252'
-            $result.IPcount | Should -Be 4
-            $result.Subnet | Should -Be '192.168.1.0'
-            $result.Broadcast | Should -Be '192.168.1.3'
-            $result.WildCard | Should -Be '0.0.0.3'
+            $result.Mask | Should-Be '255.255.255.252'
+            $result.IPcount | Should-Be 4
+            $result.Subnet | Should-Be '192.168.1.0'
+            $result.Broadcast | Should-Be '192.168.1.3'
+            $result.WildCard | Should-Be '0.0.0.3'
         }
 
         It 'Should calculate /32 host route correctly' {
             $result = Get-IPSubnet -CIDR '192.168.1.1/32'
-            $result.Mask | Should -Be '255.255.255.255'
-            $result.IPcount | Should -Be 1
-            $result.Subnet | Should -Be '192.168.1.1'
-            $result.Broadcast | Should -Be '192.168.1.1'
-            $result.WildCard | Should -Be '0.0.0.0'
+            $result.Mask | Should-Be '255.255.255.255'
+            $result.IPcount | Should-Be 1
+            $result.Subnet | Should-Be '192.168.1.1'
+            $result.Broadcast | Should-Be '192.168.1.1'
+            $result.WildCard | Should-Be '0.0.0.0'
         }
     }
 
@@ -195,14 +195,14 @@ Describe 'Get-IPSubnet' {
         }
 
         It 'Should reject invalid IP addresses' {
-            { Get-IPSubnet -CIDR '999.999.999.999/24' } | Should -Throw
-            { Get-IPSubnet -IPAddress '256.1.1.1' -Mask '255.255.255.0' } | Should -Throw
+            { Get-IPSubnet -CIDR '999.999.999.999/24' } | Should-Throw
+            { Get-IPSubnet -IPAddress '256.1.1.1' -Mask '255.255.255.0' } | Should-Throw
         }
 
         It 'Should reject invalid prefix lengths' {
-            { Get-IPSubnet -CIDR '192.168.1.0/33' } | Should -Throw
-            { Get-IPSubnet -IPAddress '192.168.1.0' -PrefixLength -1 } | Should -Throw
-            { Get-IPSubnet -IPAddress '192.168.1.0' -PrefixLength 33 } | Should -Throw
+            { Get-IPSubnet -CIDR '192.168.1.0/33' } | Should-Throw
+            { Get-IPSubnet -IPAddress '192.168.1.0' -PrefixLength -1 } | Should-Throw
+            { Get-IPSubnet -IPAddress '192.168.1.0' -PrefixLength 33 } | Should-Throw
         }
     }
 
@@ -211,14 +211,14 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.0/24'
 
             # Verify binary format (dotted octets in binary)
-            $result.IPBin | Should -Match '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
-            $result.MaskBin | Should -Match '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
-            $result.SubnetBin | Should -Match '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
-            $result.BroadcastBin | Should -Match '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
+            $result.IPBin | Should-MatchString '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
+            $result.MaskBin | Should-MatchString '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
+            $result.SubnetBin | Should-MatchString '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
+            $result.BroadcastBin | Should-MatchString '^\d{8}\.\d{8}\.\d{8}\.\d{8}$'
 
             # Verify specific values for /24
-            $result.IPBin | Should -Be '11000000.10101000.00000001.00000000'
-            $result.MaskBin | Should -Be '11111111.11111111.11111111.00000000'
+            $result.IPBin | Should-Be '11000000.10101000.00000001.00000000'
+            $result.MaskBin | Should-Be '11111111.11111111.11111111.00000000'
         }
     }
 
@@ -228,7 +228,7 @@ Describe 'Get-IPSubnet' {
 
             # 192.168.1.0 in decimal should be calculated correctly
             # 192 * 16777216 + 168 * 65536 + 1 * 256 + 0 = 3232235776
-            $result.ToDecimal | Should -Be 3232235776
+            $result.ToDecimal | Should-Be 3232235776
         }
     }
 
@@ -238,12 +238,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.0/24' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 256
-            $result.UsableIPCount | Should -Be 254
-            $result.FirstUsableIP | Should -Be '192.168.1.1'
-            $result.LastUsableIP | Should -Be '192.168.1.254'
-            $result.Subnet | Should -Be '192.168.1.0'
-            $result.Broadcast | Should -Be '192.168.1.255'
+            $result.IPcount | Should-Be 256
+            $result.UsableIPCount | Should-Be 254
+            $result.FirstUsableIP | Should-Be '192.168.1.1'
+            $result.LastUsableIP | Should-Be '192.168.1.254'
+            $result.Subnet | Should-Be '192.168.1.0'
+            $result.Broadcast | Should-Be '192.168.1.255'
         }
 
         It 'Calculate usable IPs for point-to-point /30 subnet' {
@@ -251,12 +251,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.0/30' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 4
-            $result.UsableIPCount | Should -Be 2
-            $result.FirstUsableIP | Should -Be '192.168.1.1'
-            $result.LastUsableIP | Should -Be '192.168.1.2'
-            $result.Subnet | Should -Be '192.168.1.0'
-            $result.Broadcast | Should -Be '192.168.1.3'
+            $result.IPcount | Should-Be 4
+            $result.UsableIPCount | Should-Be 2
+            $result.FirstUsableIP | Should-Be '192.168.1.1'
+            $result.LastUsableIP | Should-Be '192.168.1.2'
+            $result.Subnet | Should-Be '192.168.1.0'
+            $result.Broadcast | Should-Be '192.168.1.3'
         }
 
         It 'Calculate usable IPs for /31 subnet (RFC 3021 point-to-point)' {
@@ -264,12 +264,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.0/31' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 2
-            $result.UsableIPCount | Should -Be 2
-            $result.FirstUsableIP | Should -Be '192.168.1.0'
-            $result.LastUsableIP | Should -Be '192.168.1.1'
-            $result.Subnet | Should -Be '192.168.1.0'
-            $result.Broadcast | Should -Be '192.168.1.1'
+            $result.IPcount | Should-Be 2
+            $result.UsableIPCount | Should-Be 2
+            $result.FirstUsableIP | Should-Be '192.168.1.0'
+            $result.LastUsableIP | Should-Be '192.168.1.1'
+            $result.Subnet | Should-Be '192.168.1.0'
+            $result.Broadcast | Should-Be '192.168.1.1'
         }
 
         It 'Calculate usable IPs for /32 host route' {
@@ -277,12 +277,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.100/32' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 1
-            $result.UsableIPCount | Should -Be 1
-            $result.FirstUsableIP | Should -Be '192.168.1.100'
-            $result.LastUsableIP | Should -Be '192.168.1.100'
-            $result.Subnet | Should -Be '192.168.1.100'
-            $result.Broadcast | Should -Be '192.168.1.100'
+            $result.IPcount | Should-Be 1
+            $result.UsableIPCount | Should-Be 1
+            $result.FirstUsableIP | Should-Be '192.168.1.100'
+            $result.LastUsableIP | Should-Be '192.168.1.100'
+            $result.Subnet | Should-Be '192.168.1.100'
+            $result.Broadcast | Should-Be '192.168.1.100'
         }
 
         It 'Calculate usable IPs for small /28 subnet' {
@@ -290,12 +290,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.64/28' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 16
-            $result.UsableIPCount | Should -Be 14
-            $result.FirstUsableIP | Should -Be '192.168.1.65'
-            $result.LastUsableIP | Should -Be '192.168.1.78'
-            $result.Subnet | Should -Be '192.168.1.64'
-            $result.Broadcast | Should -Be '192.168.1.79'
+            $result.IPcount | Should-Be 16
+            $result.UsableIPCount | Should-Be 14
+            $result.FirstUsableIP | Should-Be '192.168.1.65'
+            $result.LastUsableIP | Should-Be '192.168.1.78'
+            $result.Subnet | Should-Be '192.168.1.64'
+            $result.Broadcast | Should-Be '192.168.1.79'
         }
 
         It 'Calculate usable IPs for large /16 subnet' {
@@ -303,12 +303,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '172.16.0.0/16' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 65536
-            $result.UsableIPCount | Should -Be 65534
-            $result.FirstUsableIP | Should -Be '172.16.0.1'
-            $result.LastUsableIP | Should -Be '172.16.255.254'
-            $result.Subnet | Should -Be '172.16.0.0'
-            $result.Broadcast | Should -Be '172.16.255.255'
+            $result.IPcount | Should-Be 65536
+            $result.UsableIPCount | Should-Be 65534
+            $result.FirstUsableIP | Should-Be '172.16.0.1'
+            $result.LastUsableIP | Should-Be '172.16.255.254'
+            $result.Subnet | Should-Be '172.16.0.0'
+            $result.Broadcast | Should-Be '172.16.255.255'
         }
 
         It 'Should not include usable IP properties when UsableIPs switch is not used' {
@@ -316,9 +316,9 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.0/24'
             $result | Should -Not -BeNullOrEmpty
 
-            $result.PSObject.Properties.Name | Should -Not -Contain 'UsableIPCount'
-            $result.PSObject.Properties.Name | Should -Not -Contain 'FirstUsableIP'
-            $result.PSObject.Properties.Name | Should -Not -Contain 'LastUsableIP'
+            $result.PSObject.Properties.Name | Should-NotContainCollection 'UsableIPCount'
+            $result.PSObject.Properties.Name | Should-NotContainCollection 'FirstUsableIP'
+            $result.PSObject.Properties.Name | Should-NotContainCollection 'LastUsableIP'
         }
 
         It 'Should include usable IP properties when UsableIPs is used' {
@@ -326,14 +326,14 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.0/24' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.PSObject.Properties.Name | Should -Contain 'UsableIPCount'
-            $result.PSObject.Properties.Name | Should -Contain 'FirstUsableIP'
-            $result.PSObject.Properties.Name | Should -Contain 'LastUsableIP'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'UsableIPCount'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FirstUsableIP'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'LastUsableIP'
 
             # Verify properties have correct values
-            $result.UsableIPCount | Should -Be 254
-            $result.FirstUsableIP | Should -Be '192.168.1.1'
-            $result.LastUsableIP | Should -Be '192.168.1.254'
+            $result.UsableIPCount | Should-Be 254
+            $result.FirstUsableIP | Should-Be '192.168.1.1'
+            $result.LastUsableIP | Should-Be '192.168.1.254'
         }
 
         It 'Calculate usable IPs with IP and Mask parameters' {
@@ -341,10 +341,10 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -IPAddress '10.0.0.0' -Mask '255.255.255.0' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 256
-            $result.UsableIPCount | Should -Be 254
-            $result.FirstUsableIP | Should -Be '10.0.0.1'
-            $result.LastUsableIP | Should -Be '10.0.0.254'
+            $result.IPcount | Should-Be 256
+            $result.UsableIPCount | Should-Be 254
+            $result.FirstUsableIP | Should-Be '10.0.0.1'
+            $result.LastUsableIP | Should-Be '10.0.0.254'
         }
 
         It 'Calculate usable IPs with IP and PrefixLength parameters' {
@@ -352,12 +352,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -IPAddress '172.16.5.100' -PrefixLength 24 -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 256
-            $result.UsableIPCount | Should -Be 254
-            $result.FirstUsableIP | Should -Be '172.16.5.1'
-            $result.LastUsableIP | Should -Be '172.16.5.254'
-            $result.Subnet | Should -Be '172.16.5.0'
-            $result.Broadcast | Should -Be '172.16.5.255'
+            $result.IPcount | Should-Be 256
+            $result.UsableIPCount | Should-Be 254
+            $result.FirstUsableIP | Should-Be '172.16.5.1'
+            $result.LastUsableIP | Should-Be '172.16.5.254'
+            $result.Subnet | Should-Be '172.16.5.0'
+            $result.Broadcast | Should-Be '172.16.5.255'
         }
     }
 
@@ -367,12 +367,12 @@ Describe 'Get-IPSubnet' {
             $result = Get-IPSubnet -CIDR '192.168.1.8/29' -UsableIPs
             $result | Should -Not -BeNullOrEmpty
 
-            $result.IPcount | Should -Be 8
-            $result.UsableIPCount | Should -Be 6
-            $result.FirstUsableIP | Should -Be '192.168.1.9'
-            $result.LastUsableIP | Should -Be '192.168.1.14'
-            $result.Subnet | Should -Be '192.168.1.8'
-            $result.Broadcast | Should -Be '192.168.1.15'
+            $result.IPcount | Should-Be 8
+            $result.UsableIPCount | Should-Be 6
+            $result.FirstUsableIP | Should-Be '192.168.1.9'
+            $result.LastUsableIP | Should-Be '192.168.1.14'
+            $result.Subnet | Should-Be '192.168.1.8'
+            $result.Broadcast | Should-Be '192.168.1.15'
         }
 
         It 'Verify /31 and /30 subnets have different usable IP logic' {
@@ -381,16 +381,16 @@ Describe 'Get-IPSubnet' {
             $result31 = Get-IPSubnet -CIDR '192.168.1.0/31' -UsableIPs
 
             # /30: 4 total, 2 usable (excludes network/broadcast)
-            $result30.IPcount | Should -Be 4
-            $result30.UsableIPCount | Should -Be 2
-            $result30.FirstUsableIP | Should -Be '192.168.1.1'
-            $result30.LastUsableIP | Should -Be '192.168.1.2'
+            $result30.IPcount | Should-Be 4
+            $result30.UsableIPCount | Should-Be 2
+            $result30.FirstUsableIP | Should-Be '192.168.1.1'
+            $result30.LastUsableIP | Should-Be '192.168.1.2'
 
             # /31: 2 total, 2 usable (both IPs usable)
-            $result31.IPcount | Should -Be 2
-            $result31.UsableIPCount | Should -Be 2
-            $result31.FirstUsableIP | Should -Be '192.168.1.0'
-            $result31.LastUsableIP | Should -Be '192.168.1.1'
+            $result31.IPcount | Should-Be 2
+            $result31.UsableIPCount | Should-Be 2
+            $result31.FirstUsableIP | Should-Be '192.168.1.0'
+            $result31.LastUsableIP | Should-Be '192.168.1.1'
         }
 
         It 'Verify multiple /32 host routes have correct usable IP calculations' {
@@ -400,12 +400,12 @@ Describe 'Get-IPSubnet' {
             foreach ($addr in $addresses)
             {
                 $result = Get-IPSubnet -CIDR "$addr/32" -UsableIPs
-                $result.IPcount | Should -Be 1
-                $result.UsableIPCount | Should -Be 1
-                $result.FirstUsableIP | Should -Be $addr
-                $result.LastUsableIP | Should -Be $addr
-                $result.Subnet | Should -Be $addr
-                $result.Broadcast | Should -Be $addr
+                $result.IPcount | Should-Be 1
+                $result.UsableIPCount | Should-Be 1
+                $result.FirstUsableIP | Should-Be $addr
+                $result.LastUsableIP | Should-Be $addr
+                $result.Subnet | Should-Be $addr
+                $result.Broadcast | Should-Be $addr
             }
         }
     }

--- a/Tests/Unit/NetworkAndDns/Get-NetworkProcess.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Get-NetworkProcess.Tests.ps1
@@ -50,30 +50,30 @@ Describe 'Get-NetworkProcess' {
         It 'Should parse TCP and UDP socket records' {
             $results = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof
 
-            @($results).Count | Should -Be 3
+            @($results).Count | Should-Be 3
 
             $listener = $results | Where-Object { $_.LocalPort -eq 3000 }
-            $listener.Protocol | Should -Be 'TCP'
-            $listener.LocalAddress | Should -Be '127.0.0.1'
-            $listener.State | Should -Be 'Listen'
-            $listener.ProcessName | Should -Be 'node'
-            $listener.ProcessId | Should -Be 1234
+            $listener.Protocol | Should-Be 'TCP'
+            $listener.LocalAddress | Should-Be '127.0.0.1'
+            $listener.State | Should-Be 'Listen'
+            $listener.ProcessName | Should-Be 'node'
+            $listener.ProcessId | Should-Be 1234
 
             $udp = $results | Where-Object { $_.LocalPort -eq 5353 }
-            $udp.Protocol | Should -Be 'UDP'
-            $udp.LocalAddress | Should -Be '*'
-            $udp.State | Should -Be 'Unconnected'
-            $udp.ProcessName | Should -Be 'postgres'
+            $udp.Protocol | Should-Be 'UDP'
+            $udp.LocalAddress | Should-Be '*'
+            $udp.State | Should-Be 'Unconnected'
+            $udp.ProcessName | Should-Be 'postgres'
         }
 
         It 'Should parse remote endpoints on established connections' {
             $result = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Established
 
-            @($result).Count | Should -Be 1
-            $result.LocalPort | Should -Be 50100
-            $result.RemoteAddress | Should -Be '127.0.0.1'
-            $result.RemotePort | Should -Be 5432
-            $result.State | Should -Be 'Established'
+            @($result).Count | Should-Be 1
+            $result.LocalPort | Should-Be 50100
+            $result.RemoteAddress | Should-Be '127.0.0.1'
+            $result.RemotePort | Should-Be 5432
+            $result.State | Should-Be 'Established'
         }
     }
 
@@ -81,19 +81,19 @@ Describe 'Get-NetworkProcess' {
         It 'Should parse Windows TCP and UDP netstat records' {
             $results = Get-NetworkProcess -RawConnectionOutput $script:NetstatSample -InputFormat Netstat
 
-            @($results).Count | Should -Be 3
+            @($results).Count | Should-Be 3
 
             $listener = $results | Where-Object { $_.LocalPort -eq 443 }
-            $listener.Protocol | Should -Be 'TCP'
-            $listener.LocalAddress | Should -Be '0.0.0.0'
-            $listener.State | Should -Be 'Listen'
-            $listener.ProcessId | Should -Be 4321
+            $listener.Protocol | Should-Be 'TCP'
+            $listener.LocalAddress | Should-Be '0.0.0.0'
+            $listener.State | Should-Be 'Listen'
+            $listener.ProcessId | Should-Be 4321
 
             $udp = $results | Where-Object { $_.LocalPort -eq 5353 }
-            $udp.Protocol | Should -Be 'UDP'
-            $udp.LocalAddress | Should -Be '::'
-            $udp.RemoteAddress | Should -Be '*'
-            $udp.State | Should -Be 'Unconnected'
+            $udp.Protocol | Should-Be 'UDP'
+            $udp.LocalAddress | Should-Be '::'
+            $udp.RemoteAddress | Should-Be '*'
+            $udp.State | Should-Be 'Unconnected'
         }
     }
 
@@ -101,63 +101,63 @@ Describe 'Get-NetworkProcess' {
         It 'Should filter by local port by default' {
             $results = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Port 3000
 
-            @($results).Count | Should -Be 1
-            $results.ProcessName | Should -Be 'node'
-            $results.LocalPort | Should -Be 3000
+            @($results).Count | Should-Be 1
+            $results.ProcessName | Should-Be 'node'
+            $results.LocalPort | Should-Be 3000
         }
 
         It 'Should include remote ports when IncludeRemotePort is specified' {
             $localOnly = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Port 5432
             $withRemote = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Port 5432 -IncludeRemotePort
 
-            @($localOnly).Count | Should -Be 0
-            @($withRemote).Count | Should -Be 1
-            $withRemote.RemotePort | Should -Be 5432
+            @($localOnly).Count | Should-Be 0
+            @($withRemote).Count | Should-Be 1
+            $withRemote.RemotePort | Should-Be 5432
         }
 
         It 'Should filter by process ID' {
             $results = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -ProcessId 1234
 
-            @($results).Count | Should -Be 2
-            $results | ForEach-Object { $_.ProcessId | Should -Be 1234 }
+            @($results).Count | Should-Be 2
+            $results | ForEach-Object { $_.ProcessId | Should-Be 1234 }
         }
 
         It 'Should filter by wildcard process name' {
             $results = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -ProcessName 'post*'
 
-            @($results).Count | Should -Be 1
-            $results.ProcessName | Should -Be 'postgres'
-            $results.LocalPort | Should -Be 5353
+            @($results).Count | Should-Be 1
+            $results.ProcessName | Should-Be 'postgres'
+            $results.LocalPort | Should-Be 5353
         }
 
         It 'Should filter by protocol' {
             $results = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Protocol UDP
 
-            @($results).Count | Should -Be 1
-            $results.Protocol | Should -Be 'UDP'
+            @($results).Count | Should-Be 1
+            $results.Protocol | Should-Be 'UDP'
         }
 
         It 'Should filter listening and bound sockets' {
             $results = Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Listening
 
-            @($results).Count | Should -Be 2
-            $results.LocalPort | Should -Contain 3000
-            $results.LocalPort | Should -Contain 5353
+            @($results).Count | Should-Be 2
+            $results.LocalPort | Should-ContainCollection 3000
+            $results.LocalPort | Should-ContainCollection 5353
         }
     }
 
     Context 'Parameter validation' {
         It 'Should reject invalid port numbers' {
-            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Port 0 } | Should -Throw
-            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Port 65536 } | Should -Throw
+            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Port 0 } | Should-Throw
+            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Port 65536 } | Should-Throw
         }
 
         It 'Should reject invalid protocol values' {
-            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Protocol ICMP } | Should -Throw
+            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Protocol ICMP } | Should-Throw
         }
 
         It 'Should reject mutually exclusive state switches' {
-            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Listening -Established } | Should -Throw
+            { Get-NetworkProcess -RawConnectionOutput $script:LsofSample -InputFormat Lsof -Listening -Established } | Should-Throw
         }
     }
 }

--- a/Tests/Unit/NetworkAndDns/Get-NetworkRoute.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Get-NetworkRoute.Tests.ps1
@@ -20,16 +20,16 @@ Describe 'Get-NetworkRoute' {
     Context 'Basic routing table retrieval' {
         It 'Should return at least one route' {
             $results = Get-NetworkRoute
-            @($results).Count | Should -BeGreaterThan 0
+            @($results).Count | Should-BeGreaterThan 0
         }
 
         It 'Should return objects with expected properties' {
             $results = Get-NetworkRoute
             $first = $results | Select-Object -First 1
-            $first.PSObject.Properties.Name | Should -Contain 'Destination'
-            $first.PSObject.Properties.Name | Should -Contain 'Gateway'
-            $first.PSObject.Properties.Name | Should -Contain 'Interface'
-            $first.PSObject.Properties.Name | Should -Contain 'Metric'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Destination'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Gateway'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Interface'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Metric'
         }
 
         It 'Should have non-empty Destination values' {
@@ -55,7 +55,7 @@ Describe 'Get-NetworkRoute' {
         }
 
         It 'Should reject invalid AddressFamily values' {
-            { Get-NetworkRoute -AddressFamily 'IPX' } | Should -Throw
+            { Get-NetworkRoute -AddressFamily 'IPX' } | Should-Throw
         }
     }
 

--- a/Tests/Unit/NetworkAndDns/Get-PublicDnsServer.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Get-PublicDnsServer.Tests.ps1
@@ -20,28 +20,28 @@ Describe 'Get-PublicDnsServer' {
     Context 'Default output (no parameters)' {
         It 'Should return multiple DNS server entries' {
             $results = Get-PublicDnsServer
-            @($results).Count | Should -BeGreaterThan 5
+            @($results).Count | Should-BeGreaterThan 5
         }
 
         It 'Should return objects with expected properties' {
             $results = Get-PublicDnsServer
             $first = $results | Select-Object -First 1
-            $first.PSObject.Properties.Name | Should -Contain 'Name'
-            $first.PSObject.Properties.Name | Should -Contain 'IPv4Primary'
-            $first.PSObject.Properties.Name | Should -Contain 'IPv4Secondary'
-            $first.PSObject.Properties.Name | Should -Contain 'IPv6Primary'
-            $first.PSObject.Properties.Name | Should -Contain 'IPv6Secondary'
-            $first.PSObject.Properties.Name | Should -Contain 'DoHUrl'
-            $first.PSObject.Properties.Name | Should -Contain 'DoHJsonUrl'
-            $first.PSObject.Properties.Name | Should -Contain 'PrivacyPolicyUrl'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Name'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'IPv4Primary'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'IPv4Secondary'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'IPv6Primary'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'IPv6Secondary'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'DoHUrl'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'DoHJsonUrl'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'PrivacyPolicyUrl'
         }
 
         It 'Should include well-known providers (Cloudflare, Google, Quad9)' {
             $results = Get-PublicDnsServer
             $names = $results | ForEach-Object { $_.Name }
-            $names | Should -Contain 'Cloudflare'
-            $names | Should -Contain 'Google'
-            $names | Should -Contain 'Quad9'
+            $names | Should-ContainCollection 'Cloudflare'
+            $names | Should-ContainCollection 'Google'
+            $names | Should-ContainCollection 'Quad9'
         }
 
         It 'Should have valid IPv4 addresses for all entries' {
@@ -49,7 +49,7 @@ Describe 'Get-PublicDnsServer' {
             foreach ($server in $results)
             {
                 $parsed = $null
-                [System.Net.IPAddress]::TryParse($server.IPv4Primary, [ref]$parsed) | Should -Be $true
+                [System.Net.IPAddress]::TryParse($server.IPv4Primary, [ref]$parsed) | Should-Be $true
             }
         }
     }
@@ -57,15 +57,15 @@ Describe 'Get-PublicDnsServer' {
     Context 'Name filter' {
         It 'Should filter by exact name' {
             $results = Get-PublicDnsServer -Name 'Google'
-            @($results).Count | Should -Be 1
-            $results.Name | Should -Be 'Google'
-            $results.IPv4Primary | Should -Be '8.8.8.8'
+            @($results).Count | Should-Be 1
+            $results.Name | Should-Be 'Google'
+            $results.IPv4Primary | Should-Be '8.8.8.8'
         }
 
         It 'Should support wildcard filtering' {
             $results = Get-PublicDnsServer -Name 'Cloud*'
-            @($results).Count | Should -Be 1
-            $results.Name | Should -Be 'Cloudflare'
+            @($results).Count | Should-Be 1
+            $results.Name | Should-Be 'Cloudflare'
         }
 
         It 'Should return empty for non-matching name' {
@@ -79,41 +79,41 @@ Describe 'Get-PublicDnsServer' {
             $results = Get-PublicDnsServer -IPv4Only
             foreach ($ip in $results)
             {
-                $ip | Should -BeOfType [String]
+                $ip | Should-HaveType ([String])
                 $parsed = $null
-                [System.Net.IPAddress]::TryParse($ip, [ref]$parsed) | Should -Be $true
+                [System.Net.IPAddress]::TryParse($ip, [ref]$parsed) | Should-Be $true
             }
         }
 
         It 'Should return the same count as full results' {
             $full = Get-PublicDnsServer
             $ipsOnly = Get-PublicDnsServer -IPv4Only
-            @($ipsOnly).Count | Should -Be @($full).Count
+            @($ipsOnly).Count | Should-Be @($full).Count
         }
 
         It 'Should include well-known IPs' {
             $results = Get-PublicDnsServer -IPv4Only
-            $results | Should -Contain '1.1.1.1'
-            $results | Should -Contain '8.8.8.8'
-            $results | Should -Contain '9.9.9.9'
+            $results | Should-ContainCollection '1.1.1.1'
+            $results | Should-ContainCollection '8.8.8.8'
+            $results | Should-ContainCollection '9.9.9.9'
         }
     }
 
     Context 'Known server data integrity' {
         It 'Should have correct Cloudflare data' {
             $cf = Get-PublicDnsServer -Name 'Cloudflare'
-            $cf.IPv4Primary | Should -Be '1.1.1.1'
-            $cf.IPv4Secondary | Should -Be '1.0.0.1'
-            $cf.DoHUrl | Should -Be 'https://cloudflare-dns.com/dns-query'
-            $cf.DoHJsonUrl | Should -Be 'https://cloudflare-dns.com/dns-query'
+            $cf.IPv4Primary | Should-Be '1.1.1.1'
+            $cf.IPv4Secondary | Should-Be '1.0.0.1'
+            $cf.DoHUrl | Should-Be 'https://cloudflare-dns.com/dns-query'
+            $cf.DoHJsonUrl | Should-Be 'https://cloudflare-dns.com/dns-query'
         }
 
         It 'Should have correct Google data' {
             $g = Get-PublicDnsServer -Name 'Google'
-            $g.IPv4Primary | Should -Be '8.8.8.8'
-            $g.IPv4Secondary | Should -Be '8.8.4.4'
-            $g.DoHUrl | Should -Be 'https://dns.google/dns-query'
-            $g.DoHJsonUrl | Should -Be 'https://dns.google/resolve'
+            $g.IPv4Primary | Should-Be '8.8.8.8'
+            $g.IPv4Secondary | Should-Be '8.8.4.4'
+            $g.DoHUrl | Should-Be 'https://dns.google/dns-query'
+            $g.DoHJsonUrl | Should-Be 'https://dns.google/resolve'
         }
     }
 }

--- a/Tests/Unit/NetworkAndDns/Get-ReverseDns.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Get-ReverseDns.Tests.ps1
@@ -20,40 +20,40 @@ Describe 'Get-ReverseDns' {
     Context 'Basic reverse DNS lookups' {
         It 'Should return an object with expected properties' {
             $result = Get-ReverseDns -IPAddress '127.0.0.1'
-            $result.PSObject.Properties.Name | Should -Contain 'IPAddress'
-            $result.PSObject.Properties.Name | Should -Contain 'Hostname'
-            $result.PSObject.Properties.Name | Should -Contain 'Status'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'IPAddress'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Hostname'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Status'
         }
 
         It 'Should resolve localhost (127.0.0.1)' {
             $result = Get-ReverseDns -IPAddress '127.0.0.1'
-            $result.IPAddress | Should -Be '127.0.0.1'
-            $result.Status | Should -BeIn @('Resolved', 'NotFound')
+            $result.IPAddress | Should-Be '127.0.0.1'
+            @('Resolved', 'NotFound') | Should-ContainCollection $result.Status
         }
 
         It 'Should return Resolved or NotFound status for valid IPs' {
             $result = Get-ReverseDns -IPAddress '127.0.0.1'
-            $result.Status | Should -BeIn @('Resolved', 'NotFound')
+            @('Resolved', 'NotFound') | Should-ContainCollection $result.Status
         }
     }
 
     Context 'Multiple IP addresses' {
         It 'Should accept multiple IPs via parameter' {
             $results = Get-ReverseDns -IPAddress '127.0.0.1', '127.0.0.1'
-            @($results).Count | Should -Be 2
+            @($results).Count | Should-Be 2
         }
 
         It 'Should accept IPs from the pipeline' {
             $results = '127.0.0.1', '127.0.0.1' | Get-ReverseDns
-            @($results).Count | Should -Be 2
+            @($results).Count | Should-Be 2
         }
     }
 
     Context 'Non-resolvable IP handling' {
         It 'Should return NotFound for documentation IPs (RFC 5737)' {
             $result = Get-ReverseDns -IPAddress '192.0.2.1'
-            $result.Status | Should -BeIn @('NotFound', 'Error')
-            $result.IPAddress | Should -Be '192.0.2.1'
+            @('NotFound', 'Error') | Should-ContainCollection $result.Status
+            $result.IPAddress | Should-Be '192.0.2.1'
         }
     }
 
@@ -61,17 +61,17 @@ Describe 'Get-ReverseDns' {
         It 'Should require the IPAddress parameter' {
             $param = (Get-Command Get-ReverseDns).Parameters['IPAddress']
             $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
-            ForEach-Object { $_.Mandatory } | Should -Contain $true
+            ForEach-Object { $_.Mandatory } | Should-ContainCollection $true
         }
 
         It 'Should reject invalid IP addresses' {
-            { Get-ReverseDns -IPAddress 'not-an-ip' } | Should -Throw
-            { Get-ReverseDns -IPAddress '999.999.999.999' } | Should -Throw
+            { Get-ReverseDns -IPAddress 'not-an-ip' } | Should-Throw
+            { Get-ReverseDns -IPAddress '999.999.999.999' } | Should-Throw
         }
 
         It 'Should reject empty or null values' {
-            { Get-ReverseDns -IPAddress '' } | Should -Throw
-            { Get-ReverseDns -IPAddress $null } | Should -Throw
+            { Get-ReverseDns -IPAddress '' } | Should-Throw
+            { Get-ReverseDns -IPAddress $null } | Should-Throw
         }
     }
 

--- a/Tests/Unit/NetworkAndDns/Invoke-NetworkDiagnostic.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Invoke-NetworkDiagnostic.Tests.ps1
@@ -69,18 +69,18 @@ Describe 'Invoke-NetworkDiagnostic (Default continuous mode single iteration via
         $output = Invoke-NetworkDiagnostic -HostName 'example.com' -Count 5 -MaxIterations 1 *>&1 | Out-String
 
         # Verify expected content
-        $output | Should -Match 'Network Diagnostic - Continuous Mode'
-        $output | Should -Match '\[\d{2}:\d{2}:\d{2}\]\s+Refresh #1'
-        $output | Should -Match 'example\.com:443'
-        $output | Should -Match 'Stats'
-        $output | Should -Match 'Quality\s+5/5\s+successful'
-        $output | Should -Match 'Press (Q or )?Ctrl\+C to stop monitoring\.'
-        $output | Should -Not -Match 'Samples per host'
-        $output | Should -Not -Match 'Continuous Mode \(Press Ctrl\+C to stop\)'
+        $output | Should-MatchString 'Network Diagnostic - Continuous Mode'
+        $output | Should-MatchString '\[\d{2}:\d{2}:\d{2}\]\s+Refresh #1'
+        $output | Should-MatchString 'example\.com:443'
+        $output | Should-MatchString 'Stats'
+        $output | Should-MatchString 'Quality\s+5/5\s+successful'
+        $output | Should-MatchString 'Press (Q or )?Ctrl\+C to stop monitoring\.'
+        $output | Should-NotMatchString 'Samples per host'
+        $output | Should-NotMatchString 'Continuous Mode \(Press Ctrl\+C to stop\)'
 
         # Ensure NO timestamp or wait messages
-        $output | Should -Not -Match 'Test completed at:'
-        $output | Should -Not -Match 'Waiting'
+        $output | Should-NotMatchString 'Test completed at:'
+        $output | Should-NotMatchString 'Waiting'
     }
 
     It 'does not sleep for -Interval when final iteration is reached' {
@@ -102,7 +102,7 @@ Describe 'Invoke-NetworkDiagnostic (Default continuous mode single iteration via
 
         Invoke-NetworkDiagnostic -HostName 'example.com' -Count 5 -MaxIterations 1 -Interval 9 *> $null
 
-        Should -Invoke -CommandName Start-Sleep -Times 0 -Exactly -ParameterFilter { $PSBoundParameters.ContainsKey('Seconds') -and $Seconds -eq 9 }
+        Should-Invoke -CommandName Start-Sleep -Times 0 -Exactly -ParameterFilter { $PSBoundParameters.ContainsKey('Seconds') -and $Seconds -eq 9 }
     }
 
     It 'shows per-host trend arrows from previous refresh in continuous mode' {
@@ -140,11 +140,11 @@ Describe 'Invoke-NetworkDiagnostic (Default continuous mode single iteration via
         $output = Invoke-NetworkDiagnostic -HostName 'example.com' -Count 5 -MaxIterations 2 -Interval 1 *>&1 | Out-String
         $upArrowPattern = [Regex]::Escape(([string][char]0x2191))
 
-        Should -ActualValue $output -Match 'Trend'
-        Should -ActualValue $output -Match 'avg'
-        Should -ActualValue $output -Match 'jitter'
-        Should -ActualValue $output -Match 'loss'
-        Should -ActualValue $output -Match $upArrowPattern
+        Should-MatchString -Actual $output -Expected 'Trend'
+        Should-MatchString -Actual $output -Expected 'avg'
+        Should-MatchString -Actual $output -Expected 'jitter'
+        Should-MatchString -Actual $output -Expected 'loss'
+        Should-MatchString -Actual $output -Expected $upArrowPattern
     }
 
     It 'continues when Clear-Host fails in continuous clear render mode' {
@@ -183,7 +183,7 @@ Describe 'Invoke-NetworkDiagnostic (Default continuous mode single iteration via
         $output = Invoke-NetworkDiagnostic -HostName 'example.com' -Count 5 -MaxIterations 2 -Interval 1 -RenderMode Clear *>&1 | Out-String
         $upArrowPattern = [Regex]::Escape(([string][char]0x2191))
 
-        Should -ActualValue $output -Match 'Trend'
-        Should -ActualValue $output -Match $upArrowPattern
+        Should-MatchString -Actual $output -Expected 'Trend'
+        Should-MatchString -Actual $output -Expected $upArrowPattern
     }
 }

--- a/Tests/Unit/NetworkAndDns/Show-NetworkLatencyGraph.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Show-NetworkLatencyGraph.Tests.ps1
@@ -12,16 +12,16 @@ Describe 'Show-NetworkLatencyGraph (Data mode)' {
         $data = @(10, 20, 30, 40, 50)
         $result = Show-NetworkLatencyGraph -Data $data -GraphType 'Sparkline'
 
-        $result | Should -BeOfType 'System.String'
-        $result.Length | Should -BeGreaterThan 0
+        $result | Should-HaveType ([System.String])
+        $result.Length | Should-BeGreaterThan 0
     }
 
     It 'includes stats when -ShowStats is set' {
         $data = @(20, 25, 30, 35, 40)
         $result = Show-NetworkLatencyGraph -Data $data -GraphType 'Sparkline' -ShowStats
 
-        $result | Should -Match 'min:'
-        $result | Should -Match 'max:'
-        $result | Should -Match 'avg:'
+        $result | Should-MatchString 'min:'
+        $result | Should-MatchString 'max:'
+        $result | Should-MatchString 'avg:'
     }
 }

--- a/Tests/Unit/NetworkAndDns/Test-DnsNameResolution.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Test-DnsNameResolution.Tests.ps1
@@ -26,8 +26,8 @@ Describe 'Test-DnsNameResolution' {
         It 'Tests whether localhost can be resolved using system DNS (Example: Test-DnsNameResolution -Name "localhost")' {
             # Test DNS resolution using the system resolver for cross-platform compatibility
             $result = Test-DnsNameResolution -Name 'localhost'
-            $result | Should -BeOfType [System.Boolean]
-            $result | Should -Be $true
+            $result | Should-HaveType ([System.Boolean])
+            $result | Should-Be $true
         }
 
         It 'Tests whether localhost has an IPv4 (A) record with verbose output (Example: Test-DnsNameResolution -Name "localhost" -Type "A" -Verbose)' {
@@ -36,8 +36,8 @@ Describe 'Test-DnsNameResolution' {
 
             # Extract the boolean result (last item should be the result)
             $result = $verboseOutput | Where-Object { $_ -isnot [System.Management.Automation.VerboseRecord] } | Select-Object -Last 1
-            $result | Should -BeOfType [System.Boolean]
-            $result | Should -Be $true
+            $result | Should-HaveType ([System.Boolean])
+            $result | Should-Be $true
 
             # Check for verbose output
             $verboseMessages = $verboseOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
@@ -48,21 +48,21 @@ Describe 'Test-DnsNameResolution' {
     Context 'IPv4 record resolution' {
         It 'Should resolve localhost to IPv4 addresses' {
             $result = Test-DnsNameResolution -Name 'localhost' -Type 'A'
-            $result | Should -Be $true
+            $result | Should-Be $true
         }
 
         It 'Should handle domain names with different cases' {
             $result1 = Test-DnsNameResolution -Name 'LOCALHOST'
             $result2 = Test-DnsNameResolution -Name 'localhost'
-            $result1 | Should -Be $result2
-            $result1 | Should -Be $true
+            $result1 | Should-Be $result2
+            $result1 | Should-Be $true
         }
     }
 
     Context 'IPv6 record resolution' {
         It 'Should test IPv6 resolution for localhost' {
             $result = Test-DnsNameResolution -Name 'localhost' -Type 'AAAA'
-            $result | Should -BeOfType [System.Boolean]
+            $result | Should-HaveType ([System.Boolean])
             # localhost might have IPv6 records depending on system configuration
             # We just verify it returns a boolean
         }
@@ -71,29 +71,29 @@ Describe 'Test-DnsNameResolution' {
     Context 'Invalid domain handling' {
         It 'Should return false for non-existent domains' {
             $result = Test-DnsNameResolution -Name 'this-domain-definitely-does-not-exist-12345.com'
-            $result | Should -Be $false
+            $result | Should-Be $false
         }
 
         It 'Should return false for invalid domain names' {
             $result = Test-DnsNameResolution -Name 'invalid..domain'
-            $result | Should -Be $false
+            $result | Should-Be $false
         }
 
         It 'Should handle malformed domain names gracefully' {
             $result = Test-DnsNameResolution -Name '.....'
-            $result | Should -Be $false
+            $result | Should-Be $false
         }
     }
 
     Context 'Parameter validation' {
         It 'Should require Name parameter' {
-            { Test-DnsNameResolution } | Should -Throw
+            { Test-DnsNameResolution } | Should-Throw
         }
 
         It 'Should reject null or empty Name parameter' {
-            { Test-DnsNameResolution -Name $null } | Should -Throw
-            { Test-DnsNameResolution -Name '' } | Should -Throw
-            { Test-DnsNameResolution -Name '   ' } | Should -Throw
+            { Test-DnsNameResolution -Name $null } | Should-Throw
+            { Test-DnsNameResolution -Name '' } | Should-Throw
+            { Test-DnsNameResolution -Name '   ' } | Should-Throw
         }
 
         It 'Should accept valid DNS record types' {
@@ -103,7 +103,7 @@ Describe 'Test-DnsNameResolution' {
         }
 
         It 'Should reject invalid DNS record types' {
-            { Test-DnsNameResolution -Name 'localhost' -Type 'INVALID' } | Should -Throw
+            { Test-DnsNameResolution -Name 'localhost' -Type 'INVALID' } | Should-Throw
         }
     }
 
@@ -112,18 +112,18 @@ Describe 'Test-DnsNameResolution' {
             $domains = @('localhost', 'localhost')  # Use localhost twice for predictable results
             $results = $domains | Test-DnsNameResolution
 
-            $results | Should -HaveCount 2
-            $results | ForEach-Object { $_ | Should -BeOfType [System.Boolean] }
-            $results | ForEach-Object { $_ | Should -Be $true }
+            $results | Should-BeCollection -Count 2
+            $results | ForEach-Object { $_ | Should-HaveType ([System.Boolean]) }
+            $results | ForEach-Object { $_ | Should-Be $true }
         }
 
         It 'Should handle mixed valid and invalid domains via pipeline' {
             $domains = @('localhost', 'this-definitely-does-not-exist-12345.com')
             $results = $domains | Test-DnsNameResolution
 
-            $results | Should -HaveCount 2
-            $results[0] | Should -Be $true   # localhost should resolve
-            $results[1] | Should -Be $false  # invalid domain should not resolve
+            $results | Should-BeCollection -Count 2
+            $results[0] | Should-Be $true   # localhost should resolve
+            $results[1] | Should-Be $false  # invalid domain should not resolve
         }
     }
 
@@ -131,14 +131,14 @@ Describe 'Test-DnsNameResolution' {
         It 'Should use .NET DNS methods for cross-platform compatibility' {
             # This test verifies the function works on different platforms
             $result = Test-DnsNameResolution -Name 'localhost'
-            $result | Should -BeOfType [System.Boolean]
-            $result | Should -Be $true
+            $result | Should-HaveType ([System.Boolean])
+            $result | Should-Be $true
         }
 
         It 'Should handle system DNS configuration differences across platforms' {
             # Test that it works regardless of platform-specific DNS configuration
             $result = Test-DnsNameResolution -Name 'localhost'
-            $result | Should -Be $true
+            $result | Should-Be $true
         }
     }
 
@@ -152,20 +152,20 @@ Describe 'Test-DnsNameResolution' {
 
             # Verbose messages should contain relevant information
             $verboseText = $verboseMessages | ForEach-Object { $_.Message } | Out-String
-            $verboseText | Should -Match 'DNS'
-            $verboseText | Should -Match 'localhost'
+            $verboseText | Should-MatchString 'DNS'
+            $verboseText | Should-MatchString 'localhost'
         }
 
         It 'Should log different messages for successful and failed resolutions' {
             # Successful resolution
             $successOutput = Test-DnsNameResolution -Name 'localhost' -Verbose 4>&1
             $successVerbose = ($successOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } | ForEach-Object { $_.Message }) -join ' '
-            $successVerbose | Should -Match '(successful|found)'
+            $successVerbose | Should-MatchString '(successful|found)'
 
             # Failed resolution
             $failOutput = Test-DnsNameResolution -Name 'this-does-not-exist-12345.com' -Verbose 4>&1
             $failVerbose = ($failOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] } | ForEach-Object { $_.Message }) -join ' '
-            $failVerbose | Should -Match '(not found|failed)'
+            $failVerbose | Should-MatchString '(not found|failed)'
         }
     }
 
@@ -173,9 +173,9 @@ Describe 'Test-DnsNameResolution' {
         It 'Should handle network timeouts gracefully' {
             # Test with a domain that might timeout (unreachable)
             $result = Test-DnsNameResolution -Name 'timeout-test-domain-that-does-not-exist.invalid'
-            $result | Should -BeOfType [System.Boolean]
+            $result | Should-HaveType ([System.Boolean])
             # Should return false for unresolvable domains
-            $result | Should -Be $false
+            $result | Should-Be $false
         }
 
         It 'Should return proper result type in all scenarios' {
@@ -186,7 +186,7 @@ Describe 'Test-DnsNameResolution' {
                 (Test-DnsNameResolution -Name 'localhost')
             )
 
-            $results | ForEach-Object { $_ | Should -BeOfType [System.Boolean] }
+            $results | ForEach-Object { $_ | Should-HaveType ([System.Boolean]) }
         }
     }
 }

--- a/Tests/Unit/NetworkAndDns/Test-DnsPropagation.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Test-DnsPropagation.Tests.ps1
@@ -26,12 +26,12 @@ Describe 'Test-DnsPropagation' {
         It 'Should require the Name parameter' {
             $param = (Get-Command Test-DnsPropagation).Parameters['Name']
             $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
-            ForEach-Object { $_.Mandatory } | Should -Contain $true
+            ForEach-Object { $_.Mandatory } | Should-ContainCollection $true
         }
 
         It 'Should reject empty Name parameter' {
-            { Test-DnsPropagation -Name '' } | Should -Throw
-            { Test-DnsPropagation -Name $null } | Should -Throw
+            { Test-DnsPropagation -Name '' } | Should-Throw
+            { Test-DnsPropagation -Name $null } | Should-Throw
         }
 
         It 'Should accept valid DNS record types' {
@@ -39,12 +39,12 @@ Describe 'Test-DnsPropagation' {
         }
 
         It 'Should reject invalid DNS record types' {
-            { Test-DnsPropagation -Name 'example.com' -Type 'INVALID' } | Should -Throw
+            { Test-DnsPropagation -Name 'example.com' -Type 'INVALID' } | Should-Throw
         }
 
         It 'Should validate Timeout range' {
-            { Test-DnsPropagation -Name 'example.com' -Timeout 0 } | Should -Throw
-            { Test-DnsPropagation -Name 'example.com' -Timeout 31 } | Should -Throw
+            { Test-DnsPropagation -Name 'example.com' -Timeout 0 } | Should-Throw
+            { Test-DnsPropagation -Name 'example.com' -Timeout 31 } | Should-Throw
         }
     }
 
@@ -55,22 +55,22 @@ Describe 'Test-DnsPropagation' {
         }
 
         It 'Should return results for multiple servers' {
-            @($script:results).Count | Should -BeGreaterThan 0
+            @($script:results).Count | Should-BeGreaterThan 0
         }
 
         It 'Should return objects with expected properties' {
             $first = $script:results | Select-Object -First 1
-            $first.PSObject.Properties.Name | Should -Contain 'Server'
-            $first.PSObject.Properties.Name | Should -Contain 'IPv4Primary'
-            $first.PSObject.Properties.Name | Should -Contain 'Status'
-            $first.PSObject.Properties.Name | Should -Contain 'Records'
-            $first.PSObject.Properties.Name | Should -Contain 'Propagated'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Server'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'IPv4Primary'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Status'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Records'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Propagated'
         }
 
         It 'Should have boolean Propagated values' {
             foreach ($r in $script:results)
             {
-                $r.Propagated | Should -BeOfType [System.Boolean]
+                $r.Propagated | Should-HaveType ([System.Boolean])
             }
         }
     }

--- a/Tests/Unit/NetworkAndDns/Test-Port.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Test-Port.Tests.ps1
@@ -28,32 +28,32 @@ Describe 'Test-Port' -Skip {
             # Test basic TCP port connectivity - equivalent to first documentation example
             $result = Test-Port -ComputerName 'localhost' -Port 80
             $result | Should -Not -BeNullOrEmpty
-            $result[0].Server | Should -Be 'localhost'
-            $result[0].Port | Should -Be 80
-            $result[0].Protocol | Should -Be 'TCP'
-            $result[0].Open | Should -BeOfType [Boolean]
+            $result[0].Server | Should-Be 'localhost'
+            $result[0].Port | Should-Be 80
+            $result[0].Protocol | Should-Be 'TCP'
+            $result[0].Open | Should-HaveType ([Boolean])
         }
 
         It 'Tests TCP port using pipeline input for port (Example: 80 | Test-Port)' {
             # Test pipeline input for port number - equivalent to second documentation example
             $result = 80 | Test-Port
             $result | Should -Not -BeNullOrEmpty
-            $result[0].Port | Should -Be 80
-            $result[0].Protocol | Should -Be 'TCP'
-            $result[0].Server | Should -Be 'localhost'  # Default when no ComputerName specified
+            $result[0].Port | Should-Be 80
+            $result[0].Protocol | Should-Be 'TCP'
+            $result[0].Server | Should-Be 'localhost'  # Default when no ComputerName specified
         }
 
         It 'Tests multiple TCP ports using pipeline input (Example: 22,80,443 | Test-Port)' {
             # Test multiple ports via pipeline - equivalent to third documentation example
             $result = 22, 80, 443 | Test-Port
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 3
-            $result[0].Port | Should -Be 22
-            $result[1].Port | Should -Be 80
-            $result[2].Port | Should -Be 443
+            $result | Should-BeCollection -Count 3
+            $result[0].Port | Should-Be 22
+            $result[1].Port | Should-Be 80
+            $result[2].Port | Should-Be 443
             $result | ForEach-Object {
-                $_.Protocol | Should -Be 'TCP'
-                $_.Server | Should -Be 'localhost'
+                $_.Protocol | Should-Be 'TCP'
+                $_.Server | Should-Be 'localhost'
             }
         }
 
@@ -61,13 +61,13 @@ Describe 'Test-Port' -Skip {
             # Test a small port range to validate the concept from documentation example
             $result = 1..3 | Test-Port -ComputerName 'localhost'
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 3
-            $result[0].Port | Should -Be 1
-            $result[1].Port | Should -Be 2
-            $result[2].Port | Should -Be 3
+            $result | Should-BeCollection -Count 3
+            $result[0].Port | Should-Be 1
+            $result[1].Port | Should-Be 2
+            $result[2].Port | Should-Be 3
             $result | ForEach-Object {
-                $_.Server | Should -Be 'localhost'
-                $_.Protocol | Should -Be 'TCP'
+                $_.Server | Should-Be 'localhost'
+                $_.Protocol | Should-Be 'TCP'
             }
         }
 
@@ -75,12 +75,12 @@ Describe 'Test-Port' -Skip {
             # Test multiple computers - equivalent to documentation example
             $result = Test-Port -ComputerName @('localhost', '127.0.0.1') -Port 80
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 2
-            $result[0].Server | Should -Be 'localhost'
-            $result[1].Server | Should -Be '127.0.0.1'
+            $result | Should-BeCollection -Count 2
+            $result[0].Server | Should-Be 'localhost'
+            $result[1].Server | Should-Be '127.0.0.1'
             $result | ForEach-Object {
-                $_.Port | Should -Be 80
-                $_.Protocol | Should -Be 'TCP'
+                $_.Port | Should-Be 80
+                $_.Protocol | Should-Be 'TCP'
             }
         }
     }
@@ -89,17 +89,17 @@ Describe 'Test-Port' -Skip {
         It 'Tests multiple ports on localhost using pipeline input for ports' {
             $result = 80, 443 | Test-Port -ComputerName 'localhost'
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 2
-            $result | ForEach-Object { $_.Server | Should -Be 'localhost' }
+            $result | Should-BeCollection -Count 2
+            $result | ForEach-Object { $_.Server | Should-Be 'localhost' }
         }
 
         It 'Tests a range of ports using pipeline input' {
             $result = 1..3 | Test-Port -ComputerName 'localhost'
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 3
-            $result[0].Port | Should -Be 1
-            $result[1].Port | Should -Be 2
-            $result[2].Port | Should -Be 3
+            $result | Should-BeCollection -Count 3
+            $result[0].Port | Should-Be 1
+            $result[1].Port | Should-Be 2
+            $result[2].Port | Should-Be 3
         }
     }
 
@@ -111,9 +111,9 @@ Describe 'Test-Port' -Skip {
         }
 
         It 'Should reject invalid port numbers' {
-            { Test-Port -Port 0 } | Should -Throw
-            { Test-Port -Port 65536 } | Should -Throw
-            { Test-Port -Port -1 } | Should -Throw
+            { Test-Port -Port 0 } | Should-Throw
+            { Test-Port -Port 65536 } | Should-Throw
+            { Test-Port -Port -1 } | Should-Throw
         }
 
         It 'Should accept valid timeout values' {
@@ -122,25 +122,25 @@ Describe 'Test-Port' -Skip {
         }
 
         It 'Should reject invalid timeout values' {
-            { Test-Port -Port 80 -Timeout 99 } | Should -Throw
-            { Test-Port -Port 80 -Timeout 300001 } | Should -Throw
+            { Test-Port -Port 80 -Timeout 99 } | Should-Throw
+            { Test-Port -Port 80 -Timeout 300001 } | Should-Throw
         }
     }
 
     Context 'Protocol selection' {
         It 'Should default to TCP when no protocol is specified' {
             $result = Test-Port -Port 80
-            $result[0].Protocol | Should -Be 'TCP'
+            $result[0].Protocol | Should-Be 'TCP'
         }
 
         It 'Should use TCP when Tcp switch is specified' {
             $result = Test-Port -Port 80 -Tcp
-            $result[0].Protocol | Should -Be 'TCP'
+            $result[0].Protocol | Should-Be 'TCP'
         }
 
         It 'Should use UDP when Udp switch is specified' {
             $result = Test-Port -Port 53 -Udp
-            $result[0].Protocol | Should -Be 'UDP'
+            $result[0].Protocol | Should-Be 'UDP'
         }
     }
 
@@ -148,45 +148,45 @@ Describe 'Test-Port' -Skip {
         It 'Should handle multiple target computers' {
             # Test with localhost multiple times to simulate multiple computers
             $result = Test-Port -ComputerName @('localhost', '127.0.0.1') -Port 80
-            $result | Should -HaveCount 2
-            $result[0].Server | Should -Be 'localhost'
-            $result[1].Server | Should -Be '127.0.0.1'
-            $result | ForEach-Object { $_.Port | Should -Be 80 }
+            $result | Should-BeCollection -Count 2
+            $result[0].Server | Should-Be 'localhost'
+            $result[1].Server | Should-Be '127.0.0.1'
+            $result | ForEach-Object { $_.Port | Should-Be 80 }
         }
 
         It 'Should skip empty or null computer names' {
             $result = Test-Port -ComputerName @('localhost', '', $null, 'localhost') -Port 80
             # Should only process the valid entries
-            $result | Should -HaveCount 2
-            $result | ForEach-Object { $_.Server | Should -Be 'localhost' }
+            $result | Should-BeCollection -Count 2
+            $result | ForEach-Object { $_.Server | Should-Be 'localhost' }
         }
     }
 
     Context 'TCP specific tests' {
         It 'Should properly test TCP connections' {
             $result = Test-Port -Port 80 -Tcp -ComputerName 'localhost'
-            $result[0].Protocol | Should -Be 'TCP'
-            $result[0].Open | Should -BeOfType [Boolean]
+            $result[0].Protocol | Should-Be 'TCP'
+            $result[0].Open | Should-HaveType ([Boolean])
         }
 
         It 'Should handle TCP connection failures appropriately' {
             # Test a port that's likely to be closed
             $result = Test-Port -Port 9998 -Tcp -ComputerName 'localhost' -Timeout 2000
-            $result[0].Protocol | Should -Be 'TCP'
-            $result[0].Open | Should -Be $false
+            $result[0].Protocol | Should-Be 'TCP'
+            $result[0].Open | Should-Be $false
         }
     }
 
     Context 'UDP specific tests' {
         It 'Should properly test UDP connections' {
             $result = Test-Port -Port 53 -Udp -ComputerName 'localhost'
-            $result[0].Protocol | Should -Be 'UDP'
-            $result[0].Open | Should -BeOfType [Boolean]
+            $result[0].Protocol | Should-Be 'UDP'
+            $result[0].Open | Should-HaveType ([Boolean])
         }
 
         It 'Should handle UDP port testing with appropriate status messages' {
             $result = Test-Port -Port 9997 -Udp -ComputerName 'localhost' -Timeout 3000
-            $result[0].Protocol | Should -Be 'UDP'
+            $result[0].Protocol | Should-Be 'UDP'
             # UDP results are often ambiguous, but should have a status
             $result[0].Status | Should -Not -BeNullOrEmpty
         }

--- a/Tests/Unit/NetworkAndDns/Test-TlsProtocol.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Test-TlsProtocol.Tests.ps1
@@ -57,62 +57,62 @@ Describe 'Test-TlsProtocol' {
         It 'Accepts ComputerName from pipeline input with supported aliases' {
             $parameter = Get-TestTlsProtocolParameter -Name 'ComputerName'
 
-            $parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $true
-            $parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $true
-            $parameter.Aliases | Should -Contain 'Server'
-            $parameter.Aliases | Should -Contain 'Host'
-            $parameter.Aliases | Should -Contain 'HostName'
+            $parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should-Be $true
+            $parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should-Be $true
+            $parameter.Aliases | Should-ContainCollection 'Server'
+            $parameter.Aliases | Should-ContainCollection 'Host'
+            $parameter.Aliases | Should-ContainCollection 'HostName'
         }
 
         It 'Uses localhost as default ComputerName' {
-            Get-TestTlsProtocolParameterDefaultText -Name 'ComputerName' | Should -Be "'localhost'"
+            Get-TestTlsProtocolParameterDefaultText -Name 'ComputerName' | Should-Be "'localhost'"
         }
 
         It 'Accepts the valid port range' {
             $parameter = Get-TestTlsProtocolParameter -Name 'Port'
             $range = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
 
-            $range.MinRange | Should -Be 1
-            $range.MaxRange | Should -Be 65535
+            $range.MinRange | Should-Be 1
+            $range.MaxRange | Should-Be 65535
         }
 
         It 'Rejects invalid port numbers' {
-            { Test-TlsProtocol -Port 0 -Protocol Tls12 } | Should -Throw
-            { Test-TlsProtocol -Port 65536 -Protocol Tls12 } | Should -Throw
-            { Test-TlsProtocol -Port -1 -Protocol Tls12 } | Should -Throw
+            { Test-TlsProtocol -Port 0 -Protocol Tls12 } | Should-Throw
+            { Test-TlsProtocol -Port 65536 -Protocol Tls12 } | Should-Throw
+            { Test-TlsProtocol -Port -1 -Protocol Tls12 } | Should-Throw
         }
 
         It 'Uses 443 as default port' {
-            Get-TestTlsProtocolParameterDefaultText -Name 'Port' | Should -Be '443'
+            Get-TestTlsProtocolParameterDefaultText -Name 'Port' | Should-Be '443'
         }
 
         It 'Accepts the valid timeout range' {
             $parameter = Get-TestTlsProtocolParameter -Name 'Timeout'
             $range = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
 
-            $range.MinRange | Should -Be 100
-            $range.MaxRange | Should -Be 30000
+            $range.MinRange | Should-Be 100
+            $range.MaxRange | Should-Be 30000
         }
 
         It 'Rejects invalid timeout values' {
-            { Test-TlsProtocol -Timeout 99 -Protocol Tls12 } | Should -Throw
-            { Test-TlsProtocol -Timeout 30001 -Protocol Tls12 } | Should -Throw
+            { Test-TlsProtocol -Timeout 99 -Protocol Tls12 } | Should-Throw
+            { Test-TlsProtocol -Timeout 30001 -Protocol Tls12 } | Should-Throw
         }
 
         It 'Uses 3000ms as default timeout' {
-            Get-TestTlsProtocolParameterDefaultText -Name 'Timeout' | Should -Be '3000'
+            Get-TestTlsProtocolParameterDefaultText -Name 'Timeout' | Should-Be '3000'
         }
 
         It 'Accepts supported TLS protocol values' {
             $parameter = Get-TestTlsProtocolParameter -Name 'Protocol'
             $validateSet = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
 
-            $validateSet.ValidValues | Should -Be @('Tls', 'Tls11', 'Tls12', 'Tls13')
+            $validateSet.ValidValues | Should-BeCollection @('Tls', 'Tls11', 'Tls12', 'Tls13')
         }
 
         It 'Rejects invalid TLS protocol values' {
-            { Test-TlsProtocol -Protocol 'InvalidProtocol' } | Should -Throw
-            { Test-TlsProtocol -Protocol 'SSL3' } | Should -Throw
+            { Test-TlsProtocol -Protocol 'InvalidProtocol' } | Should-Throw
+            { Test-TlsProtocol -Protocol 'SSL3' } | Should-Throw
         }
     }
 
@@ -121,38 +121,38 @@ Describe 'Test-TlsProtocol' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Protocol Tls12 -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result[0].PSObject.Properties.Name | Should -Contain 'Server'
-            $result[0].PSObject.Properties.Name | Should -Contain 'Port'
-            $result[0].PSObject.Properties.Name | Should -Contain 'Protocol'
-            $result[0].PSObject.Properties.Name | Should -Contain 'Supported'
-            $result[0].PSObject.Properties.Name | Should -Contain 'Status'
-            $result[0].PSObject.Properties.Name | Should -Contain 'ResponseTime'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Server'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Port'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Protocol'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Supported'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Status'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'ResponseTime'
         }
 
         It 'Has correct property types' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Protocol Tls12 -Timeout 100
 
-            $result[0].Server | Should -BeOfType [String]
-            $result[0].Port | Should -BeOfType [Int]
-            $result[0].Protocol | Should -BeOfType [String]
-            $result[0].Supported | Should -BeOfType [Boolean]
-            $result[0].Status | Should -BeOfType [String]
-            $result[0].ResponseTime | Should -BeOfType [TimeSpan]
+            $result[0].Server | Should-HaveType ([String])
+            $result[0].Port | Should-HaveType ([Int])
+            $result[0].Protocol | Should-HaveType ([String])
+            $result[0].Supported | Should-HaveType ([Boolean])
+            $result[0].Status | Should-HaveType ([String])
+            $result[0].ResponseTime | Should-HaveType ([TimeSpan])
         }
 
         It 'Populates Server property correctly' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Protocol Tls12 -Timeout 100
-            $result[0].Server | Should -Be $script:FastFailureHost
+            $result[0].Server | Should-Be $script:FastFailureHost
         }
 
         It 'Populates Port property correctly' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Port 8443 -Protocol Tls12 -Timeout 100
-            $result[0].Port | Should -Be 8443
+            $result[0].Port | Should-Be 8443
         }
 
         It 'Populates Protocol property correctly' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Protocol Tls12 -Timeout 100
-            $result[0].Protocol | Should -Be 'Tls12'
+            $result[0].Protocol | Should-Be 'Tls12'
         }
     }
 
@@ -161,20 +161,20 @@ Describe 'Test-TlsProtocol' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Protocol Tls12, Tls13 -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 2
-            $result[0].Protocol | Should -Be 'Tls12'
-            $result[1].Protocol | Should -Be 'Tls13'
+            $result | Should-BeCollection -Count 2
+            $result[0].Protocol | Should-Be 'Tls12'
+            $result[1].Protocol | Should-Be 'Tls13'
         }
 
         It 'Tests all protocols when none specified' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 4
-            $result[0].Protocol | Should -Be 'Tls'
-            $result[1].Protocol | Should -Be 'Tls11'
-            $result[2].Protocol | Should -Be 'Tls12'
-            $result[3].Protocol | Should -Be 'Tls13'
+            $result | Should-BeCollection -Count 4
+            $result[0].Protocol | Should-Be 'Tls'
+            $result[1].Protocol | Should-Be 'Tls11'
+            $result[2].Protocol | Should-Be 'Tls12'
+            $result[3].Protocol | Should-Be 'Tls13'
         }
     }
 
@@ -183,7 +183,7 @@ Describe 'Test-TlsProtocol' {
             $result = $script:FastFailureHost | Test-TlsProtocol -Protocol Tls12 -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result[0].Server | Should -Be $script:FastFailureHost
+            $result[0].Server | Should-Be $script:FastFailureHost
         }
 
         It 'Handles multiple computer names via pipeline' {
@@ -191,9 +191,9 @@ Describe 'Test-TlsProtocol' {
             $result = $servers | Test-TlsProtocol -Protocol Tls12 -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -HaveCount 2
-            $result[0].Server | Should -Be $servers[0]
-            $result[1].Server | Should -Be $servers[1]
+            $result | Should-BeCollection -Count 2
+            $result[0].Server | Should-Be $servers[0]
+            $result[1].Server | Should-Be $servers[1]
         }
     }
 
@@ -202,7 +202,7 @@ Describe 'Test-TlsProtocol' {
             $result = Test-TlsProtocol -ComputerName '192.0.2.1' -Protocol Tls12 -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result[0].Supported | Should -Be $false
+            $result[0].Supported | Should-Be $false
             $result[0].Status | Should -Not -BeNullOrEmpty
         }
 
@@ -210,32 +210,32 @@ Describe 'Test-TlsProtocol' {
             $result = Test-TlsProtocol -ComputerName $script:FastFailureHost -Protocol Tls12 -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result[0].Supported | Should -Be $false
+            $result[0].Supported | Should-Be $false
         }
 
         It 'Handles timeout scenarios' {
             $result = Test-TlsProtocol -ComputerName '192.0.2.1' -Protocol Tls12 -Timeout 100
 
             $result | Should -Not -BeNullOrEmpty
-            $result[0].Supported | Should -Be $false
-            $result[0].Status | Should -Match 'timeout|failed'
+            $result[0].Supported | Should-Be $false
+            $result[0].Status | Should-MatchString 'timeout|failed'
         }
     }
 
     Context 'Alias support' {
         It 'Accepts Server alias for ComputerName' {
             $result = Test-TlsProtocol -Server $script:FastFailureHost -Protocol Tls12 -Timeout 100
-            $result[0].Server | Should -Be $script:FastFailureHost
+            $result[0].Server | Should-Be $script:FastFailureHost
         }
 
         It 'Accepts Host alias for ComputerName' {
             $result = Test-TlsProtocol -Host $script:FastFailureHost -Protocol Tls12 -Timeout 100
-            $result[0].Server | Should -Be $script:FastFailureHost
+            $result[0].Server | Should-Be $script:FastFailureHost
         }
 
         It 'Accepts HostName alias for ComputerName' {
             $result = Test-TlsProtocol -HostName $script:FastFailureHost -Protocol Tls12 -Timeout 100
-            $result[0].Server | Should -Be $script:FastFailureHost
+            $result[0].Server | Should-Be $script:FastFailureHost
         }
     }
 }

--- a/Tests/Unit/NetworkAndDns/Trace-Route.Tests.ps1
+++ b/Tests/Unit/NetworkAndDns/Trace-Route.Tests.ps1
@@ -21,59 +21,59 @@ Describe 'Trace-Route' {
         It 'Should require the ComputerName parameter' {
             $param = (Get-Command Trace-Route).Parameters['ComputerName']
             $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
-            ForEach-Object { $_.Mandatory } | Should -Contain $true
+            ForEach-Object { $_.Mandatory } | Should-ContainCollection $true
         }
 
         It 'Should reject empty ComputerName' {
-            { Trace-Route -ComputerName '' } | Should -Throw
-            { Trace-Route -ComputerName $null } | Should -Throw
+            { Trace-Route -ComputerName '' } | Should-Throw
+            { Trace-Route -ComputerName $null } | Should-Throw
         }
 
         It 'Should validate MaxHops range' {
-            { Trace-Route -ComputerName 'localhost' -MaxHops 0 } | Should -Throw
-            { Trace-Route -ComputerName 'localhost' -MaxHops 65 } | Should -Throw
+            { Trace-Route -ComputerName 'localhost' -MaxHops 0 } | Should-Throw
+            { Trace-Route -ComputerName 'localhost' -MaxHops 65 } | Should-Throw
         }
 
         It 'Should validate Timeout range' {
-            { Trace-Route -ComputerName 'localhost' -Timeout 50 } | Should -Throw
-            { Trace-Route -ComputerName 'localhost' -Timeout 31000 } | Should -Throw
+            { Trace-Route -ComputerName 'localhost' -Timeout 50 } | Should-Throw
+            { Trace-Route -ComputerName 'localhost' -Timeout 31000 } | Should-Throw
         }
 
         It 'Should validate Queries range' {
-            { Trace-Route -ComputerName 'localhost' -Queries 0 } | Should -Throw
-            { Trace-Route -ComputerName 'localhost' -Queries 6 } | Should -Throw
+            { Trace-Route -ComputerName 'localhost' -Queries 0 } | Should-Throw
+            { Trace-Route -ComputerName 'localhost' -Queries 6 } | Should-Throw
         }
 
         It 'Should validate BufferSize range' {
-            { Trace-Route -ComputerName 'localhost' -BufferSize -1 } | Should -Throw
+            { Trace-Route -ComputerName 'localhost' -BufferSize -1 } | Should-Throw
         }
     }
 
     Context 'Localhost traceroute' {
         It 'Should trace route to localhost successfully' {
             $results = Trace-Route -ComputerName 'localhost' -MaxHops 3 -Timeout 2000
-            @($results).Count | Should -BeGreaterThan 0
+            @($results).Count | Should-BeGreaterThan 0
         }
 
         It 'Should return objects with expected properties' {
             $results = Trace-Route -ComputerName 'localhost' -MaxHops 3 -Timeout 2000
             $first = $results | Select-Object -First 1
-            $first.PSObject.Properties.Name | Should -Contain 'Hop'
-            $first.PSObject.Properties.Name | Should -Contain 'IP'
-            $first.PSObject.Properties.Name | Should -Contain 'Hostname'
-            $first.PSObject.Properties.Name | Should -Contain 'Latency'
-            $first.PSObject.Properties.Name | Should -Contain 'Status'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Hop'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'IP'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Hostname'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Latency'
+            $first.PSObject.Properties.Name | Should-ContainCollection 'Status'
         }
 
         It 'Should return valid status values for each hop' {
             $results = Trace-Route -ComputerName 'localhost' -MaxHops 3 -Timeout 2000
             $validStatuses = @('Success', 'TimedOut', 'TtlExpired', 'Error')
-            $results | ForEach-Object { $_.Status | Should -BeIn $validStatuses }
+            $results | ForEach-Object { $validStatuses | Should-ContainCollection $_.Status }
         }
 
         It 'Should have Hop numbers starting at 1' {
             $results = Trace-Route -ComputerName 'localhost' -MaxHops 3 -Timeout 2000
-            $results[0].Hop | Should -Be 1
+            $results[0].Hop | Should-Be 1
         }
     }
 

--- a/Tests/Unit/ProfileManagement/Find-ProfileFunction.Tests.ps1
+++ b/Tests/Unit/ProfileManagement/Find-ProfileFunction.Tests.ps1
@@ -119,15 +119,15 @@ Describe 'Find-ProfileFunction' {
         It 'Should have mandatory Query parameter' {
             $command = Get-Command Find-ProfileFunction
             $queryParam = $command.Parameters['Query']
-            $queryParam.Attributes.Mandatory | Should -Contain $true
+            $queryParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should validate Top parameter range' {
             $command = Get-Command Find-ProfileFunction
             $topParam = $command.Parameters['Top']
             $validateRange = $topParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
-            $validateRange.MinRange | Should -Be 1
-            $validateRange.MaxRange | Should -Be 500
+            $validateRange.MinRange | Should-Be 1
+            $validateRange.MaxRange | Should-Be 500
         }
     }
 
@@ -135,39 +135,39 @@ Describe 'Find-ProfileFunction' {
         It 'Should find by function name keyword' {
             $results = @(Find-ProfileFunction -Query 'sqlfluff')
             $results | Should -Not -BeNullOrEmpty
-            $results[0].Name | Should -Be 'Invoke-SqlFluff'
+            $results[0].Name | Should-Be 'Invoke-SqlFluff'
         }
 
         It 'Should find by synopsis keyword' {
             $results = @(Find-ProfileFunction -Query 'pandoc markdown')
-            $results.Count | Should -Be 1
-            $results[0].Name | Should -Be 'ConvertTo-Markdown'
+            $results.Count | Should-Be 1
+            $results[0].Name | Should-Be 'ConvertTo-Markdown'
         }
 
         It 'Should find by alias keyword' {
             $results = @(Find-ProfileFunction -Query 'docker-auto')
-            $results.Count | Should -Be 1
-            $results[0].Name | Should -Be 'Invoke-DockerAutoRun'
-            $results[0].Aliases | Should -Match 'docker-auto'
+            $results.Count | Should-Be 1
+            $results[0].Name | Should-Be 'Invoke-DockerAutoRun'
+            $results[0].Aliases | Should-MatchString 'docker-auto'
         }
 
         It 'Should support MatchAny for multi-term queries' {
             $results = @(Find-ProfileFunction -Query 'docker reboot' -MatchAny)
-            $results.Count | Should -BeGreaterThan 1
-            $results.Name | Should -Contain 'Invoke-DockerAutoRun'
-            $results.Name | Should -Contain 'Test-PendingReboot'
+            $results.Count | Should-BeGreaterThan 1
+            $results.Name | Should-ContainCollection 'Invoke-DockerAutoRun'
+            $results.Name | Should-ContainCollection 'Test-PendingReboot'
         }
 
         It 'Should rank stronger function name matches ahead of weaker matches' {
             $results = @(Find-ProfileFunction -Query 'docker')
-            $results.Count | Should -BeGreaterThan 1
-            $results[0].Name | Should -Be 'Invoke-DockerAutoRun'
-            $results[0].Score | Should -BeGreaterOrEqual $results[1].Score
+            $results.Count | Should-BeGreaterThan 1
+            $results[0].Name | Should-Be 'Invoke-DockerAutoRun'
+            $results[0].Score | Should-BeGreaterThanOrEqual $results[1].Score
         }
 
         It 'Should apply Top result limiting' {
             $results = @(Find-ProfileFunction -Query 'docker' -Top 1)
-            $results.Count | Should -Be 1
+            $results.Count | Should-Be 1
         }
     }
 
@@ -175,27 +175,27 @@ Describe 'Find-ProfileFunction' {
         It 'Should filter by category alias' {
             $results = @(Find-ProfileFunction -Query 'docker' -Category 'dev')
             $results | Should -Not -BeNullOrEmpty
-            ($results | Select-Object -ExpandProperty Category -Unique) | Should -Be 'Developer'
+            ($results | Select-Object -ExpandProperty Category -Unique) | Should-Be 'Developer'
         }
 
         It 'Should filter by spaced category display name' {
             $results = @(Find-ProfileFunction -Query 'dns' -Category 'Network And Dns')
-            $results.Count | Should -Be 1
-            $results[0].Name | Should -Be 'Test-DnsPropagation'
-            $results[0].Category | Should -Be 'Network And Dns'
+            $results.Count | Should-Be 1
+            $results[0].Name | Should-Be 'Test-DnsPropagation'
+            $results[0].Category | Should-Be 'Network And Dns'
         }
 
         It 'Should warn for unknown category values' {
             $warnings = Find-ProfileFunction -Query 'docker' -Category 'bogus' 3>&1
-            ($warnings | Out-String) | Should -Match "Unknown category: 'bogus'"
-            ($warnings | Out-String) | Should -Match 'No valid categories specified'
+            ($warnings | Out-String) | Should-MatchString "Unknown category: 'bogus'"
+            ($warnings | Out-String) | Should-MatchString 'No valid categories specified'
         }
     }
 
     Context 'No match behavior' {
         It 'Should warn when no results match the query' {
             $warnings = Find-ProfileFunction -Query 'no-such-function-keyword' 3>&1
-            ($warnings | Out-String) | Should -Match 'No functions matched query'
+            ($warnings | Out-String) | Should-MatchString 'No functions matched query'
         }
     }
 }

--- a/Tests/Unit/ProfileManagement/Show-ProfileFunction.Tests.ps1
+++ b/Tests/Unit/ProfileManagement/Show-ProfileFunction.Tests.ps1
@@ -104,30 +104,30 @@ Describe 'Show-ProfileFunction' {
             $output = Show-ProfileFunction 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Active Directory'
-            $outputText | Should -Match 'Developer'
-            $outputText | Should -Match 'Network And Dns'
-            $outputText | Should -Match 'System Administration'
-            $outputText | Should -Match 'Utilities'
+            $outputText | Should-MatchString 'Active Directory'
+            $outputText | Should-MatchString 'Developer'
+            $outputText | Should-MatchString 'Network And Dns'
+            $outputText | Should-MatchString 'System Administration'
+            $outputText | Should-MatchString 'Utilities'
         }
 
         It 'Should display all function names when no -Category is specified' {
             $output = Show-ProfileFunction 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Test-ADCredential'
-            $outputText | Should -Match 'Import-DotEnv'
-            $outputText | Should -Match 'Test-Port'
-            $outputText | Should -Match 'Test-Admin'
-            $outputText | Should -Match 'Format-Byte'
+            $outputText | Should-MatchString 'Test-ADCredential'
+            $outputText | Should-MatchString 'Import-DotEnv'
+            $outputText | Should-MatchString 'Test-Port'
+            $outputText | Should-MatchString 'Test-Admin'
+            $outputText | Should-MatchString 'Format-Byte'
         }
 
         It 'Should show correct total count across all categories' {
             $output = Show-ProfileFunction 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match '7 functions'
-            $outputText | Should -Match '5 categories'
+            $outputText | Should-MatchString '7 functions'
+            $outputText | Should-MatchString '5 categories'
         }
     }
 
@@ -136,39 +136,39 @@ Describe 'Show-ProfileFunction' {
             $output = Show-ProfileFunction -Category 'ActiveDirectory' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Active Directory'
-            $outputText | Should -Match 'Test-ADCredential'
-            $outputText | Should -Match '1 functions'
-            $outputText | Should -Match '1 categories'
+            $outputText | Should-MatchString 'Active Directory'
+            $outputText | Should-MatchString 'Test-ADCredential'
+            $outputText | Should-MatchString '1 functions'
+            $outputText | Should-MatchString '1 categories'
         }
 
         It 'Should filter to a single category case-insensitively' {
             $output = Show-ProfileFunction -Category 'activedirectory' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Active Directory'
-            $outputText | Should -Match 'Test-ADCredential'
+            $outputText | Should-MatchString 'Active Directory'
+            $outputText | Should-MatchString 'Test-ADCredential'
         }
 
         It 'Should filter to multiple categories by folder name' {
             $output = Show-ProfileFunction -Category 'Developer', 'Utilities' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Developer'
-            $outputText | Should -Match 'Import-DotEnv'
-            $outputText | Should -Match 'Utilities'
-            $outputText | Should -Match 'Format-Byte'
-            $outputText | Should -Match '3 functions'
-            $outputText | Should -Match '2 categories'
+            $outputText | Should-MatchString 'Developer'
+            $outputText | Should-MatchString 'Import-DotEnv'
+            $outputText | Should-MatchString 'Utilities'
+            $outputText | Should-MatchString 'Format-Byte'
+            $outputText | Should-MatchString '3 functions'
+            $outputText | Should-MatchString '2 categories'
         }
 
         It 'Should not show categories not requested' {
             $output = Show-ProfileFunction -Category 'Utilities' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Not -Match 'Active Directory'
-            $outputText | Should -Not -Match 'Developer'
-            $outputText | Should -Not -Match 'Network And Dns'
+            $outputText | Should-NotMatchString 'Active Directory'
+            $outputText | Should-NotMatchString 'Developer'
+            $outputText | Should-NotMatchString 'Network And Dns'
         }
     }
 
@@ -177,75 +177,75 @@ Describe 'Show-ProfileFunction' {
             $output = Show-ProfileFunction -Category 'ad' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Active Directory'
-            $outputText | Should -Match 'Test-ADCredential'
+            $outputText | Should-MatchString 'Active Directory'
+            $outputText | Should-MatchString 'Test-ADCredential'
         }
 
         It 'Should resolve "dev" to Developer' {
             $output = Show-ProfileFunction -Category 'dev' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Developer'
-            $outputText | Should -Match 'Import-DotEnv'
+            $outputText | Should-MatchString 'Developer'
+            $outputText | Should-MatchString 'Import-DotEnv'
         }
 
         It 'Should resolve "network" to NetworkAndDns' {
             $output = Show-ProfileFunction -Category 'network' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Network And Dns'
-            $outputText | Should -Match 'Test-Port'
+            $outputText | Should-MatchString 'Network And Dns'
+            $outputText | Should-MatchString 'Test-Port'
         }
 
         It 'Should resolve "dns" to NetworkAndDns' {
             $output = Show-ProfileFunction -Category 'dns' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Network And Dns'
+            $outputText | Should-MatchString 'Network And Dns'
         }
 
         It 'Should resolve "sysadmin" to SystemAdministration' {
             $output = Show-ProfileFunction -Category 'sysadmin' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'System Administration'
-            $outputText | Should -Match 'Test-Admin'
+            $outputText | Should-MatchString 'System Administration'
+            $outputText | Should-MatchString 'Test-Admin'
         }
 
         It 'Should resolve "sys" to SystemAdministration' {
             $output = Show-ProfileFunction -Category 'sys' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'System Administration'
+            $outputText | Should-MatchString 'System Administration'
         }
 
         It 'Should resolve "admin" to SystemAdministration' {
             $output = Show-ProfileFunction -Category 'admin' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'System Administration'
+            $outputText | Should-MatchString 'System Administration'
         }
 
         It 'Should resolve "utils" to Utilities' {
             $output = Show-ProfileFunction -Category 'utils' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Utilities'
-            $outputText | Should -Match 'Format-Byte'
+            $outputText | Should-MatchString 'Utilities'
+            $outputText | Should-MatchString 'Format-Byte'
         }
 
         It 'Should resolve "util" to Utilities' {
             $output = Show-ProfileFunction -Category 'util' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Utilities'
+            $outputText | Should-MatchString 'Utilities'
         }
 
         It 'Short aliases should be case-insensitive' {
             $output = Show-ProfileFunction -Category 'AD' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Active Directory'
+            $outputText | Should-MatchString 'Active Directory'
         }
     }
 
@@ -254,23 +254,23 @@ Describe 'Show-ProfileFunction' {
             $output = Show-ProfileFunction -Category 'Active Directory' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Active Directory'
-            $outputText | Should -Match 'Test-ADCredential'
+            $outputText | Should-MatchString 'Active Directory'
+            $outputText | Should-MatchString 'Test-ADCredential'
         }
 
         It 'Should resolve "Network And Dns" (spaced display name)' {
             $output = Show-ProfileFunction -Category 'Network And Dns' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Network And Dns'
-            $outputText | Should -Match 'Test-Port'
+            $outputText | Should-MatchString 'Network And Dns'
+            $outputText | Should-MatchString 'Test-Port'
         }
 
         It 'Spaced display names should be case-insensitive' {
             $output = Show-ProfileFunction -Category 'active directory' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Active Directory'
+            $outputText | Should-MatchString 'Active Directory'
         }
     }
 
@@ -279,28 +279,28 @@ Describe 'Show-ProfileFunction' {
             $output = Show-ProfileFunction 'dev' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Developer'
-            $outputText | Should -Match 'Import-DotEnv'
+            $outputText | Should-MatchString 'Developer'
+            $outputText | Should-MatchString 'Import-DotEnv'
         }
     }
 
     Context 'Unknown category handling' {
         It 'Should warn for unknown category names' {
             $warnings = Show-ProfileFunction -Category 'bogus' 3>&1
-            ($warnings | Out-String) | Should -Match "Unknown category: 'bogus'"
+            ($warnings | Out-String) | Should-MatchString "Unknown category: 'bogus'"
         }
 
         It 'Should warn no valid categories when all are unknown' {
             $warnings = Show-ProfileFunction -Category 'bogus' 3>&1
-            ($warnings | Out-String) | Should -Match 'No valid categories specified'
+            ($warnings | Out-String) | Should-MatchString 'No valid categories specified'
         }
 
         It 'Should show valid category even if another is unknown' {
             $allOutput = Show-ProfileFunction -Category 'dev', 'bogus' *>&1
             $outputText = ($allOutput | Out-String)
 
-            $outputText | Should -Match 'Developer'
-            $outputText | Should -Match "Unknown category: 'bogus'"
+            $outputText | Should-MatchString 'Developer'
+            $outputText | Should-MatchString "Unknown category: 'bogus'"
         }
     }
 
@@ -309,7 +309,7 @@ Describe 'Show-ProfileFunction' {
             $output = Show-ProfileFunction -Category 'ad' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Test Active Directory credentials'
+            $outputText | Should-MatchString 'Test Active Directory credentials'
         }
 
         It 'Should display functions sorted alphabetically within a category' {
@@ -319,7 +319,7 @@ Describe 'Show-ProfileFunction' {
             # Get-DotNetVersion should appear before Import-DotEnv
             $dotnetPos = $outputText.IndexOf('Get-DotNetVersion')
             $importPos = $outputText.IndexOf('Import-DotEnv')
-            $dotnetPos | Should -BeLessThan $importPos
+            $dotnetPos | Should-BeLessThan $importPos
         }
     }
 
@@ -328,7 +328,7 @@ Describe 'Show-ProfileFunction' {
             $output = Show-ProfileFunction -Category 'ad' 6>&1
             $outputText = ($output | Out-String)
 
-            $outputText | Should -Match 'Get-Help'
+            $outputText | Should-MatchString 'Get-Help'
         }
 
     }

--- a/Tests/Unit/ProfileManagement/Test-ProfileUpdate.Tests.ps1
+++ b/Tests/Unit/ProfileManagement/Test-ProfileUpdate.Tests.ps1
@@ -85,10 +85,10 @@ Describe 'Test-ProfileUpdate' {
 
             $result = Test-ProfileUpdate -ProfileRoot $profileRoot -GitRunner ${function:Invoke-TestProfileUpdateGitShim} -ConnectivityTest $script:ConnectivityTest -ErrorAction Stop
 
-            $result | Should -Be $null
-            $script:GitInvocations.Count | Should -Be 0
-            $script:ConnectivityHosts.Count | Should -Be 0
-            (Get-Location).Path | Should -Be $script:OriginalLocation.Path
+            $result | Should-Be $null
+            $script:GitInvocations.Count | Should-Be 0
+            $script:ConnectivityHosts.Count | Should-Be 0
+            (Get-Location).Path | Should-Be $script:OriginalLocation.Path
         }
 
         It 'Returns null when remote.origin.url is missing' {
@@ -96,16 +96,16 @@ Describe 'Test-ProfileUpdate' {
             $script:GitBehavior = {
                 param([Object[]]$Arguments)
 
-                ($Arguments -join ' ') | Should -Be 'config --get remote.origin.url'
+                ($Arguments -join ' ') | Should-Be 'config --get remote.origin.url'
                 $global:LASTEXITCODE = 1
                 return @()
             }
 
             $result = Test-ProfileUpdate -ProfileRoot $profileRoot -GitRunner ${function:Invoke-TestProfileUpdateGitShim} -ConnectivityTest $script:ConnectivityTest -ErrorAction Stop
 
-            $result | Should -Be $null
-            $script:GitInvocations.Count | Should -Be 1
-            $script:ConnectivityHosts.Count | Should -Be 0
+            $result | Should-Be $null
+            $script:GitInvocations.Count | Should-Be 1
+            $script:ConnectivityHosts.Count | Should-Be 0
         }
     }
 
@@ -132,11 +132,11 @@ Describe 'Test-ProfileUpdate' {
 
             $result = Test-ProfileUpdate -ProfileRoot $profileRoot -GitRunner ${function:Invoke-TestProfileUpdateGitShim} -ConnectivityTest $script:ConnectivityTest -ErrorAction Stop
 
-            $result | Should -Be $null
-            $script:ConnectivityHosts | Should -Contain 'github.com'
+            $result | Should-Be $null
+            $script:ConnectivityHosts | Should-ContainCollection 'github.com'
 
             $fetchInvocations = @($script:GitInvocations | Where-Object { ($_ -join ' ') -eq 'fetch origin' })
-            $fetchInvocations.Count | Should -Be 0
+            $fetchInvocations.Count | Should-Be 0
         }
 
         It 'Returns null when git fetch origin fails' {
@@ -166,13 +166,13 @@ Describe 'Test-ProfileUpdate' {
 
             $result = Test-ProfileUpdate -ProfileRoot $profileRoot -GitRunner ${function:Invoke-TestProfileUpdateGitShim} -ConnectivityTest $script:ConnectivityTest -ErrorAction Stop
 
-            $result | Should -Be $null
+            $result | Should-Be $null
 
             $fetchInvocations = @($script:GitInvocations | Where-Object { ($_ -join ' ') -eq 'fetch origin' })
-            $fetchInvocations.Count | Should -Be 1
+            $fetchInvocations.Count | Should-Be 1
 
             $revParseInvocations = @($script:GitInvocations | Where-Object { ($_ -join ' ') -match '^rev-parse ' })
-            $revParseInvocations.Count | Should -Be 0
+            $revParseInvocations.Count | Should-Be 0
         }
     }
 
@@ -214,12 +214,12 @@ Describe 'Test-ProfileUpdate' {
 
             $result = Test-ProfileUpdate -ProfileRoot $profileRoot -GitRunner ${function:Invoke-TestProfileUpdateGitShim} -ConnectivityTest $script:ConnectivityTest -ErrorAction Stop
 
-            $result | Should -BeFalse
+            $result | Should-BeFalsy
 
             $revListInvocations = @($script:GitInvocations | Where-Object { ($_ -join ' ') -match '^rev-list ' })
             $logInvocations = @($script:GitInvocations | Where-Object { ($_ -join ' ') -match '^log ' })
-            $revListInvocations.Count | Should -Be 0
-            $logInvocations.Count | Should -Be 0
+            $revListInvocations.Count | Should-Be 0
+            $logInvocations.Count | Should-Be 0
         }
 
         It 'Returns true and shows cleaned change bullets when updates are available with ShowChanges' {
@@ -272,19 +272,19 @@ Describe 'Test-ProfileUpdate' {
 
             $rawOutput = @(Test-ProfileUpdate -ProfileRoot $profileRoot -ShowChanges -GitRunner ${function:Invoke-TestProfileUpdateGitShim} -ConnectivityTest $script:ConnectivityTest -ErrorAction Stop 6>&1)
 
-            $rawOutput | Should -Contain $true
+            $rawOutput | Should-ContainCollection $true
 
             $hostOutput = @($rawOutput | Where-Object { $_ -isnot [Boolean] } | ForEach-Object { [String]$_ })
-            $hostOutput | Should -Contain 'Profile updates are available!'
-            $hostOutput | Should -Contain 'Here are the available changes:'
-            $hostOutput | Should -Contain '  - feat: add updater coverage'
-            $hostOutput | Should -Contain '  - docs: refresh update notes'
-            $hostOutput | Should -Contain "Run 'Update-Profile' to apply these changes."
+            $hostOutput | Should-ContainCollection 'Profile updates are available!'
+            $hostOutput | Should-ContainCollection 'Here are the available changes:'
+            $hostOutput | Should-ContainCollection '  - feat: add updater coverage'
+            $hostOutput | Should-ContainCollection '  - docs: refresh update notes'
+            $hostOutput | Should-ContainCollection "Run 'Update-Profile' to apply these changes."
 
             $output = $hostOutput -join "`n"
-            $output | Should -Not -Match '2222222'
-            $output | Should -Not -Match 'HEAD -> main'
-            $output | Should -Not -Match '\(profile\)'
+            $output | Should-NotMatchString '2222222'
+            $output | Should-NotMatchString 'HEAD -> main'
+            $output | Should-NotMatchString '\(profile\)'
         }
     }
 }

--- a/Tests/Unit/ProfileManagement/Update-Profile.Tests.ps1
+++ b/Tests/Unit/ProfileManagement/Update-Profile.Tests.ps1
@@ -76,9 +76,9 @@ Describe 'Update-Profile' {
             $hostOutput = @(Update-Profile -ProfileRoot (New-UpdateProfileTestRoot) -ErrorAction Stop 6>&1 | ForEach-Object { [String]$_ })
 
             $output = $hostOutput -join "`n"
-            $output | Should -Match 'Git is not installed or not found in PATH\.'
-            $output | Should -Match 'install\.ps1'
-            $script:GitInvocations.Count | Should -Be 0
+            $output | Should-MatchString 'Git is not installed or not found in PATH\.'
+            $output | Should-MatchString 'install\.ps1'
+            $script:GitInvocations.Count | Should-Be 0
         }
 
         It 'Writes an error when the profile root is not a git repository' {
@@ -93,8 +93,8 @@ Describe 'Update-Profile' {
 
             $null = Update-Profile -ProfileRoot $profileRoot -ErrorAction SilentlyContinue -ErrorVariable updateErrors 6>&1
 
-            $updateErrors[0].Exception.Message | Should -Match 'is not a git repository'
-            $script:GitInvocations.Count | Should -Be 0
+            $updateErrors[0].Exception.Message | Should-MatchString 'is not a git repository'
+            $script:GitInvocations.Count | Should-Be 0
         }
     }
 
@@ -133,14 +133,14 @@ Describe 'Update-Profile' {
 
             $hostOutput = @(Update-Profile -ProfileRoot $profileRoot -ErrorAction SilentlyContinue -ErrorVariable updateErrors 6>&1 | ForEach-Object { [String]$_ })
 
-            $hostOutput | Should -Contain 'fatal: cannot rebase: You have unstaged changes.'
-            $updateErrors[0].Exception.Message | Should -Match 'git pull failed with exit code 128'
+            $hostOutput | Should-ContainCollection 'fatal: cannot rebase: You have unstaged changes.'
+            $updateErrors[0].Exception.Message | Should-MatchString 'git pull failed with exit code 128'
 
             $pullInvocations = @($script:GitInvocations | Where-Object { ($_ -join ' ') -match 'pull --rebase$' })
-            $pullInvocations.Count | Should -Be 1
+            $pullInvocations.Count | Should-Be 1
 
             $logInvocations = @($script:GitInvocations | Where-Object { ($_ -join ' ') -match 'log --oneline' })
-            $logInvocations.Count | Should -Be 0
+            $logInvocations.Count | Should-Be 0
         }
 
         It 'Shows the up-to-date message when HEAD is unchanged' {
@@ -168,8 +168,8 @@ Describe 'Update-Profile' {
 
             $hostOutput = @(Update-Profile -ProfileRoot $profileRoot -ErrorAction Stop 6>&1 | ForEach-Object { [String]$_ })
 
-            $hostOutput | Should -Contain 'Profile is already up to date.'
-            $hostOutput | Should -Not -Contain 'Updates:'
+            $hostOutput | Should-ContainCollection 'Profile is already up to date.'
+            $hostOutput | Should-NotContainCollection 'Updates:'
         }
 
         It 'Prints cleaned commit summary bullets when HEAD changes' {
@@ -213,15 +213,15 @@ Describe 'Update-Profile' {
 
             $hostOutput = @(Update-Profile -ProfileRoot $profileRoot -ErrorAction Stop 6>&1 | ForEach-Object { [String]$_ })
 
-            $hostOutput | Should -Contain 'Updates:'
-            $hostOutput | Should -Contain '  - feat: add updater coverage'
-            $hostOutput | Should -Contain '  - docs: refresh update notes'
-            $hostOutput | Should -Contain 'Profile updated successfully! Restart your PowerShell session to reload your profile.'
+            $hostOutput | Should-ContainCollection 'Updates:'
+            $hostOutput | Should-ContainCollection '  - feat: add updater coverage'
+            $hostOutput | Should-ContainCollection '  - docs: refresh update notes'
+            $hostOutput | Should-ContainCollection 'Profile updated successfully! Restart your PowerShell session to reload your profile.'
 
             $output = $hostOutput -join "`n"
-            $output | Should -Not -Match '2222222'
-            $output | Should -Not -Match 'HEAD -> main'
-            $output | Should -Not -Match '\(profile\)'
+            $output | Should-NotMatchString '2222222'
+            $output | Should-NotMatchString 'HEAD -> main'
+            $output | Should-NotMatchString '\(profile\)'
 
             Remove-Variable -Name RevParseCount -Scope Script -ErrorAction SilentlyContinue
         }

--- a/Tests/Unit/Security/ConvertFrom-JwtToken.Tests.ps1
+++ b/Tests/Unit/Security/ConvertFrom-JwtToken.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
             # Test that the Token parameter is mandatory by checking the parameter metadata
             $command = Get-Command ConvertFrom-JwtToken
             $tokenParam = $command.Parameters['Token']
-            $tokenParam.Attributes.Mandatory | Should -Contain $true
+            $tokenParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should accept token from pipeline' {
@@ -88,20 +88,20 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
         }
 
         It 'Should throw when token is null or empty' {
-            { ConvertFrom-JwtToken -Token '' } | Should -Throw
-            { ConvertFrom-JwtToken -Token $null } | Should -Throw
+            { ConvertFrom-JwtToken -Token '' } | Should-Throw
+            { ConvertFrom-JwtToken -Token $null } | Should-Throw
         }
 
         It 'Should throw when token format is invalid (missing parts)' {
-            { ConvertFrom-JwtToken -Token 'invalid.token' } | Should -Throw '*Invalid JWT token format*'
+            { ConvertFrom-JwtToken -Token 'invalid.token' } | Should-Throw '*Invalid JWT token format*'
         }
 
         It 'Should throw when token has too many parts' {
-            { ConvertFrom-JwtToken -Token 'part1.part2.part3.part4' } | Should -Throw '*Invalid JWT token format*'
+            { ConvertFrom-JwtToken -Token 'part1.part2.part3.part4' } | Should-Throw '*Invalid JWT token format*'
         }
 
         It 'Should throw when token has only one part' {
-            { ConvertFrom-JwtToken -Token 'singlepart' } | Should -Throw '*Invalid JWT token format*'
+            { ConvertFrom-JwtToken -Token 'singlepart' } | Should-Throw '*Invalid JWT token format*'
         }
     }
 
@@ -118,22 +118,22 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
         It 'Should decode header correctly' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -AsObject
 
-            $result.Header.alg | Should -Be 'HS256'
-            $result.Header.typ | Should -Be 'JWT'
+            $result.Header.alg | Should-Be 'HS256'
+            $result.Header.typ | Should-Be 'JWT'
         }
 
         It 'Should decode payload correctly' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -AsObject
 
-            $result.Payload.sub | Should -Be '1234567890'
-            $result.Payload.name | Should -Be 'John Doe'
-            $result.Payload.iat | Should -Be 1516239022
+            $result.Payload.sub | Should-Be '1234567890'
+            $result.Payload.name | Should-Be 'John Doe'
+            $result.Payload.iat | Should-Be 1516239022
         }
 
         It 'Should not include signature by default' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -AsObject
 
-            $result.PSObject.Properties.Name | Should -Not -Contain 'Signature'
+            $result.PSObject.Properties.Name | Should-NotContainCollection 'Signature'
         }
 
         It 'Should handle tokens with whitespace (Example: Get-Clipboard | ConvertFrom-JwtToken -AsObject)' {
@@ -141,15 +141,15 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
             $tokenWithWhitespace = "  $script:ValidToken  "
             $result = ConvertFrom-JwtToken -Token $tokenWithWhitespace -AsObject
 
-            $result.Payload.name | Should -Be 'John Doe'
+            $result.Payload.name | Should-Be 'John Doe'
         }
 
         It 'Should handle bearer tokens with embedded whitespace and line breaks' {
             $tokenWithWhitespace = "  Bearer`n$script:ValidToken`r`n"
             $result = ConvertFrom-JwtToken -Token $tokenWithWhitespace -AsObject
 
-            $result.Header.alg | Should -Be 'HS256'
-            $result.Payload.name | Should -Be 'John Doe'
+            $result.Header.alg | Should-Be 'HS256'
+            $result.Payload.name | Should-Be 'John Doe'
         }
     }
 
@@ -157,43 +157,43 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
         It 'Should decode token with multiple claims (Example: $jwt.Payload.exp)' {
             $result = ConvertFrom-JwtToken -Token $script:ComplexToken -AsObject
 
-            $result.Payload.sub | Should -Be 'user123'
-            $result.Payload.name | Should -Be 'Jane Smith'
-            $result.Payload.email | Should -Be 'jane@example.com'
-            $result.Payload.exp | Should -Be 1735689600
-            $result.Payload.iat | Should -Be 1704067200
-            $result.Payload.iss | Should -Be 'https://example.com'
-            $result.Payload.aud | Should -Be 'api://default'
+            $result.Payload.sub | Should-Be 'user123'
+            $result.Payload.name | Should-Be 'Jane Smith'
+            $result.Payload.email | Should-Be 'jane@example.com'
+            $result.Payload.exp | Should-Be 1735689600
+            $result.Payload.iat | Should-Be 1704067200
+            $result.Payload.iss | Should-Be 'https://example.com'
+            $result.Payload.aud | Should-Be 'api://default'
         }
 
         It 'Should decode RS256 algorithm in header' {
             $result = ConvertFrom-JwtToken -Token $script:ComplexToken -AsObject
 
-            $result.Header.alg | Should -Be 'RS256'
-            $result.Header.typ | Should -Be 'JWT'
+            $result.Header.alg | Should-Be 'RS256'
+            $result.Header.typ | Should-Be 'JWT'
         }
 
         It 'Should allow accessing specific payload properties (Example: $decoded.Payload.sub)' {
             $decoded = ConvertFrom-JwtToken -Token $script:ComplexToken -AsObject
 
-            $decoded.Payload.sub | Should -Be 'user123'
-            $decoded.Payload.name | Should -Be 'Jane Smith'
+            $decoded.Payload.sub | Should-Be 'user123'
+            $decoded.Payload.name | Should-Be 'Jane Smith'
         }
 
         It 'Should allow accessing header properties (Example: $decoded.Header.alg)' {
             $decoded = ConvertFrom-JwtToken -Token $script:ComplexToken -AsObject
 
-            $decoded.Header.alg | Should -Be 'RS256'
+            $decoded.Header.alg | Should-Be 'RS256'
         }
 
         It 'Should preserve nested objects, arrays, and booleans in payload claims' {
             $result = ConvertFrom-JwtToken -Token $script:NestedClaimsToken -AsObject
 
-            $result.Payload.roles | Should -Be @('admin', 'reader')
-            $result.Payload.aud | Should -Be @('api://default', 'api://secondary')
-            $result.Payload.email_verified | Should -BeTrue
-            $result.Payload.profile.region | Should -Be 'us-east-1'
-            $result.Header.kid | Should -Be 'test-key'
+            $result.Payload.roles | Should-BeCollection @('admin', 'reader')
+            $result.Payload.aud | Should-BeCollection @('api://default', 'api://secondary')
+            $result.Payload.email_verified | Should-BeTruthy
+            $result.Payload.profile.region | Should-Be 'us-east-1'
+            $result.Header.kid | Should-Be 'test-key'
         }
     }
 
@@ -201,14 +201,14 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
         It 'Should include signature when -IncludeSignature is specified (Example: ConvertFrom-JwtToken -Token $token -IncludeSignature -AsObject)' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -IncludeSignature -AsObject
 
-            $result.PSObject.Properties.Name | Should -Contain 'Signature'
-            $result.Signature | Should -Be 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Signature'
+            $result.Signature | Should-Be 'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
         }
 
         It 'Should return signature as string' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -IncludeSignature -AsObject
 
-            $result.Signature | Should -BeOfType [String]
+            $result.Signature | Should-HaveType ([String])
             $result.Signature | Should -Not -BeNullOrEmpty
         }
     }
@@ -222,8 +222,8 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
 
             $result = ConvertFrom-JwtToken -Token $specialToken -AsObject
 
-            $result.Header.alg | Should -Be 'HS256'
-            $result.Payload.test | Should -Be 'value-with_special'
+            $result.Header.alg | Should-Be 'HS256'
+            $result.Payload.test | Should-Be 'value-with_special'
         }
 
         It 'Should handle Base64URL padding correctly' {
@@ -240,26 +240,26 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
         It 'Should return PSCustomObject' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -AsObject
 
-            $result | Should -BeOfType [PSCustomObject]
+            $result | Should-HaveType ([PSCustomObject])
         }
 
         It 'Should have Header and Payload properties' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -AsObject
 
-            $result.PSObject.Properties.Name | Should -Contain 'Header'
-            $result.PSObject.Properties.Name | Should -Contain 'Payload'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Header'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Payload'
         }
 
         It 'Should have exactly 2 properties without -IncludeSignature' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -AsObject
 
-            $result.PSObject.Properties.Name.Count | Should -Be 2
+            $result.PSObject.Properties.Name.Count | Should-Be 2
         }
 
         It 'Should have exactly 3 properties with -IncludeSignature' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -IncludeSignature -AsObject
 
-            $result.PSObject.Properties.Name.Count | Should -Be 3
+            $result.PSObject.Properties.Name.Count | Should-Be 3
         }
     }
 
@@ -267,27 +267,27 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
         It 'Should throw on invalid Base64 in header' {
             $invalidToken = 'invalid!!!.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig'
 
-            { ConvertFrom-JwtToken -Token $invalidToken } | Should -Throw '*header segment*'
+            { ConvertFrom-JwtToken -Token $invalidToken } | Should-Throw '*header segment*'
         }
 
         It 'Should throw on invalid Base64 in payload' {
             $invalidToken = 'eyJhbGciOiJIUzI1NiJ9.invalid!!!.sig'
 
-            { ConvertFrom-JwtToken -Token $invalidToken } | Should -Throw '*payload segment*'
+            { ConvertFrom-JwtToken -Token $invalidToken } | Should-Throw '*payload segment*'
         }
 
         It 'Should throw on invalid JSON in header' {
             # Valid Base64 but invalid JSON
             $invalidToken = 'bm90anNvbg.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig'
 
-            { ConvertFrom-JwtToken -Token $invalidToken } | Should -Throw '*Invalid JSON in the header segment*'
+            { ConvertFrom-JwtToken -Token $invalidToken } | Should-Throw '*Invalid JSON in the header segment*'
         }
 
         It 'Should throw on invalid JSON in payload' {
             # Valid Base64 but invalid JSON
             $invalidToken = 'eyJhbGciOiJIUzI1NiJ9.bm90anNvbg.sig'
 
-            { ConvertFrom-JwtToken -Token $invalidToken } | Should -Throw '*Invalid JSON in the payload segment*'
+            { ConvertFrom-JwtToken -Token $invalidToken } | Should-Throw '*Invalid JSON in the payload segment*'
         }
     }
 
@@ -295,16 +295,16 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
         It 'Should process token from pipeline' {
             $result = $script:ValidToken | ConvertFrom-JwtToken -AsObject
 
-            $result.Payload.name | Should -Be 'John Doe'
+            $result.Payload.name | Should-Be 'John Doe'
         }
 
         It 'Should process multiple tokens from pipeline' {
             $tokens = @($script:ValidToken, $script:ComplexToken)
             $results = $tokens | ConvertFrom-JwtToken -AsObject
 
-            $results.Count | Should -Be 2
-            $results[0].Payload.name | Should -Be 'John Doe'
-            $results[1].Payload.name | Should -Be 'Jane Smith'
+            $results.Count | Should-Be 2
+            $results[0].Payload.name | Should-Be 'John Doe'
+            $results[1].Payload.name | Should-Be 'Jane Smith'
         }
     }
 
@@ -319,7 +319,7 @@ Describe 'ConvertFrom-JwtToken Unit Tests' {
             $result = ConvertFrom-JwtToken -Token $script:ValidToken -AsObject
 
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -BeOfType [PSCustomObject]
+            $result | Should-HaveType ([PSCustomObject])
         }
 
         It 'Should support -IncludeSignature with formatted output' {

--- a/Tests/Unit/Security/Get-CertificateExpiration.Tests.ps1
+++ b/Tests/Unit/Security/Get-CertificateExpiration.Tests.ps1
@@ -58,23 +58,23 @@ Describe 'Get-CertificateExpiration' {
 
             $result = @(Get-CertificateExpiration -Path $certPath)
 
-            $result | Should -HaveCount 1
-            $result[0] | Should -BeOfType [PSCustomObject]
-            $result[0].PSObject.Properties.Name | Should -Contain 'ComputerName'
-            $result[0].PSObject.Properties.Name | Should -Contain 'ExpirationDate'
-            $result[0].PSObject.Properties.Name | Should -Contain 'ExpiresIn'
-            $result[0].PSObject.Properties.Name | Should -Contain 'Status'
-            $result[0].PSObject.Properties.Name | Should -Contain 'CertificatePath'
-            $result[0].ComputerName | Should -Be $null
-            $result[0].CertificatePath | Should -Be $certPath
-            $result[0].ExpirationDate | Should -BeOfType [datetime]
-            $result[0].ExpiresIn | Should -Be '31 days'
-            $result[0].Status | Should -Be 'Valid'
-            ($result[0].ExpirationDate).ToUniversalTime().ToString('o') | Should -Be $script:ExpectedExpirationDate.UtcDateTime.ToString('o')
+            $result | Should-BeCollection -Count 1
+            $result[0] | Should-HaveType ([PSCustomObject])
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'ComputerName'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'ExpirationDate'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'ExpiresIn'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Status'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'CertificatePath'
+            $result[0].ComputerName | Should-Be $null
+            $result[0].CertificatePath | Should-Be $certPath
+            $result[0].ExpirationDate | Should-HaveType ([datetime])
+            $result[0].ExpiresIn | Should-Be '31 days'
+            $result[0].Status | Should-Be 'Valid'
+            ($result[0].ExpirationDate).ToUniversalTime().ToString('o') | Should-Be $script:ExpectedExpirationDate.UtcDateTime.ToString('o')
 
             $renderedOutput = $result | Out-String
-            $renderedOutput | Should -Match 'ComputerName\s+ExpirationDate\s+ExpiresIn\s+Status'
-            $renderedOutput | Should -Not -Match 'ComputerName\s*:'
+            $renderedOutput | Should-MatchString 'ComputerName\s+ExpirationDate\s+ExpiresIn\s+Status'
+            $renderedOutput | Should-NotMatchString 'ComputerName\s*:'
         }
 
         It 'treats an existing file path passed through ComputerName as a certificate path' {
@@ -85,12 +85,12 @@ Describe 'Get-CertificateExpiration' {
 
             $result = @(Get-CertificateExpiration -ComputerName $certPath)
 
-            $result | Should -HaveCount 1
-            $result[0].ComputerName | Should -Be $null
-            $result[0].CertificatePath | Should -Be $certPath
-            $result[0].ExpirationDate | Should -BeOfType [datetime]
-            $result[0].ExpiresIn | Should -Be '1 day ago'
-            $result[0].Status | Should -Be 'Expired'
+            $result | Should-BeCollection -Count 1
+            $result[0].ComputerName | Should-Be $null
+            $result[0].CertificatePath | Should-Be $certPath
+            $result[0].ExpirationDate | Should-HaveType ([datetime])
+            $result[0].ExpiresIn | Should-Be '1 day ago'
+            $result[0].Status | Should-Be 'Expired'
         }
     }
 
@@ -103,18 +103,18 @@ Describe 'Get-CertificateExpiration' {
 
             $result = @(Get-CertificateExpiration -Path $certPath -Detailed -DaysToWarn 7)
 
-            $result | Should -HaveCount 1
-            $result[0].PSObject.Properties.Name | Should -Contain 'ComputerName'
-            $result[0].PSObject.Properties.Name | Should -Contain 'ExpirationDate'
-            $result[0].PSObject.Properties.Name | Should -Contain 'ExpiresIn'
-            $result[0].PSObject.Properties.Name | Should -Contain 'Status'
-            $result[0].PSObject.Properties.Name | Should -Contain 'NotAfter'
-            $result[0].PSObject.Properties.Name | Should -Contain 'CertificatePath'
-            $result[0].ComputerName | Should -Be $null
-            $result[0].CertificatePath | Should -Be $certPath
-            $result[0].ExpirationDate | Should -Be $result[0].NotAfter
-            $result[0].ExpiresIn | Should -Be '1 day'
-            $result[0].Status | Should -Be 'ExpiringSoon'
+            $result | Should-BeCollection -Count 1
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'ComputerName'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'ExpirationDate'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'ExpiresIn'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'Status'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'NotAfter'
+            $result[0].PSObject.Properties.Name | Should-ContainCollection 'CertificatePath'
+            $result[0].ComputerName | Should-Be $null
+            $result[0].CertificatePath | Should-Be $certPath
+            $result[0].ExpirationDate | Should-Be $result[0].NotAfter
+            $result[0].ExpiresIn | Should-Be '1 day'
+            $result[0].Status | Should-Be 'ExpiringSoon'
         }
     }
 }

--- a/Tests/Unit/Security/Protect-PathWithPassword.Tests.ps1
+++ b/Tests/Unit/Security/Protect-PathWithPassword.Tests.ps1
@@ -75,16 +75,16 @@ Describe 'Protect-PathWithPassword Unit Tests' {
             # Test that the Path parameter is mandatory by checking the parameter metadata
             $command = Get-Command Protect-PathWithPassword
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Mandatory | Should -Contain $true
+            $pathParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should accept path from pipeline' {
             $result = Get-Item $script:TestFile1 | Protect-PathWithPassword -Password $script:TestPassword -Force
-            $result.Success | Should -Be $true
+            $result.Success | Should-Be $true
         }
 
         It 'Should throw when path does not exist' {
-            { Protect-PathWithPassword -Path 'C:\NonExistent\file.txt' -Password $script:TestPassword } | Should -Throw '*does not exist*'
+            { Protect-PathWithPassword -Path 'C:\NonExistent\file.txt' -Password $script:TestPassword } | Should-Throw '*does not exist*'
         }
     }
 
@@ -93,15 +93,15 @@ Describe 'Protect-PathWithPassword Unit Tests' {
             # Test basic file encryption functionality as shown in documentation
             $result = Protect-PathWithPassword -Path $script:TestFile1 -Password $script:TestPassword -Force
 
-            $result.Success | Should -Be $true
-            $result.OriginalPath | Should -Be $script:TestFile1
-            $result.EncryptedPath | Should -Be ($script:TestFile1 + '.enc')
-            Test-Path ($script:TestFile1 + '.enc') | Should -Be $true
+            $result.Success | Should-Be $true
+            $result.OriginalPath | Should-Be $script:TestFile1
+            $result.EncryptedPath | Should-Be ($script:TestFile1 + '.enc')
+            Test-Path ($script:TestFile1 + '.enc') | Should-Be $true
         }
 
         It 'Should create encrypted file with .enc extension by default' {
             Protect-PathWithPassword -Path $script:TestFile1 -Password $script:TestPassword -Force | Out-Null
-            Test-Path ($script:TestFile1 + '.enc') | Should -Be $true
+            Test-Path ($script:TestFile1 + '.enc') | Should-Be $true
         }
 
         It 'Should respect custom output path' {
@@ -111,16 +111,16 @@ Describe 'Protect-PathWithPassword Unit Tests' {
 
             $result = Protect-PathWithPassword -Path $script:TestFile1 -Password $script:TestPassword -OutputPath $customOutput -Force
 
-            $result.EncryptedPath | Should -Be $customOutput
-            Test-Path $customOutput | Should -Be $true
+            $result.EncryptedPath | Should-Be $customOutput
+            Test-Path $customOutput | Should-Be $true
         }
 
         It 'Should support RemoveOriginal parameter' {
             $result = Protect-PathWithPassword -Path $script:TestFile1 -Password $script:TestPassword -RemoveOriginal -Force
 
-            $result.Success | Should -Be $true
-            Test-Path $script:TestFile1 | Should -Be $false
-            Test-Path ($script:TestFile1 + '.enc') | Should -Be $true
+            $result.Success | Should-Be $true
+            Test-Path $script:TestFile1 | Should-Be $false
+            Test-Path ($script:TestFile1 + '.enc') | Should-Be $true
         }
     }
 
@@ -129,18 +129,18 @@ Describe 'Protect-PathWithPassword Unit Tests' {
             Protect-PathWithPassword -Path $script:TestDir -Password $script:TestPassword -Force | Out-Null
 
             # Should encrypt files in root directory only
-            Test-Path ($script:TestFile1 + '.enc') | Should -Be $true
-            Test-Path ($script:TestFile2 + '.enc') | Should -Be $true
-            Test-Path ($script:TestFile3 + '.enc') | Should -Be $false
+            Test-Path ($script:TestFile1 + '.enc') | Should-Be $true
+            Test-Path ($script:TestFile2 + '.enc') | Should-Be $true
+            Test-Path ($script:TestFile3 + '.enc') | Should-Be $false
         }
 
         It 'Should encrypt files recursively when -Recurse is specified' {
             Protect-PathWithPassword -Path $script:TestDir -Password $script:TestPassword -Recurse -Force | Out-Null
 
             # Should encrypt all files including subdirectories
-            Test-Path ($script:TestFile1 + '.enc') | Should -Be $true
-            Test-Path ($script:TestFile2 + '.enc') | Should -Be $true
-            Test-Path ($script:TestFile3 + '.enc') | Should -Be $true
+            Test-Path ($script:TestFile1 + '.enc') | Should-Be $true
+            Test-Path ($script:TestFile2 + '.enc') | Should-Be $true
+            Test-Path ($script:TestFile3 + '.enc') | Should-Be $true
         }
     }
 
@@ -148,10 +148,10 @@ Describe 'Protect-PathWithPassword Unit Tests' {
         It 'Should accept input from pipeline' {
             $results = Get-ChildItem -Path $script:TestDir -File | Protect-PathWithPassword -Password $script:TestPassword -Force
 
-            $results | Should -HaveCount 2
-            $results | ForEach-Object { $_.Success | Should -Be $true }
-            Test-Path ($script:TestFile1 + '.enc') | Should -Be $true
-            Test-Path ($script:TestFile2 + '.enc') | Should -Be $true
+            $results | Should-BeCollection -Count 2
+            $results | ForEach-Object { $_.Success | Should-Be $true }
+            Test-Path ($script:TestFile1 + '.enc') | Should-Be $true
+            Test-Path ($script:TestFile2 + '.enc') | Should-Be $true
         }
     }
 
@@ -166,9 +166,9 @@ Describe 'Protect-PathWithPassword Unit Tests' {
             # Encrypt again with -Force
             $result = Protect-PathWithPassword -Path $script:TestFile1 -Password $script:TestPassword -Force
 
-            $result.Success | Should -Be $true
+            $result.Success | Should-Be $true
             $newTime = (Get-Item ($script:TestFile1 + '.enc')).LastWriteTime
-            $newTime | Should -BeGreaterThan $initialTime
+            $newTime | Should-BeGreaterThan $initialTime
         }
     }
 
@@ -179,14 +179,14 @@ Describe 'Protect-PathWithPassword Unit Tests' {
             $result2 = Protect-PathWithPassword -Path $script:TestFile1 -Password $script:TestPassword -OutputPath (Join-Path -Path $script:TestDir -ChildPath 'enc2.dat') -Force
 
             $both = $result1, $result2
-            $both | ForEach-Object { $_.Success | Should -Be $true }
+            $both | ForEach-Object { $_.Success | Should-Be $true }
 
             # Files should be different due to random salt and IV
             $bytes1 = [System.IO.File]::ReadAllBytes($result1.EncryptedPath)
             $bytes2 = [System.IO.File]::ReadAllBytes($result2.EncryptedPath)
 
             # Compare first 48 bytes (salt + IV) - they should be different
-            $bytes1[0..47] | Should -Not -Be $bytes2[0..47]
+            $bytes1[0..47] | Should-NotBe $bytes2[0..47]
         }
 
         It 'Should create files with appropriate size (larger than original due to encryption overhead)' {
@@ -196,9 +196,9 @@ Describe 'Protect-PathWithPassword Unit Tests' {
             $encryptedSize = (Get-Item ($script:TestFile1 + '.enc')).Length
 
             # Encrypted file should be larger (salt + IV + padding)
-            $encryptedSize | Should -BeGreaterThan $originalSize
+            $encryptedSize | Should-BeGreaterThan $originalSize
             # Should have at least 48 bytes overhead (32 salt + 16 IV)
-            $encryptedSize | Should -BeGreaterThan ($originalSize + 48)
+            $encryptedSize | Should-BeGreaterThan ($originalSize + 48)
         }
     }
 }

--- a/Tests/Unit/Security/Protect-PathWithPassword.Tests.ps1
+++ b/Tests/Unit/Security/Protect-PathWithPassword.Tests.ps1
@@ -186,7 +186,7 @@ Describe 'Protect-PathWithPassword Unit Tests' {
             $bytes2 = [System.IO.File]::ReadAllBytes($result2.EncryptedPath)
 
             # Compare first 48 bytes (salt + IV) - they should be different
-            $bytes1[0..47] | Should-NotBe $bytes2[0..47]
+            [Convert]::ToBase64String($bytes1[0..47]) | Should-NotBe ([Convert]::ToBase64String($bytes2[0..47]))
         }
 
         It 'Should create files with appropriate size (larger than original due to encryption overhead)' {

--- a/Tests/Unit/Security/Unprotect-PathWithPassword.Tests.ps1
+++ b/Tests/Unit/Security/Unprotect-PathWithPassword.Tests.ps1
@@ -91,18 +91,18 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
             # Test that the Path parameter is mandatory by checking the parameter metadata
             $command = Get-Command Unprotect-PathWithPassword
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Mandatory | Should -Contain $true
+            $pathParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should accept path from pipeline' {
             # Ensure the encrypted test file exists before piping it
-            Test-Path $script:EncFile1 | Should -Be $true
+            Test-Path $script:EncFile1 | Should-Be $true
             $result = Get-Item $script:EncFile1 | Unprotect-PathWithPassword -Password $script:TestPassword -Force
-            $result.Success | Should -Be $true
+            $result.Success | Should-Be $true
         }
 
         It 'Should throw when path does not exist' {
-            { Unprotect-PathWithPassword -Path 'C:\NonExistent\file.enc' -Password $script:TestPassword } | Should -Throw '*does not exist*'
+            { Unprotect-PathWithPassword -Path 'C:\NonExistent\file.enc' -Password $script:TestPassword } | Should-Throw '*does not exist*'
         }
     }
 
@@ -110,30 +110,30 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
         It 'Should decrypt a single file successfully' {
             $result = Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:TestPassword -Force
 
-            $result.Success | Should -Be $true
-            $result.EncryptedPath | Should -Be $script:EncFile1
-            $result.DecryptedPath | Should -Be $script:TestFile1
-            Test-Path $script:TestFile1 | Should -Be $true
+            $result.Success | Should-Be $true
+            $result.EncryptedPath | Should-Be $script:EncFile1
+            $result.DecryptedPath | Should-Be $script:TestFile1
+            Test-Path $script:TestFile1 | Should-Be $true
         }
 
         It 'Should restore original file content correctly' {
             Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:TestPassword -Force | Out-Null
 
             $content = Get-Content -Path $script:TestFile1 -Raw
-            $content.Trim() | Should -Be 'Test content 1'
+            $content.Trim() | Should-Be 'Test content 1'
         }
 
         It 'Should remove .enc extension by default' {
             $result = Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:TestPassword -Force
-            $result.DecryptedPath | Should -Be $script:TestFile1
+            $result.DecryptedPath | Should-Be $script:TestFile1
         }
 
         It 'Should respect custom output path' {
             $customOutput = Join-Path -Path $script:TestDir -ChildPath 'custom.decrypted'
             $result = Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:TestPassword -OutputPath $customOutput -Force
 
-            $result.DecryptedPath | Should -Be $customOutput
-            Test-Path $customOutput | Should -Be $true
+            $result.DecryptedPath | Should-Be $customOutput
+            Test-Path $customOutput | Should-Be $true
         }
 
         It 'Should fail with wrong password' {
@@ -145,8 +145,8 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
 
             $result = Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:WrongPassword -ErrorAction SilentlyContinue
 
-            $result.Success | Should -Be $false
-            $result.Error | Should -Match 'Decryption failed|Invalid password'
+            $result.Success | Should-Be $false
+            $result.Error | Should-MatchString 'Decryption failed|Invalid password'
         }
     }
 
@@ -155,18 +155,18 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
             Unprotect-PathWithPassword -Path $script:TestDir -Password $script:TestPassword -Force | Out-Null
 
             # Should decrypt files in root directory only
-            Test-Path $script:TestFile1 | Should -Be $true
-            Test-Path $script:TestFile2 | Should -Be $true
-            Test-Path $script:TestFile3 | Should -Be $false
+            Test-Path $script:TestFile1 | Should-Be $true
+            Test-Path $script:TestFile2 | Should-Be $true
+            Test-Path $script:TestFile3 | Should-Be $false
         }
 
         It 'Should decrypt .enc files recursively when -Recurse is specified' {
             Unprotect-PathWithPassword -Path $script:TestDir -Password $script:TestPassword -Recurse -Force | Out-Null
 
             # Should decrypt all .enc files including subdirectories
-            Test-Path $script:TestFile1 | Should -Be $true
-            Test-Path $script:TestFile2 | Should -Be $true
-            Test-Path $script:TestFile3 | Should -Be $true
+            Test-Path $script:TestFile1 | Should-Be $true
+            Test-Path $script:TestFile2 | Should-Be $true
+            Test-Path $script:TestFile3 | Should-Be $true
         }
 
         It 'Should only process .enc files in directories' {
@@ -177,10 +177,10 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
             Unprotect-PathWithPassword -Path $script:TestDir -Password $script:TestPassword -Force | Out-Null
 
             # .enc files should be processed
-            Test-Path $script:TestFile1 | Should -Be $true
-            Test-Path $script:TestFile2 | Should -Be $true
+            Test-Path $script:TestFile1 | Should-Be $true
+            Test-Path $script:TestFile2 | Should-Be $true
             # Regular file should remain unchanged
-            Test-Path $nonEncFile | Should -Be $true
+            Test-Path $nonEncFile | Should-Be $true
         }
     }
 
@@ -188,16 +188,16 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
         It 'Should remove encrypted file by default' {
             Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:TestPassword -Force | Out-Null
 
-            Test-Path $script:TestFile1 | Should -Be $true
-            Test-Path $script:EncFile1 | Should -Be $false
+            Test-Path $script:TestFile1 | Should-Be $true
+            Test-Path $script:EncFile1 | Should-Be $false
         }
 
         It 'Should keep encrypted file when -KeepEncrypted is specified' {
             $result = Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:TestPassword -KeepEncrypted
 
-            $result.Success | Should -Be $true
-            Test-Path $script:TestFile1 | Should -Be $true
-            Test-Path $script:EncFile1 | Should -Be $true
+            $result.Success | Should-Be $true
+            Test-Path $script:TestFile1 | Should-Be $true
+            Test-Path $script:EncFile1 | Should-Be $true
         }
 
         It 'Should overwrite when -Force is specified' {
@@ -206,9 +206,9 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
 
             $result = Unprotect-PathWithPassword -Path $script:EncFile1 -Password $script:TestPassword -Force
 
-            $result.Success | Should -Be $true
+            $result.Success | Should-Be $true
             $content = Get-Content -Path $script:TestFile1 -Raw
-            $content.Trim() | Should -Be 'Test content 1'
+            $content.Trim() | Should-Be 'Test content 1'
         }
     }
 
@@ -234,7 +234,7 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
 
                 $result = Unprotect-PathWithPassword -Path $encFile -Password $script:TestPassword
 
-                $result.Success | Should -Be $true
+                $result.Success | Should-Be $true
                 $decryptedContent = Get-Content -Path $testFile -Raw
                 if ($case.Content -eq '')
                 {
@@ -242,7 +242,7 @@ Describe 'Unprotect-PathWithPassword Unit Tests' {
                 }
                 else
                 {
-                    $decryptedContent.TrimEnd("`r", "`n") | Should -Be $case.Content
+                    $decryptedContent.TrimEnd("`r", "`n") | Should-Be $case.Content
                 }
             }
         }

--- a/Tests/Unit/SystemAdministration/Export-InstalledPlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Export-InstalledPlatformPackage.Tests.ps1
@@ -44,13 +44,13 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'packages.json'
         $result = @($packages | Export-InstalledPlatformPackage -Path $exportPath)
 
-        $result.Count | Should -Be 1
-        $result[0].Format | Should -Be 'JSON'
-        $result[0].Count | Should -Be 2
+        $result.Count | Should-Be 1
+        $result[0].Format | Should-Be 'JSON'
+        $result[0].Count | Should-Be 2
         $exportedPackages = Get-Content -LiteralPath $exportPath -Raw | ConvertFrom-Json
-        $exportedPackages.Count | Should -Be 2
-        ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should -Be '2.44.0'
-        Should -Invoke -CommandName Write-Host -Times 0 -Exactly
+        $exportedPackages.Count | Should-Be 2
+        ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should-Be '2.44.0'
+        Should-Invoke -CommandName Write-Host -Times 0 -Exactly
     }
 
     It 'exports CSV with direct dependencies' {
@@ -87,15 +87,15 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'packages.csv'
         $result = @(Export-InstalledPlatformPackage -Package $package -Path $exportPath -DependencyMode DependsOn)
 
-        $result.Count | Should -Be 1
-        $result[0].Format | Should -Be 'CSV'
-        $result[0].DependencyMode | Should -Be 'DependsOn'
+        $result.Count | Should-Be 1
+        $result[0].Format | Should-Be 'CSV'
+        $result[0].DependencyMode | Should-Be 'DependsOn'
         $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
-        $exportedPackages.Count | Should -Be 1
-        $exportedPackages[0].DependsOn | Should -Be 'openssl'
-        $exportedPackages[0].RequiredBy | Should -Be ''
-        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0 -Exactly
+        $exportedPackages.Count | Should-Be 1
+        $exportedPackages[0].DependsOn | Should-Be 'openssl'
+        $exportedPackages[0].RequiredBy | Should-Be ''
+        Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+        Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0 -Exactly
     }
 
     It 'exports CSV with both dependency directions when DependencyMode is Both' {
@@ -144,16 +144,16 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'git-both.csv'
         $result = @(Export-InstalledPlatformPackage -Package $package -Path $exportPath -DependencyMode Both)
 
-        $result.Count | Should -Be 1
-        $result[0].Format | Should -Be 'CSV'
-        $result[0].DependencyMode | Should -Be 'Both'
-        $result[0].IncludeDependencies | Should -BeTrue
+        $result.Count | Should-Be 1
+        $result[0].Format | Should-Be 'CSV'
+        $result[0].DependencyMode | Should-Be 'Both'
+        $result[0].IncludeDependencies | Should-BeTruthy
         $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
-        $exportedPackages.Count | Should -Be 1
-        $exportedPackages[0].DependsOn | Should -Be 'openssl'
-        $exportedPackages[0].RequiredBy | Should -Be 'git-extras'
-        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-        Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+        $exportedPackages.Count | Should-Be 1
+        $exportedPackages[0].DependsOn | Should-Be 'openssl'
+        $exportedPackages[0].RequiredBy | Should-Be 'git-extras'
+        Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+        Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
     }
 
     It 'rejects Both dependency export mode for winget records' {
@@ -169,9 +169,9 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'winget-both.json'
 
         { Export-InstalledPlatformPackage -Package $package -Path $exportPath -DependencyMode Both } |
-            Should -Throw -ExpectedMessage "*Value 'Both' for parameter -DependencyMode*package manager 'winget'*supports only 'None' and 'DependsOn'*"
+            Should-Throw -ExceptionMessage "*Value 'Both' for parameter -DependencyMode*package manager 'winget'*supports only 'None' and 'DependsOn'*"
 
-        Test-Path -LiteralPath $exportPath | Should -BeFalse
+        Test-Path -LiteralPath $exportPath | Should-BeFalsy
     }
 
     It 'sets IncludeDependencies to false on the result when DependencyMode is None' {
@@ -191,16 +191,16 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'git-none.json'
         $result = @(Export-InstalledPlatformPackage -Package $package -Path $exportPath)
 
-        $result.Count | Should -Be 1
-        $result[0].DependencyMode | Should -Be 'None'
-        $result[0].IncludeDependencies | Should -BeFalse
+        $result.Count | Should-Be 1
+        $result[0].DependencyMode | Should-Be 'None'
+        $result[0].IncludeDependencies | Should-BeFalsy
     }
 
     It 'throws when no packages are supplied' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'empty.json'
 
         { Export-InstalledPlatformPackage -Package @() -Path $exportPath } |
-        Should -Throw -ExpectedMessage '*No packages are available for the current scope*'
+        Should-Throw -ExceptionMessage '*No packages are available for the current scope*'
     }
 
     It 'throws when format cannot be inferred from the export path extension' {
@@ -220,7 +220,7 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'packages'
 
         { Export-InstalledPlatformPackage -Package $package -Path $exportPath } |
-        Should -Throw -ExpectedMessage '*Export format could not be inferred*'
+        Should-Throw -ExceptionMessage '*Export format could not be inferred*'
     }
 
     It 'uses explicit Format override when path extension is ambiguous' {
@@ -240,12 +240,12 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'packages'
         $result = @(Export-InstalledPlatformPackage -Package $package -Path $exportPath -Format Csv)
 
-        $result.Count | Should -Be 1
-        $result[0].Format | Should -Be 'CSV'
-        Test-Path -LiteralPath $exportPath | Should -BeTrue
+        $result.Count | Should-Be 1
+        $result[0].Format | Should-Be 'CSV'
+        Test-Path -LiteralPath $exportPath | Should-BeTruthy
         $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
-        $exportedPackages.Count | Should -Be 1
-        $exportedPackages[0].Name | Should -Be 'git'
+        $exportedPackages.Count | Should-Be 1
+        $exportedPackages[0].Name | Should-Be 'git'
     }
 
     It 'uses explicit Format Json override even when path has a csv extension' {
@@ -265,8 +265,8 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path $TestDrive -ChildPath 'packages.csv'
         $result = @(Export-InstalledPlatformPackage -Package $package -Path $exportPath -Format Json)
 
-        $result.Count | Should -Be 1
-        $result[0].Format | Should -Be 'JSON'
+        $result.Count | Should-Be 1
+        $result[0].Format | Should-Be 'JSON'
         $exportedJson = Get-Content -LiteralPath $exportPath -Raw | ConvertFrom-Json
         $exportedJson | Should -Not -BeNullOrEmpty
     }
@@ -286,7 +286,7 @@ Describe 'Export-InstalledPlatformPackage' {
         }
 
         { Export-InstalledPlatformPackage -Package $package -Path $TestDrive } |
-        Should -Throw -ExpectedMessage '*points to a directory*'
+        Should-Throw -ExceptionMessage '*points to a directory*'
     }
 
     It 'throws when the parent directory does not exist' {
@@ -306,6 +306,6 @@ Describe 'Export-InstalledPlatformPackage' {
         $exportPath = Join-Path -Path (Join-Path -Path $TestDrive -ChildPath 'nonexistent-dir') -ChildPath 'packages.json'
 
         { Export-InstalledPlatformPackage -Package $package -Path $exportPath } |
-        Should -Throw -ExpectedMessage '*Export directory does not exist*'
+        Should-Throw -ExceptionMessage '*Export directory does not exist*'
     }
 }

--- a/Tests/Unit/SystemAdministration/Find-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Find-PlatformPackage.Tests.ps1
@@ -52,12 +52,12 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager winget -NonInteractive -Query git -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Git'
-            $result[0].Id | Should -Be 'Git.Git'
-            $result[0].Version | Should -Be '2.45.1'
-            $result[0].Description | Should -Be 'Distributed version control system'
-            $result[0].Publisher | Should -Be 'winget'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Git'
+            $result[0].Id | Should-Be 'Git.Git'
+            $result[0].Version | Should-Be '2.45.1'
+            $result[0].Description | Should-Be 'Distributed version control system'
+            $result[0].Publisher | Should-Be 'winget'
         }
 
         It 'marks search results as installed from winget list output' {
@@ -98,8 +98,8 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager winget -NonInteractive -Query git -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Installed | Should -BeTrue
+            $result.Count | Should-Be 1
+            $result[0].Installed | Should-BeTruthy
         }
 
         It 'does not mark winget search results installed by display name when ids differ' {
@@ -146,8 +146,8 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager winget -NonInteractive -Query node -CommandRunner $runner)
 
-            ($result | Where-Object { $_.Id -eq 'OpenJS.NodeJS' }).Installed | Should -BeFalse
-            ($result | Where-Object { $_.Id -eq 'OpenJS.NodeJS.LTS' }).Installed | Should -BeTrue
+            ($result | Where-Object { $_.Id -eq 'OpenJS.NodeJS' }).Installed | Should-BeFalsy
+            ($result | Where-Object { $_.Id -eq 'OpenJS.NodeJS.LTS' }).Installed | Should-BeTruthy
         }
 
         It 'returns no results when winget reports no package found with progress output' {
@@ -163,7 +163,7 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager winget -NonInteractive -Query codeql -CommandRunner $runner)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
         }
 
         It 'strips winget progress output from search failure messages' {
@@ -187,10 +187,10 @@ Describe 'Find-PlatformPackage' {
                 $thrown = $_
             }
 
-            ($null -eq $thrown) | Should -BeFalse
-            $thrown.Exception.Message | Should -Be 'Failed to search winget packages: Failed when opening source(s); try source reset.'
-            $thrown.Exception.Message | Should -Not -Match '\u2588'
-            $thrown.Exception.Message | Should -Not -Match '\\\s+\|'
+            ($null -eq $thrown) | Should-BeFalsy
+            $thrown.Exception.Message | Should-Be 'Failed to search winget packages: Failed when opening source(s); try source reset.'
+            $thrown.Exception.Message | Should-NotMatchString '\u2588'
+            $thrown.Exception.Message | Should-NotMatchString '\\\s+\|'
         }
     }
 
@@ -203,9 +203,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -NonInteractive -Query git -CommandRunner $runner -Top 0)
 
-            $result.Count | Should -Be 3
-            ($result | Where-Object { $_.Name -eq 'git' }).Type | Should -Be 'Formula'
-            ($result | Where-Object { $_.Name -eq 'git-credential-manager' }).Type | Should -Be 'Cask'
+            $result.Count | Should-Be 3
+            ($result | Where-Object { $_.Name -eq 'git' }).Type | Should-Be 'Formula'
+            ($result | Where-Object { $_.Name -eq 'git-credential-manager' }).Type | Should-Be 'Cask'
         }
 
         It 'marks formula search results as installed from Homebrew list output' {
@@ -218,9 +218,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -NonInteractive -Query jq -CommandRunner $runner -Top 0)
 
-            ($result | Where-Object { $_.Name -eq 'jq' }).Installed | Should -BeTrue
-            ($result | Where-Object { $_.Name -eq 'gojq' }).Installed | Should -BeFalse
-            ($result | Where-Object { $_.Name -eq 'jquake' }).Installed | Should -BeFalse
+            ($result | Where-Object { $_.Name -eq 'jq' }).Installed | Should-BeTruthy
+            ($result | Where-Object { $_.Name -eq 'gojq' }).Installed | Should-BeFalsy
+            ($result | Where-Object { $_.Name -eq 'jquake' }).Installed | Should-BeFalsy
         }
 
         It 'keeps formula results when cask search reports no Homebrew matches' {
@@ -231,9 +231,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -NonInteractive -Query 7zip -CommandRunner $runner -Top 0)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be '7zip'
-            $result[0].Type | Should -Be 'Formula'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be '7zip'
+            $result[0].Type | Should-Be 'Formula'
         }
 
         It 'keeps cask results when formula search reports no Homebrew matches' {
@@ -244,9 +244,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -NonInteractive -Query code -CommandRunner $runner -Top 0)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'visual-studio-code'
-            $result[0].Type | Should -Be 'Cask'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'visual-studio-code'
+            $result[0].Type | Should-Be 'Cask'
         }
     }
 
@@ -263,11 +263,11 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager apt -NonInteractive -Query openssl -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'openssl'
-            $result[0].Installed | Should -BeTrue
-            $result[0].Notes | Should -Be 'Automatic'
-            $result[0].Description | Should -Be 'Secure Sockets Layer toolkit - cryptographic utility'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'openssl'
+            $result[0].Installed | Should-BeTruthy
+            $result[0].Notes | Should-Be 'Automatic'
+            $result[0].Description | Should-Be 'Secure Sockets Layer toolkit - cryptographic utility'
         }
     }
 
@@ -282,9 +282,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager apk -NonInteractive -Query bash -CommandRunner $runner -Top 0)
 
-            $result.Count | Should -Be 2
-            ($result | Where-Object { $_.Name -eq 'bash' }).Installed | Should -BeTrue
-            ($result | Where-Object { $_.Name -eq 'bash-doc' }).Version | Should -Be '5.2.15-r5'
+            $result.Count | Should-Be 2
+            ($result | Where-Object { $_.Name -eq 'bash' }).Installed | Should-BeTruthy
+            ($result | Where-Object { $_.Name -eq 'bash-doc' }).Version | Should-Be '5.2.15-r5'
         }
     }
 
@@ -297,8 +297,8 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -NonInteractive -Query git -ExcludePackage 'git-lfs' -Top 1 -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
         }
     }
 
@@ -308,7 +308,7 @@ Describe 'Find-PlatformPackage' {
 
             {
                 Find-PlatformPackage -PackageManager brew -NonInteractive -PassThru -Query git -CommandRunner $runner
-            } | Should -Throw -ExpectedMessage '*PassThru requires interactive package search*'
+            } | Should-Throw -ExceptionMessage '*PassThru requires interactive package search*'
         }
 
         It 'requires a query in NonInteractive mode' {
@@ -316,7 +316,7 @@ Describe 'Find-PlatformPackage' {
 
             {
                 Find-PlatformPackage -PackageManager brew -NonInteractive -CommandRunner $runner
-            } | Should -Throw -ExpectedMessage '*Query is required when -NonInteractive is used*'
+            } | Should-Throw -ExceptionMessage '*Query is required when -NonInteractive is used*'
         }
     }
 
@@ -338,12 +338,12 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: git' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I install  V details  A toggle all' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-3 of 3 visible  $([char]0x00B7)  3 total  $([char]0x00B7)  0 selected  $([char]0x00B7)  source: All" -and $ForegroundColor -eq 'White' } -Times 1
-            @($script:HostOutputRecords | Where-Object { $_.ForegroundColor -eq [ConsoleColor]::DarkGray -and $_.Object -like '*git*' }).Count | Should -BeGreaterOrEqual 2
-            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 4
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: git' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I install  V details  A toggle all' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-3 of 3 visible  $([char]0x00B7)  3 total  $([char]0x00B7)  0 selected  $([char]0x00B7)  source: All" -and $ForegroundColor -eq 'White' } -Times 1
+            @($script:HostOutputRecords | Where-Object { $_.ForegroundColor -eq [ConsoleColor]::DarkGray -and $_.Object -like '*git*' }).Count | Should-BeGreaterThanOrEqual 2
+            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should-Be 4
         }
 
         It 'allows a new query to be entered from the interactive browser' {
@@ -371,10 +371,10 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew search --formulae git' }).Count | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew search --casks code' }).Count | Should -Be 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: code' } -Times 1
+            $result.Count | Should-Be 0
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew search --formulae git' }).Count | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew search --casks code' }).Count | Should-Be 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search: code' } -Times 1
         }
 
         It 'shows keyboard help from the search result picker' {
@@ -399,10 +399,10 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Find-PlatformPackage Help' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq '/: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'start a new search' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Find-PlatformPackage Help' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq '/: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'start a new search' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'returns selected packages when PassThru is used' {
@@ -426,9 +426,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -PassThru -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
         }
 
         It 'opens the result picker with the requested source filter' {
@@ -481,10 +481,10 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager winget -PassThru -FilterSource msstore -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
-            $result.Count | Should -Be 1
-            $result[0].Source | Should -Be 'msstore'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*winget*' -and $Object -notlike '*msstore*' } -Times 0 -Exactly
+            $result.Count | Should-Be 1
+            $result[0].Source | Should-Be 'msstore'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*winget*' -and $Object -notlike '*msstore*' } -Times 0 -Exactly
         }
 
         It 'keeps picker table rows within the current console width' {
@@ -535,12 +535,12 @@ Describe 'Find-PlatformPackage' {
                 }
             )
 
-            $tableLines.Count | Should -BeGreaterThan 1
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should -Match '\bVer\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should -Match '\bTyp\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should -Match '\bSrc\b'
-            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\]\s+' } | Select-Object -First 1) | Should -Match 'homebrew/core'
-            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should -BeLessOrEqual (Get-TestPickerLineLimit)
+            $tableLines.Count | Should-BeGreaterThan 1
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should-MatchString '\bVer\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should-MatchString '\bTyp\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should-MatchString '\bSrc\b'
+            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\]\s+' } | Select-Object -First 1) | Should-MatchString 'homebrew/core'
+            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should-BeLessThanOrEqual (Get-TestPickerLineLimit)
         }
 
         It 'returns the current package when PassThru is used without a selection' {
@@ -559,9 +559,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager brew -PassThru -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  I install  V details  A toggle all' } -Times 1
         }
 
         It 'installs the selected package from the interactive browser' {
@@ -586,10 +586,10 @@ Describe 'Find-PlatformPackage' {
 
             $result = Find-PlatformPackage -PackageManager brew -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader
 
-            $result.Selected | Should -Be 1
-            $result.Installed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew install git output' } -Times 1
+            $result.Selected | Should-Be 1
+            $result.Installed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew install git output' } -Times 1
         }
 
         It 'loads missing winget descriptions only when D is pressed' {
@@ -640,11 +640,11 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager winget -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'winget show --id Git.Git --exact --accept-source-agreements --output json' }).Count | Should -Be 1
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'winget show --id Git.Git --exact --accept-source-agreements --output json' }).Count | Should-Be 1
         }
 
         It 'does not suppress terminal echo when a custom key reader drives winget details' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -692,9 +692,9 @@ Describe 'Find-PlatformPackage' {
 
             $result = @(Find-PlatformPackage -PackageManager winget -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader -TerminalEchoController $terminalEchoController)
 
-            $result.Count | Should -Be 0
-            $echoActions.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            $result.Count | Should-Be 0
+            $echoActions.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
         }
 
         It 'restores terminal echo when winget details throw in the console key reader flow' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -762,9 +762,9 @@ Describe 'Find-PlatformPackage' {
 
             {
                 Find-PlatformPackage -PackageManager winget -CommandRunner $runner -QueryReader $queryReader -KeyReader $keyReader -TreatKeyReaderAsConsoleKeyReader -TerminalEchoController $terminalEchoController
-            } | Should -Throw -ExpectedMessage '*winget details failed*'
+            } | Should-Throw -ExceptionMessage '*winget details failed*'
 
-            ($echoActions -join '|') | Should -Be 'Disable|Restore:saved-stty-state'
+            ($echoActions -join '|') | Should-Be 'Disable|Restore:saved-stty-state'
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Get-PathPermission.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Get-PathPermission.Tests.ps1
@@ -65,68 +65,68 @@ Describe 'Get-PathPermission' {
     It 'is available as a function' {
         $command = Get-Command -Name 'Get-PathPermission' -ErrorAction SilentlyContinue
         $command | Should -Not -BeNullOrEmpty
-        $command.CommandType | Should -Be 'Function'
+        $command.CommandType | Should-Be 'Function'
     }
 
     It 'has a Recurse switch parameter' {
         $command = Get-Command -Name 'Get-PathPermission' -ErrorAction SilentlyContinue
-        $command.Parameters['Recurse'].SwitchParameter | Should -BeTrue
+        $command.Parameters['Recurse'].SwitchParameter | Should-BeTruthy
     }
 
     It 'returns permission details for a file path' {
         $result = Get-PathPermission -Path $script:RegularFile
 
         $result | Should -Not -BeNullOrEmpty
-        $result.PSObject.Properties.Name | Should -Contain 'Path'
-        $result.PSObject.Properties.Name | Should -Contain 'ItemType'
-        $result.PSObject.Properties.Name | Should -Contain 'Permissions'
-        $result.PSObject.Properties.Name | Should -Contain 'Octal'
-        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($script:RegularFile))
+        $result.PSObject.Properties.Name | Should-ContainCollection 'Path'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'ItemType'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'Permissions'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'Octal'
+        $result.Path | Should-Be ([System.IO.Path]::GetFullPath($script:RegularFile))
     }
 
     It 'supports pipeline input for multiple paths' {
         $results = @($script:RegularFile, $script:SampleDirectory) | Get-PathPermission
 
-        @($results).Count | Should -Be 2
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:RegularFile))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:SampleDirectory))
+        @($results).Count | Should-Be 2
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:RegularFile))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:SampleDirectory))
     }
 
     It 'supports wildcard expansion with -Path' {
         $wildcardPath = Join-Path -Path $script:TestDir -ChildPath 'wild-*.txt'
         $results = @(Get-PathPermission -Path $wildcardPath)
 
-        $results.Count | Should -Be 2
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:WildcardMatchFile1))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:WildcardMatchFile2))
+        $results.Count | Should-Be 2
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:WildcardMatchFile1))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:WildcardMatchFile2))
     }
 
     It 'supports literal paths containing wildcard characters' {
         $result = Get-PathPermission -LiteralPath $script:LiteralWildcardFile
 
         $result | Should -Not -BeNullOrEmpty
-        $result.InputPath | Should -Be $script:LiteralWildcardFile
-        $result.Path | Should -Be ([System.IO.Path]::GetFullPath($script:LiteralWildcardFile))
+        $result.InputPath | Should-Be $script:LiteralWildcardFile
+        $result.Path | Should-Be ([System.IO.Path]::GetFullPath($script:LiteralWildcardFile))
     }
 
     It 'recurses into directory contents with -Path -Recurse' {
         $results = @(Get-PathPermission -Path $script:SampleDirectory -Recurse)
 
-        $results.Count | Should -Be 4
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:SampleDirectory))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:ChildFile))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:NestedDirectory))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:NestedFile))
+        $results.Count | Should-Be 4
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:SampleDirectory))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:ChildFile))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:NestedDirectory))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:NestedFile))
     }
 
     It 'recurses into directory contents with -LiteralPath -Recurse' {
         $results = @(Get-PathPermission -LiteralPath $script:SampleDirectory -Recurse)
 
-        $results.Count | Should -Be 4
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:SampleDirectory))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:ChildFile))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:NestedDirectory))
-        @($results.Path) | Should -Contain ([System.IO.Path]::GetFullPath($script:NestedFile))
+        $results.Count | Should-Be 4
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:SampleDirectory))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:ChildFile))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:NestedDirectory))
+        @($results.Path) | Should-ContainCollection ([System.IO.Path]::GetFullPath($script:NestedFile))
     }
 
     It 'writes an error for missing paths and continues processing' {
@@ -134,9 +134,9 @@ Describe 'Get-PathPermission' {
         $errors = $null
         $results = @($script:RegularFile, $missingPath) | Get-PathPermission -ErrorAction SilentlyContinue -ErrorVariable errors
 
-        @($results).Count | Should -Be 1
-        @($errors).Count | Should -BeGreaterThan 0
-        $errors[0].FullyQualifiedErrorId | Should -Match '^PathNotFound'
+        @($results).Count | Should-Be 1
+        @($errors).Count | Should-BeGreaterThan 0
+        $errors[0].FullyQualifiedErrorId | Should-MatchString '^PathNotFound'
     }
 
     It 'writes an error for non-filesystem providers' {
@@ -144,19 +144,19 @@ Describe 'Get-PathPermission' {
         $result = Get-PathPermission -Path 'Variable:\PSVersionTable' -ErrorAction SilentlyContinue -ErrorVariable errors
 
         $result | Should -BeNullOrEmpty
-        @($errors).Count | Should -BeGreaterThan 0
-        $errors[0].FullyQualifiedErrorId | Should -Match '^UnsupportedProvider'
+        @($errors).Count | Should-BeGreaterThan 0
+        $errors[0].FullyQualifiedErrorId | Should-MatchString '^UnsupportedProvider'
     }
 
     Context 'Unix-style permission output' -Skip:$script:SkipUnixContext {
         It 'returns symbolic and octal values on Unix platforms' {
             $result = Get-PathPermission -Path $script:RegularFile
 
-            $result.Symbolic | Should -Match '^[-dlcbps][rwxstST-]{9}$'
-            $result.Permissions | Should -Match '^[rwxstST-]{9}$'
-            $result.Octal | Should -Match '^[0-7]{3}$'
-            $result.OctalWithSpecial | Should -Match '^[0-7]{4}$'
-            $result.FullOctal | Should -Match '^[0-7]+$'
+            $result.Symbolic | Should-MatchString '^[-dlcbps][rwxstST-]{9}$'
+            $result.Permissions | Should-MatchString '^[rwxstST-]{9}$'
+            $result.Octal | Should-MatchString '^[0-7]{3}$'
+            $result.OctalWithSpecial | Should-MatchString '^[0-7]{4}$'
+            $result.FullOctal | Should-MatchString '^[0-7]+$'
             $result.Owner | Should -Not -BeNullOrEmpty
             $result.Group | Should -Not -BeNullOrEmpty
         }
@@ -169,11 +169,11 @@ Describe 'Get-PathPermission' {
 
             $result = Get-PathPermission -Path $script:RegularFile
 
-            $result.Octal | Should -Be $expectedOctal
-            $result.Permissions | Should -Be $expectedPermissions
-            $result.OwnerPermissions | Should -Be $expectedPermissions.Substring(0, 3)
-            $result.GroupPermissions | Should -Be $expectedPermissions.Substring(3, 3)
-            $result.OtherPermissions | Should -Be $expectedPermissions.Substring(6, 3)
+            $result.Octal | Should-Be $expectedOctal
+            $result.Permissions | Should-Be $expectedPermissions
+            $result.OwnerPermissions | Should-Be $expectedPermissions.Substring(0, 3)
+            $result.GroupPermissions | Should-Be $expectedPermissions.Substring(3, 3)
+            $result.OtherPermissions | Should-Be $expectedPermissions.Substring(6, 3)
         }
     }
 
@@ -185,7 +185,7 @@ Describe 'Get-PathPermission' {
             $result.OctalWithSpecial | Should -BeNullOrEmpty
             $result.FullOctal | Should -BeNullOrEmpty
             $result.Owner | Should -Not -BeNullOrEmpty
-            $result.PSObject.Properties.Name | Should -Contain 'AccessSummary'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'AccessSummary'
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Get-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Get-PlatformPackage.Tests.ps1
@@ -21,18 +21,18 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager brew -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $formula = $result | Where-Object { $_.Name -eq 'git' }
-            $formula.PackageManager | Should -Be 'brew'
-            $formula.Type | Should -Be 'Formula'
-            $formula.InstalledVersion | Should -Be '2.44.0'
-            $formula.Publisher | Should -Be 'Homebrew'
-            $formula.PSObject.Properties.Name | Should -Not -Contain 'RemoveArguments'
+            $formula.PackageManager | Should-Be 'brew'
+            $formula.Type | Should-Be 'Formula'
+            $formula.InstalledVersion | Should-Be '2.44.0'
+            $formula.Publisher | Should-Be 'Homebrew'
+            $formula.PSObject.Properties.Name | Should-NotContainCollection 'RemoveArguments'
 
             $cask = $result | Where-Object { $_.Name -eq 'visual-studio-code' }
-            $cask.Type | Should -Be 'Cask'
-            $cask.Source | Should -Be 'homebrew/cask'
+            $cask.Type | Should-Be 'Cask'
+            $cask.Source | Should-Be 'homebrew/cask'
         }
     }
 
@@ -59,12 +59,12 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager winget -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Git'
-            $result[0].Id | Should -Be 'Git.Git'
-            $result[0].InstalledVersion | Should -Be '2.45.1'
-            $result[0].Source | Should -Be 'winget'
-            $result[0].Publisher | Should -Be 'winget'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Git'
+            $result[0].Id | Should-Be 'Git.Git'
+            $result[0].InstalledVersion | Should-Be '2.45.1'
+            $result[0].Source | Should-Be 'winget'
+            $result[0].Publisher | Should-Be 'winget'
         }
     }
 
@@ -79,11 +79,11 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager apt -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'openssl'
-            $result[0].Type | Should -Be 'arm64'
-            $result[0].InstalledVersion | Should -Be '3.0.2-0ubuntu1.15'
-            $result[0].Notes | Should -Be 'Automatic'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'openssl'
+            $result[0].Type | Should-Be 'arm64'
+            $result[0].InstalledVersion | Should-Be '3.0.2-0ubuntu1.15'
+            $result[0].Notes | Should-Be 'Automatic'
         }
 
         It 'parses apk output and keeps hyphenated package names' {
@@ -96,13 +96,13 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager apk -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $busybox = $result | Where-Object { $_.Name -eq 'busybox' }
-            $busybox.InstalledVersion | Should -Be '1.36.1-r19'
+            $busybox.InstalledVersion | Should-Be '1.36.1-r19'
 
             $requests = $result | Where-Object { $_.Name -eq 'py3-requests' }
-            $requests.InstalledVersion | Should -Be '2.31.0-r0'
+            $requests.InstalledVersion | Should-Be '2.31.0-r0'
         }
     }
 
@@ -115,8 +115,8 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager brew -Name 'g*' -ExcludePackage 'gh' -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
         }
 
         It 'returns empty when brew list output is empty' {
@@ -127,7 +127,7 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager brew -CommandRunner $runner)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
         }
 
         It 'excludes winget packages matched by wildcard ExcludePackage pattern' {
@@ -158,8 +158,8 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager winget -ExcludePackage '*Desktop*' -SkipDescriptionEnrichment -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Git'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Git'
         }
 
         It 'falls back to winget table output when the JSON command fails' {
@@ -176,8 +176,8 @@ Describe 'Get-PlatformPackage' {
 
             $result = @(Get-PlatformPackage -PackageManager winget -SkipDescriptionEnrichment -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Git'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Git'
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Get-PlatformPackageDependency.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Get-PlatformPackageDependency.Tests.ps1
@@ -16,8 +16,8 @@ Describe 'Get-PlatformPackageDependency' {
         It 'uses Name as an alias for Package without exposing an Id alias' {
             $command = Get-Command Get-PlatformPackageDependency
 
-            $command.Parameters['Package'].Aliases | Should -Contain 'Name'
-            $command.Parameters['Package'].Aliases | Should -Not -Contain 'Id'
+            $command.Parameters['Package'].Aliases | Should-ContainCollection 'Name'
+            $command.Parameters['Package'].Aliases | Should-NotContainCollection 'Id'
         }
     }
 
@@ -35,12 +35,12 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager brew -Package git -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
-            $result[0].Package | Should -Be 'git'
-            $result[0].Direction | Should -Be 'DependsOn'
-            $result[0].RelatedPackage | Should -Be 'gettext'
-            $result[0].Relationship | Should -Be 'git -> gettext'
-            $result[0].DependencyType | Should -Be 'Dependency'
+            $result.Count | Should-Be 2
+            $result[0].Package | Should-Be 'git'
+            $result[0].Direction | Should-Be 'DependsOn'
+            $result[0].RelatedPackage | Should-Be 'gettext'
+            $result[0].Relationship | Should-Be 'git -> gettext'
+            $result[0].DependencyType | Should-Be 'Dependency'
         }
 
         It 'returns installed dependents from brew uses' {
@@ -50,12 +50,12 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager brew -Package openssl -Direction RequiredBy -InstalledOnly -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Package | Should -Be 'openssl'
-            $result[0].Direction | Should -Be 'RequiredBy'
-            $result[0].RelatedPackage | Should -Be 'curl'
-            $result[0].Relationship | Should -Be 'curl -> openssl'
-            $result[0].Installed | Should -BeTrue
+            $result.Count | Should-Be 1
+            $result[0].Package | Should-Be 'openssl'
+            $result[0].Direction | Should-Be 'RequiredBy'
+            $result[0].RelatedPackage | Should-Be 'curl'
+            $result[0].Relationship | Should-Be 'curl -> openssl'
+            $result[0].Installed | Should-BeTruthy
         }
 
         It 'uses eval-all for broad dependent discovery' {
@@ -65,10 +65,10 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager brew -Package jq -Direction RequiredBy -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Package | Should -Be 'jq'
-            $result[0].Direction | Should -Be 'RequiredBy'
-            $result[0].RelatedPackage | Should -Be 'gojq'
+            $result.Count | Should-Be 1
+            $result[0].Package | Should-Be 'jq'
+            $result[0].Direction | Should-Be 'RequiredBy'
+            $result[0].RelatedPackage | Should-Be 'gojq'
         }
 
         It 'returns both dependency directions when Direction is Both' {
@@ -79,11 +79,11 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager brew -Package openssl -Direction Both -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
-            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).RelatedPackage | Should -Be 'ca-certificates'
-            ($result | Where-Object { $_.Direction -eq 'RequiredBy' }).RelatedPackage | Should -Be 'curl'
-            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).Relationship | Should -Be 'openssl -> ca-certificates'
-            ($result | Where-Object { $_.Direction -eq 'RequiredBy' }).Relationship | Should -Be 'curl -> openssl'
+            $result.Count | Should-Be 2
+            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).RelatedPackage | Should-Be 'ca-certificates'
+            ($result | Where-Object { $_.Direction -eq 'RequiredBy' }).RelatedPackage | Should-Be 'curl'
+            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).Relationship | Should-Be 'openssl -> ca-certificates'
+            ($result | Where-Object { $_.Direction -eq 'RequiredBy' }).Relationship | Should-Be 'curl -> openssl'
         }
     }
 
@@ -101,12 +101,12 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager apt -Package curl -CommandRunner $runner)
 
-            $result.Count | Should -Be 3
-            $result.RelatedPackage | Should -Contain 'libc6'
-            $result.RelatedPackage | Should -Contain 'libcurl4'
-            $result.RelatedPackage | Should -Contain 'dpkg'
-            $result.RelatedPackage | Should -Not -Contain 'ca-certificates'
-            ($result | Where-Object { $_.RelatedPackage -eq 'dpkg' }).DependencyType | Should -Be 'PreDepends'
+            $result.Count | Should-Be 3
+            $result.RelatedPackage | Should-ContainCollection 'libc6'
+            $result.RelatedPackage | Should-ContainCollection 'libcurl4'
+            $result.RelatedPackage | Should-ContainCollection 'dpkg'
+            $result.RelatedPackage | Should-NotContainCollection 'ca-certificates'
+            ($result | Where-Object { $_.RelatedPackage -eq 'dpkg' }).DependencyType | Should-Be 'PreDepends'
         }
 
         It 'filters reverse dependency records to installed APT packages' {
@@ -125,9 +125,9 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager apt -Package openssl -Direction RequiredBy -InstalledOnly -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].RelatedPackage | Should -Be 'curl'
-            $result[0].Installed | Should -BeTrue
+            $result.Count | Should-Be 1
+            $result[0].RelatedPackage | Should-Be 'curl'
+            $result[0].Installed | Should-BeTruthy
         }
     }
 
@@ -147,10 +147,10 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager apk -Package pipewire -Direction Both -CommandRunner $runner)
 
-            $result.Count | Should -Be 3
-            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).RelatedPackage | Should -Contain '/bin/sh'
-            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).RelatedPackage | Should -Contain 'so:libpipewire-0.3.so.0'
-            ($result | Where-Object { $_.Direction -eq 'RequiredBy' }).RelatedPackage | Should -Be 'pipewire-pulse'
+            $result.Count | Should-Be 3
+            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).RelatedPackage | Should-ContainCollection '/bin/sh'
+            ($result | Where-Object { $_.Direction -eq 'DependsOn' }).RelatedPackage | Should-ContainCollection 'so:libpipewire-0.3.so.0'
+            ($result | Where-Object { $_.Direction -eq 'RequiredBy' }).RelatedPackage | Should-Be 'pipewire-pulse'
         }
     }
 
@@ -170,28 +170,28 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager winget -Package Git.Git -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Package | Should -Be 'Git.Git'
-            $result[0].RelatedPackage | Should -Be 'Microsoft.VCRedist.2015+.x64'
-            $result[0].DependencyType | Should -Be 'Package Dependencies'
+            $result.Count | Should-Be 1
+            $result[0].Package | Should-Be 'Git.Git'
+            $result[0].RelatedPackage | Should-Be 'Microsoft.VCRedist.2015+.x64'
+            $result[0].DependencyType | Should-Be 'Package Dependencies'
         }
 
         It 'rejects reverse dependency lookup for winget' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Get-PlatformPackageDependency -PackageManager winget -Package Git.Git -Direction RequiredBy -CommandRunner $runner } |
-                Should -Throw -ExpectedMessage "*Value 'RequiredBy' for parameter -Direction*package manager 'winget'*supports only 'DependsOn'*"
+                Should-Throw -ExceptionMessage "*Value 'RequiredBy' for parameter -Direction*package manager 'winget'*supports only 'DependsOn'*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
 
         It 'rejects partial Both dependency lookup for winget' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Get-PlatformPackageDependency -PackageManager winget -Package Git.Git -Direction Both -CommandRunner $runner } |
-                Should -Throw -ExpectedMessage "*Value 'Both' for parameter -Direction*package manager 'winget'*supports only 'DependsOn'*"
+                Should-Throw -ExceptionMessage "*Value 'Both' for parameter -Direction*package manager 'winget'*supports only 'DependsOn'*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
 
         It 'filters winget installed dependencies by id instead of ambiguous display name' {
@@ -226,8 +226,8 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @(Get-PlatformPackageDependency -PackageManager winget -Package Git.Git -InstalledOnly -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].RelatedPackage | Should -Be 'OpenJS.NodeJS.LTS'
+            $result.Count | Should-Be 1
+            $result[0].RelatedPackage | Should-Be 'OpenJS.NodeJS.LTS'
         }
     }
 
@@ -245,10 +245,10 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @($package | Get-PlatformPackageDependency -PackageManager brew -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Package | Should -Be 'git'
-            $result[0].Id | Should -Be 'git'
-            $result[0].RelatedPackage | Should -Be 'gettext'
+            $result.Count | Should-Be 1
+            $result[0].Package | Should-Be 'git'
+            $result[0].Id | Should-Be 'git'
+            $result[0].RelatedPackage | Should-Be 'gettext'
         }
 
         It 'returns empty when brew reports no dependencies for a package' {
@@ -264,7 +264,7 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @($package | Get-PlatformPackageDependency -PackageManager brew -CommandRunner $runner)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
         }
 
         It 'returns dependency records for each package when multiple packages are piped' {
@@ -280,9 +280,9 @@ Describe 'Get-PlatformPackageDependency' {
 
             $result = @($packages | Get-PlatformPackageDependency -PackageManager brew -CommandRunner $runner)
 
-            $result.Count | Should -Be 4
-            ($result | Where-Object { $_.Package -eq 'git' }).Count | Should -Be 2
-            ($result | Where-Object { $_.Package -eq 'curl' }).Count | Should -Be 2
+            $result.Count | Should-Be 4
+            ($result | Where-Object { $_.Package -eq 'git' }).Count | Should-Be 2
+            ($result | Where-Object { $_.Package -eq 'curl' }).Count | Should-Be 2
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Get-TlsSecurityProtocol.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Get-TlsSecurityProtocol.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Get-TlsSecurityProtocol' {
         }
 
         It 'rejects invalid protocol values' {
-            { Get-TlsSecurityProtocol -Protocol 'InvalidTls' } | Should -Throw
+            { Get-TlsSecurityProtocol -Protocol 'InvalidTls' } | Should-Throw
         }
     }
 
@@ -40,43 +40,43 @@ Describe 'Get-TlsSecurityProtocol' {
             $result = Get-TlsSecurityProtocol
 
             $result | Should -Not -BeNullOrEmpty
-            $result.PSObject.Properties.Name | Should -Contain 'CurrentProtocol'
-            $result.PSObject.Properties.Name | Should -Contain 'CurrentProtocolDisplay'
-            $result.PSObject.Properties.Name | Should -Contain 'EnabledProtocols'
-            $result.PSObject.Properties.Name | Should -Contain 'AvailableProtocols'
-            $result.PSObject.Properties.Name | Should -Contain 'ConfigurationMode'
-            $result.PSObject.Properties.Name | Should -Contain 'SupportsSystemDefault'
-            $result.PSObject.Properties.Name | Should -Contain 'IsSystemDefault'
-            $result.PSObject.Properties.Name | Should -Contain 'EffectiveProtocolKnown'
-            $result.PSObject.Properties.Name | Should -Contain 'EffectiveProtocolNote'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'CurrentProtocol'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'CurrentProtocolDisplay'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'EnabledProtocols'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'AvailableProtocols'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ConfigurationMode'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'SupportsSystemDefault'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'IsSystemDefault'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'EffectiveProtocolKnown'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'EffectiveProtocolNote'
 
-            $result.CurrentProtocol | Should -BeOfType [System.Net.SecurityProtocolType]
-            $result.CurrentProtocolDisplay | Should -BeOfType [String]
-            $result.EnabledProtocols.GetType().FullName | Should -Be 'System.String[]'
-            $result.AvailableProtocols.GetType().FullName | Should -Be 'System.String[]'
+            $result.CurrentProtocol | Should-HaveType ([System.Net.SecurityProtocolType])
+            $result.CurrentProtocolDisplay | Should-HaveType ([String])
+            $result.EnabledProtocols.GetType().FullName | Should-Be 'System.String[]'
+            $result.AvailableProtocols.GetType().FullName | Should-Be 'System.String[]'
         }
 
         It 'returns evaluation details when Protocol is specified' {
             $result = Get-TlsSecurityProtocol -Protocol 'Tls12'
 
-            $result.PSObject.Properties.Name | Should -Contain 'RequestedProtocol'
-            $result.PSObject.Properties.Name | Should -Contain 'RequestedProtocolAvailable'
-            $result.PSObject.Properties.Name | Should -Contain 'ResolvedProtocol'
-            $result.PSObject.Properties.Name | Should -Contain 'TargetProtocol'
-            $result.PSObject.Properties.Name | Should -Contain 'TargetProtocolDisplay'
-            $result.PSObject.Properties.Name | Should -Contain 'ForceTargetProtocol'
-            $result.PSObject.Properties.Name | Should -Contain 'ForceTargetProtocolDisplay'
-            $result.PSObject.Properties.Name | Should -Contain 'FallbackUsed'
-            $result.PSObject.Properties.Name | Should -Contain 'FallbackDirection'
-            $result.PSObject.Properties.Name | Should -Contain 'ChangeRequired'
-            $result.PSObject.Properties.Name | Should -Contain 'ForceRequired'
-            $result.PSObject.Properties.Name | Should -Contain 'EvaluationNote'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'RequestedProtocol'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'RequestedProtocolAvailable'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ResolvedProtocol'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'TargetProtocol'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'TargetProtocolDisplay'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ForceTargetProtocol'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ForceTargetProtocolDisplay'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FallbackUsed'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FallbackDirection'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ChangeRequired'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ForceRequired'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'EvaluationNote'
 
-            $result.RequestedProtocol | Should -Be 'Tls12'
-            $result.TargetProtocol | Should -BeOfType [System.Net.SecurityProtocolType]
-            $result.ForceTargetProtocol | Should -BeOfType [System.Net.SecurityProtocolType]
-            $result.ChangeRequired | Should -BeOfType [Boolean]
-            $result.ForceRequired | Should -BeOfType [Boolean]
+            $result.RequestedProtocol | Should-Be 'Tls12'
+            $result.TargetProtocol | Should-HaveType ([System.Net.SecurityProtocolType])
+            $result.ForceTargetProtocol | Should-HaveType ([System.Net.SecurityProtocolType])
+            $result.ChangeRequired | Should-HaveType ([Boolean])
+            $result.ForceRequired | Should-HaveType ([Boolean])
         }
     }
 
@@ -86,8 +86,8 @@ Describe 'Get-TlsSecurityProtocol' {
 
             $result = Get-TlsSecurityProtocol -Protocol 'Tls12'
 
-            $result.ChangeRequired | Should -Be $false
-            $result.TargetProtocol | Should -Be ([Net.SecurityProtocolType]::Tls12)
+            $result.ChangeRequired | Should-Be $false
+            $result.TargetProtocol | Should-Be ([Net.SecurityProtocolType]::Tls12)
         }
 
         It 'reports a change when weaker-only protocols are enabled' {
@@ -103,9 +103,9 @@ Describe 'Get-TlsSecurityProtocol' {
 
             $result = Get-TlsSecurityProtocol -Protocol 'Tls12'
 
-            $result.ChangeRequired | Should -Be $true
-            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls12) | Should -Not -Be 0
-            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls) | Should -Be 0
+            $result.ChangeRequired | Should-Be $true
+            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls12) | Should-NotBe 0
+            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls) | Should-Be 0
         }
 
         It 'preserves stronger secure protocols when evaluating a lower secure request' {
@@ -121,26 +121,26 @@ Describe 'Get-TlsSecurityProtocol' {
 
             $result = Get-TlsSecurityProtocol -Protocol 'Tls12'
 
-            $result.ChangeRequired | Should -Be $false
-            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls12) | Should -Not -Be 0
-            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls13) | Should -Not -Be 0
+            $result.ChangeRequired | Should-Be $false
+            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls12) | Should-NotBe 0
+            ($result.TargetProtocol -band [Net.SecurityProtocolType]::Tls13) | Should-NotBe 0
         }
 
         It 'handles TLS 1.3 evaluation gracefully when it is unavailable' {
             $result = Get-TlsSecurityProtocol -Protocol 'Tls13'
 
             $result | Should -Not -BeNullOrEmpty
-            $result.RequestedProtocol | Should -Be 'Tls13'
-            $result.ChangeRequired | Should -BeOfType [Boolean]
+            $result.RequestedProtocol | Should-Be 'Tls13'
+            $result.ChangeRequired | Should-HaveType ([Boolean])
             $result.ResolvedProtocol | Should -Not -BeNullOrEmpty
         }
 
         It 'evaluates SystemDefault requests without throwing' {
             $result = Get-TlsSecurityProtocol -Protocol 'SystemDefault'
 
-            $result.RequestedProtocol | Should -Be 'SystemDefault'
+            $result.RequestedProtocol | Should-Be 'SystemDefault'
             $result.TargetProtocolDisplay | Should -Not -BeNullOrEmpty
-            $result.ChangeRequired | Should -BeOfType [Boolean]
+            $result.ChangeRequired | Should-HaveType ([Boolean])
         }
 
         It 'treats explicit requests as no-op when the current session is SystemDefault' {
@@ -154,16 +154,16 @@ Describe 'Get-TlsSecurityProtocol' {
 
             $result = Get-TlsSecurityProtocol -Protocol 'Tls12'
 
-            $result.IsSystemDefault | Should -Be $true
-            $result.ConfigurationMode | Should -Be 'SystemDefault'
-            $result.EffectiveProtocolKnown | Should -Be $false
-            $result.ChangeRequired | Should -Be $false
-            $result.ForceRequired | Should -Be $true
-            $result.ResolvedProtocol | Should -Be 'SystemDefault'
-            $result.TargetProtocol | Should -Be ([Net.SecurityProtocolType]::SystemDefault)
-            $result.TargetProtocolDisplay | Should -Be 'SystemDefault'
-            $result.ForceTargetProtocolDisplay | Should -Be 'Tls12'
-            $result.EvaluationNote | Should -Match 'SystemDefault|OS-managed|Force'
+            $result.IsSystemDefault | Should-Be $true
+            $result.ConfigurationMode | Should-Be 'SystemDefault'
+            $result.EffectiveProtocolKnown | Should-Be $false
+            $result.ChangeRequired | Should-Be $false
+            $result.ForceRequired | Should-Be $true
+            $result.ResolvedProtocol | Should-Be 'SystemDefault'
+            $result.TargetProtocol | Should-Be ([Net.SecurityProtocolType]::SystemDefault)
+            $result.TargetProtocolDisplay | Should-Be 'SystemDefault'
+            $result.ForceTargetProtocolDisplay | Should-Be 'Tls12'
+            $result.EvaluationNote | Should-MatchString 'SystemDefault|OS-managed|Force'
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Install-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Install-PlatformPackage.Tests.ps1
@@ -20,18 +20,18 @@ Describe 'Install-PlatformPackage' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Install-PlatformPackage -PackageManager brew -Name git -Interactive -CommandRunner $runner -Confirm:$false } |
-                Should -Throw -ExpectedMessage "*Parameter -Interactive*package manager 'brew'*only supported by winget*"
+                Should-Throw -ExceptionMessage "*Parameter -Interactive*package manager 'brew'*only supported by winget*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
 
         It 'rejects NoSudo for package managers that do not use sudo' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Install-PlatformPackage -PackageManager winget -Name Git.Git -NoSudo -CommandRunner $runner -Confirm:$false } |
-                Should -Throw -ExpectedMessage "*Parameter -NoSudo*package manager 'winget'*only supported by apt and apk*"
+                Should-Throw -ExceptionMessage "*Parameter -NoSudo*package manager 'winget'*only supported by apt and apk*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
     }
 
@@ -43,9 +43,9 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager winget -Name Git.Git -CommandRunner $runner -Confirm:$false
 
-            $result.Installed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
+            $result.Installed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget install output' } -Times 1
         }
 
         It 'passes interactive mode to winget installs' {
@@ -55,8 +55,8 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager winget -Name Git.Git -Interactive -CommandRunner $runner -Confirm:$false
 
-            $result.Installed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements --interactive' }).StreamOutput | Should -BeTrue
+            $result.Installed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --accept-source-agreements --accept-package-agreements --interactive' }).StreamOutput | Should-BeTruthy
         }
 
         It 'promotes the full failure message into informational results' {
@@ -66,22 +66,22 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager winget -Name Microsoft.Edge -CommandRunner $runner -Confirm:$false -WarningAction SilentlyContinue
 
-            $result.Installed | Should -Be 0
-            $result.Failed | Should -Be 1
-            $result.Results[0].Message | Should -Match 'winget install --id Microsoft.Edge --exact'
-            $result.Results[0].Message | Should -Match 'failed with exit code -1978335090'
-            $result.Results[0].InformationalOutput | Should -HaveCount 1
-            $result.Results[0].InformationalOutput[0] | Should -BeExactly $result.Results[0].Message
-            $result.InformationalResults | Should -HaveCount 1
-            $result.InformationalResults[0].Lines | Should -HaveCount 1
-            $result.InformationalResults[0].Lines[0] | Should -BeExactly $result.Results[0].Message
+            $result.Installed | Should-Be 0
+            $result.Failed | Should-Be 1
+            $result.Results[0].Message | Should-MatchString 'winget install --id Microsoft.Edge --exact'
+            $result.Results[0].Message | Should-MatchString 'failed with exit code -1978335090'
+            $result.Results[0].InformationalOutput | Should-BeCollection -Count 1
+            $result.Results[0].InformationalOutput[0] | Should-BeString $result.Results[0].Message -CaseSensitive
+            $result.InformationalResults | Should-BeCollection -Count 1
+            $result.InformationalResults[0].Lines | Should-BeCollection -Count 1
+            $result.InformationalResults[0].Lines[0] | Should-BeString $result.Results[0].Message -CaseSensitive
         }
 
         It 'does not expose a separate Id parameter' {
             $command = Get-Command Install-PlatformPackage
 
-            $command.Parameters.ContainsKey('Name') | Should -BeTrue
-            $command.Parameters.ContainsKey('Id') | Should -BeFalse
+            $command.Parameters.ContainsKey('Name') | Should-BeTruthy
+            $command.Parameters.ContainsKey('Id') | Should-BeFalsy
         }
 
         It 'honors WhatIf for direct installs' {
@@ -91,9 +91,9 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager brew -Name git -CommandRunner $runner -WhatIf
 
-            $result.Installed | Should -Be 0
-            $result.Skipped | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).Count | Should -Be 0
+            $result.Installed | Should-Be 0
+            $result.Skipped | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).Count | Should-Be 0
         }
 
         It 'captures post-install instructions in the result object' {
@@ -108,11 +108,11 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager brew -Name python -CommandRunner $runner -Confirm:$false
 
-            $result.Installed | Should -Be 1
-            $result.Results[0].CapturedOutput | Should -Contain 'Installing python...'
-            $result.Results[0].InformationalOutput | Should -Contain '==> Caveats'
-            $result.InformationalResults.Count | Should -Be 1
-            $result.InformationalResults[0].Lines | Should -Contain 'Python is installed as'
+            $result.Installed | Should-Be 1
+            $result.Results[0].CapturedOutput | Should-ContainCollection 'Installing python...'
+            $result.Results[0].InformationalOutput | Should-ContainCollection '==> Caveats'
+            $result.InformationalResults.Count | Should-Be 1
+            $result.InformationalResults[0].Lines | Should-ContainCollection 'Python is installed as'
         }
     }
 
@@ -135,11 +135,11 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager brew -Query code -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.Installed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew install --cask visual-studio-code' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  1 selected" -and $ForegroundColor -eq 'White' } -Times 1
+            $result.Selected | Should-Be 1
+            $result.Installed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew install --cask visual-studio-code' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  1 selected" -and $ForegroundColor -eq 'White' } -Times 1
         }
 
         It 'installs the current search result when Enter is pressed without a selection' {
@@ -155,11 +155,11 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager brew -Query git -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.NotSelected | Should -Be 0
-            $result.Installed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
+            $result.Selected | Should-Be 1
+            $result.NotSelected | Should-Be 0
+            $result.Installed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter install  V details  A toggle all' } -Times 1
         }
 
         It 'shows keyboard help from the query result picker' {
@@ -180,11 +180,11 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager brew -Query git -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.Installed | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Install-PlatformPackage Help' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'install selected packages, or the current package if none are selected' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            $result.Selected | Should-Be 0
+            $result.Installed | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Install-PlatformPackage Help' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'install selected packages, or the current package if none are selected' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'shows and skips an installed Homebrew search result' {
@@ -206,14 +206,14 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager brew -Query jq -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.Installed | Should -Be 0
-            $result.Skipped | Should -Be 1
-            $result.Results[0].Message | Should -Be 'Package is already installed'
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew install jq' }).Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current: jq' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Id: jq | Source: homebrew/core | Publisher: Homebrew | Installed: yes' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $ForegroundColor -eq 'DarkGray' -and $Object -like '*jq*' } -Times 2
+            $result.Selected | Should-Be 1
+            $result.Installed | Should-Be 0
+            $result.Skipped | Should-Be 1
+            $result.Results[0].Message | Should-Be 'Package is already installed'
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew install jq' }).Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current: jq' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Id: jq | Source: homebrew/core | Publisher: Homebrew | Installed: yes' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $ForegroundColor -eq 'DarkGray' -and $Object -like '*jq*' } -Times 2
         }
 
         It 'installs only the visible package when filtering duplicate winget ids by source' {
@@ -263,10 +263,10 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager winget -Query git -FilterSource msstore -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.Installed | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source winget --accept-source-agreements --accept-package-agreements' }).Count | Should -Be 0
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source msstore --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
+            $result.Selected | Should-Be 1
+            $result.Installed | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source winget --accept-source-agreements --accept-package-agreements' }).Count | Should-Be 0
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source msstore --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should-BeTruthy
         }
 
         It 'toggles interactive mode for the current winget picker row' {
@@ -299,11 +299,11 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager winget -Query git -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Installed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source winget --accept-source-agreements --accept-package-agreements --interactive' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I interactive installer  Enter install  V details  A toggle all' } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+UI\s+' } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^> \[ \] \[I\]' } -Times 1
+            $result.Installed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source winget --accept-source-agreements --accept-package-agreements --interactive' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  I interactive installer  Enter install  V details  A toggle all' } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+UI\s+' } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^> \[ \] \[I\]' } -Times 1
         }
 
         It 'does not suppress terminal echo when a custom key reader drives winget details' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -347,9 +347,9 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager winget -Query git -CommandRunner $runner -KeyReader $keyReader -TerminalEchoController $terminalEchoController -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $echoActions.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            $result.Selected | Should-Be 0
+            $echoActions.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
         }
 
         It 'restores terminal echo when winget details throw in the console key reader flow' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -417,9 +417,9 @@ Describe 'Install-PlatformPackage' {
 
             {
                 Install-PlatformPackage -PackageManager winget -Query git -CommandRunner $runner -KeyReader $keyReader -TreatKeyReaderAsConsoleKeyReader -TerminalEchoController $terminalEchoController -Confirm:$false
-            } | Should -Throw -ExpectedMessage '*winget details failed*'
+            } | Should-Throw -ExceptionMessage '*winget details failed*'
 
-            ($echoActions -join '|') | Should -Be 'Disable|Restore:saved-stty-state'
+            ($echoActions -join '|') | Should-Be 'Disable|Restore:saved-stty-state'
         }
 
         It 'keeps picker table rows within the current console width' {
@@ -467,12 +467,12 @@ Describe 'Install-PlatformPackage' {
                 }
             )
 
-            $tableLines.Count | Should -BeGreaterThan 1
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should -Match '\bVer\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should -Match '\bTyp\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should -Match '\bSrc\b'
-            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\]\s+' } | Select-Object -First 1) | Should -Match 'homebrew/core'
-            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should -BeLessOrEqual (Get-TestPickerLineLimit)
+            $tableLines.Count | Should-BeGreaterThan 1
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should-MatchString '\bVer\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should-MatchString '\bTyp\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+' } | Select-Object -First 1) | Should-MatchString '\bSrc\b'
+            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\]\s+' } | Select-Object -First 1) | Should-MatchString 'homebrew/core'
+            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should-BeLessThanOrEqual (Get-TestPickerLineLimit)
         }
 
         It 'returns a no-selection summary when the picker is cancelled' {
@@ -487,11 +487,11 @@ Describe 'Install-PlatformPackage' {
 
             $result = Install-PlatformPackage -PackageManager brew -Query git -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.NotSelected | Should -Be 1
-            $result.Installed | Should -Be 0
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).Count | Should -Be 0
-            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 4
+            $result.Selected | Should-Be 0
+            $result.NotSelected | Should-Be 1
+            $result.Installed | Should-Be 0
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew install git' }).Count | Should-Be 0
+            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should-Be 4
         }
     }
 
@@ -508,9 +508,9 @@ Describe 'Install-PlatformPackage' {
 
             $result = $package | Install-PlatformPackage -CommandRunner (& $script:NewPackageCommandRunner @{}) -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.Skipped | Should -Be 1
-            $result.Results[0].Message | Should -Be 'Package is already installed'
+            $result.Selected | Should-Be 1
+            $result.Skipped | Should-Be 1
+            $result.Results[0].Message | Should-Be 'Package is already installed'
         }
 
         It 'passes the package source to winget install commands' {
@@ -529,8 +529,8 @@ Describe 'Install-PlatformPackage' {
 
             $result = $package | Install-PlatformPackage -CommandRunner $runner -Confirm:$false
 
-            $result.Installed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source msstore --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should -BeTrue
+            $result.Installed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget install --id Git.Git --exact --source msstore --accept-source-agreements --accept-package-agreements' }).StreamOutput | Should-BeTruthy
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Remove-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Remove-PlatformPackage.Tests.ps1
@@ -23,9 +23,9 @@ Describe 'Remove-PlatformPackage' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Remove-PlatformPackage -PackageManager brew -NonInteractive -NoSudo -CommandRunner $runner -Confirm:$false } |
-                Should -Throw -ExpectedMessage "*Parameter -NoSudo*package manager 'brew'*only supported by apt and apk*"
+                Should-Throw -ExceptionMessage "*Parameter -NoSudo*package manager 'brew'*only supported by apt and apk*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
     }
 
@@ -38,17 +38,17 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager brew -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $formula = $result | Where-Object { $_.Name -eq 'git' }
-            $formula.PackageManager | Should -Be 'brew'
-            $formula.Type | Should -Be 'Formula'
-            $formula.InstalledVersion | Should -Be '2.44.0'
-            (@($formula.RemoveArguments) -join '|') | Should -Be 'uninstall|git'
+            $formula.PackageManager | Should-Be 'brew'
+            $formula.Type | Should-Be 'Formula'
+            $formula.InstalledVersion | Should-Be '2.44.0'
+            (@($formula.RemoveArguments) -join '|') | Should-Be 'uninstall|git'
 
             $cask = $result | Where-Object { $_.Name -eq 'visual-studio-code' }
-            $cask.Type | Should -Be 'Cask'
-            (@($cask.RemoveArguments) -join '|') | Should -Be 'uninstall|--cask|visual-studio-code'
+            $cask.Type | Should-Be 'Cask'
+            (@($cask.RemoveArguments) -join '|') | Should-Be 'uninstall|--cask|visual-studio-code'
         }
 
         It 'keeps AsObject as an alias for NonInteractive discovery' {
@@ -59,10 +59,10 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager brew -AsObject -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            (@($result[0].RemoveArguments) -join '|') | Should -Be 'uninstall|git'
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            (@($result[0].RemoveArguments) -join '|') | Should-Be 'uninstall|git'
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 0
         }
 
         It 'uses zap for casks when purge is requested' {
@@ -73,7 +73,7 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager brew -NonInteractive -Purge -CommandRunner $runner)
 
-            (@($result[0].RemoveArguments) -join '|') | Should -Be 'uninstall|--cask|--zap|visual-studio-code'
+            (@($result[0].RemoveArguments) -join '|') | Should-Be 'uninstall|--cask|--zap|visual-studio-code'
         }
 
         It 'streams remove command output when removing all matching packages' {
@@ -85,13 +85,13 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -IncludePackage git -All -CommandRunner $runner -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            $result.Failed | Should -Be 0
-            $result.NotSelected | Should -Be 0
+            $result.Removed | Should-Be 1
+            $result.Failed | Should-Be 0
+            $result.NotSelected | Should-Be 0
 
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).StreamOutput | Should -BeTrue
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).StreamOutput | Should-BeTruthy
 
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew uninstall git output' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew uninstall git output' } -Times 1
         }
 
         It 'captures post-removal instructions in the result object' {
@@ -107,11 +107,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -IncludePackage python -All -CommandRunner $runner -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            $result.Results[0].CapturedOutput | Should -Contain 'Removing python...'
-            $result.Results[0].InformationalOutput | Should -Contain 'Note:'
-            $result.InformationalResults.Count | Should -Be 1
-            $result.InformationalResults[0].Lines | Should -Contain 'Python user site-packages were left in place.'
+            $result.Removed | Should-Be 1
+            $result.Results[0].CapturedOutput | Should-ContainCollection 'Removing python...'
+            $result.Results[0].InformationalOutput | Should-ContainCollection 'Note:'
+            $result.InformationalResults.Count | Should-Be 1
+            $result.InformationalResults[0].Lines | Should-ContainCollection 'Python user site-packages were left in place.'
         }
 
         It 'reports streamed command failures with command context when captured output is unavailable' {
@@ -123,16 +123,16 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -IncludePackage git -All -CommandRunner $runner -Confirm:$false -WarningAction SilentlyContinue
 
-            $result.Removed | Should -Be 0
-            $result.Failed | Should -Be 1
-            $result.Skipped | Should -Be 0
-            $result.Results[0].Message | Should -Match 'brew uninstall git failed with exit code 41'
-            $result.Results[0].Message | Should -Match 'streamed directly to the console'
-            $result.Results[0].InformationalOutput | Should -HaveCount 1
-            $result.Results[0].InformationalOutput[0] | Should -BeExactly $result.Results[0].Message
-            $result.InformationalResults | Should -HaveCount 1
-            $result.InformationalResults[0].Lines | Should -HaveCount 1
-            $result.InformationalResults[0].Lines[0] | Should -BeExactly $result.Results[0].Message
+            $result.Removed | Should-Be 0
+            $result.Failed | Should-Be 1
+            $result.Skipped | Should-Be 0
+            $result.Results[0].Message | Should-MatchString 'brew uninstall git failed with exit code 41'
+            $result.Results[0].Message | Should-MatchString 'streamed directly to the console'
+            $result.Results[0].InformationalOutput | Should-BeCollection -Count 1
+            $result.Results[0].InformationalOutput[0] | Should-BeString $result.Results[0].Message -CaseSensitive
+            $result.InformationalResults | Should-BeCollection -Count 1
+            $result.InformationalResults[0].Lines | Should-BeCollection -Count 1
+            $result.InformationalResults[0].Lines[0] | Should-BeString $result.Results[0].Message -CaseSensitive
         }
 
         It 'does not read stale LASTEXITCODE for unstructured command runner output' {
@@ -185,9 +185,9 @@ Describe 'Remove-PlatformPackage' {
 
                 $result = Remove-PlatformPackage -PackageManager brew -IncludePackage git -All -CommandRunner $runner -Confirm:$false
 
-                $result.Removed | Should -Be 1
-                $result.Failed | Should -Be 0
-                $result.Results[0].ExitCode | Should -Be 0
+                $result.Removed | Should-Be 1
+                $result.Failed | Should-Be 0
+                $result.Results[0].ExitCode | Should-Be 0
             }
             finally
             {
@@ -209,7 +209,7 @@ Describe 'Remove-PlatformPackage' {
             }
 
             { Remove-PlatformPackage -PackageManager brew -All -CommandRunner $runner -Confirm:$false } |
-            Should -Throw -ExpectedMessage '*without an include filter*'
+            Should-Throw -ExceptionMessage '*without an include filter*'
         }
 
         It 'warns about installed Homebrew dependents before removing with -All' {
@@ -222,13 +222,13 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -IncludePackage openssl -All -CommandRunner $runner -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            $result.Results[0].RequiredByCount | Should -Be 1
-            $result.Results[0].RequiredByPackages | Should -Contain 'curl'
-            $script:Warnings | Should -Contain 'openssl is required by 1 installed package(s): curl. Removing it may break dependent packages.'
+            $result.Removed | Should-Be 1
+            $result.Results[0].RequiredByCount | Should-Be 1
+            $result.Results[0].RequiredByPackages | Should-ContainCollection 'curl'
+            $script:Warnings | Should-ContainCollection 'openssl is required by 1 installed package(s): curl. Removing it may break dependent packages.'
 
             $keys = @($script:Invocations | ForEach-Object { $_.Key })
-            [Array]::IndexOf($keys, 'brew uses --installed openssl') | Should -BeLessThan ([Array]::IndexOf($keys, 'brew uninstall openssl'))
+            [Array]::IndexOf($keys, 'brew uses --installed openssl') | Should-BeLessThan ([Array]::IndexOf($keys, 'brew uninstall openssl'))
         }
     }
 
@@ -243,12 +243,12 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager apt -NonInteractive -Purge -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'openssl'
-            $result[0].PackageManager | Should -Be 'apt'
-            $result[0].InstalledVersion | Should -Be '3.0.2-0ubuntu1.15'
-            $result[0].Notes | Should -Be 'Automatic'
-            (@($result[0].RemoveArguments) -join '|') | Should -Be 'purge|-y|openssl'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'openssl'
+            $result[0].PackageManager | Should-Be 'apt'
+            $result[0].InstalledVersion | Should-Be '3.0.2-0ubuntu1.15'
+            $result[0].Notes | Should-Be 'Automatic'
+            (@($result[0].RemoveArguments) -join '|') | Should-Be 'purge|-y|openssl'
         }
 
         It 'parses apk package output and keeps hyphenated package names' {
@@ -261,14 +261,14 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager apk -NonInteractive -Purge -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $busybox = $result | Where-Object { $_.Name -eq 'busybox' }
-            $busybox.InstalledVersion | Should -Be '1.36.1-r19'
-            (@($busybox.RemoveArguments) -join '|') | Should -Be 'del|--purge|busybox'
+            $busybox.InstalledVersion | Should-Be '1.36.1-r19'
+            (@($busybox.RemoveArguments) -join '|') | Should-Be 'del|--purge|busybox'
 
             $requests = $result | Where-Object { $_.Name -eq 'py3-requests' }
-            $requests.InstalledVersion | Should -Be '2.31.0-r0'
+            $requests.InstalledVersion | Should-Be '2.31.0-r0'
         }
 
         It 'warns about installed APT dependents before removing the current interactive package' {
@@ -292,12 +292,12 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager apt -IncludePackage openssl -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            $result.Results[0].RequiredByPackages | Should -Contain 'curl'
-            $script:Warnings | Should -Contain 'openssl is required by 1 installed package(s): curl. Removing it may break dependent packages.'
+            $result.Removed | Should-Be 1
+            $result.Results[0].RequiredByPackages | Should-ContainCollection 'curl'
+            $script:Warnings | Should-ContainCollection 'openssl is required by 1 installed package(s): curl. Removing it may break dependent packages.'
 
             $keys = @($script:Invocations | ForEach-Object { $_.Key })
-            [Array]::IndexOf($keys, 'apt-cache rdepends openssl') | Should -BeLessThan ([Array]::IndexOf($keys, 'apt remove -y openssl'))
+            [Array]::IndexOf($keys, 'apt-cache rdepends openssl') | Should-BeLessThan ([Array]::IndexOf($keys, 'apt remove -y openssl'))
         }
 
         It 'warns about installed apk dependents before removing with -All' {
@@ -315,12 +315,12 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager apk -IncludePackage pipewire -All -CommandRunner $runner -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            $result.Results[0].RequiredByPackages | Should -Contain 'pipewire-pulse'
-            $script:Warnings | Should -Contain 'pipewire is required by 1 installed package(s): pipewire-pulse. Removing it may break dependent packages.'
+            $result.Removed | Should-Be 1
+            $result.Results[0].RequiredByPackages | Should-ContainCollection 'pipewire-pulse'
+            $script:Warnings | Should-ContainCollection 'pipewire is required by 1 installed package(s): pipewire-pulse. Removing it may break dependent packages.'
 
             $keys = @($script:Invocations | ForEach-Object { $_.Key })
-            [Array]::IndexOf($keys, 'apk info --rdepends pipewire') | Should -BeLessThan ([Array]::IndexOf($keys, 'apk del pipewire'))
+            [Array]::IndexOf($keys, 'apk info --rdepends pipewire') | Should-BeLessThan ([Array]::IndexOf($keys, 'apk del pipewire'))
         }
     }
 
@@ -338,13 +338,13 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.NotSelected | Should -Be 0
-            $result.Removed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C cancel" } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
+            $result.Selected | Should-Be 1
+            $result.NotSelected | Should-Be 0
+            $result.Removed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C cancel" } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
         }
 
         It 'shows keyboard help from the removal picker' {
@@ -365,11 +365,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.Removed | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Help' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'P: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'toggle purge/zap removal for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            $result.Selected | Should-Be 0
+            $result.Removed | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Help' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'P: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'toggle purge/zap removal for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'treats Ctrl+C as a cancel command' {
@@ -385,11 +385,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.NotSelected | Should -Be 1
-            $result.Removed | Should -Be 0
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
-            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 4
+            $result.Selected | Should-Be 0
+            $result.NotSelected | Should-Be 1
+            $result.Removed | Should-Be 0
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 0
+            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should-Be 4
         }
 
         It 'ignores Backspace and Delete as manager navigation when not launched by the manager' {
@@ -411,11 +411,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.Removed | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 3
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0 -Exactly
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
+            $result.Selected | Should-Be 0
+            $result.Removed | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 3
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0 -Exactly
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 0
         }
 
         It 'returns to the manager menu on <Name> when manager navigation is enabled' -TestCases @(
@@ -436,11 +436,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.Removed | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
+            $result.Selected | Should-Be 0
+            $result.Removed | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 0
         }
 
         It 'renders only the current viewport for long package lists' {
@@ -460,10 +460,10 @@ Describe 'Remove-PlatformPackage' {
 
             $null = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PickerPageSize 2 -Confirm:$false
 
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
         }
 
         It 'allows purge behavior to be toggled for the selected package' {
@@ -485,10 +485,10 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall --cask --zap visual-studio-code' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*P purge/zap*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
+            $result.Removed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall --cask --zap visual-studio-code' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*P purge/zap*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
         }
 
         It 'shows both dependency directions from the removal picker with D' {
@@ -525,14 +525,14 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Removed | Should -Be 0
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
+            $result.Removed | Should-Be 0
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
         }
 
         It 'returns from dependency view to the removal picker on <Name> when manager navigation is enabled' -TestCases @(
@@ -569,11 +569,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.Removed | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Dependencies - Homebrew' } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
+            $result.Selected | Should-Be 0
+            $result.Removed | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  P purge/zap  Enter remove  D deps  V details  A toggle all  F: [all]" } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage Dependencies - Homebrew' } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
         }
 
         It 'filters picker results by package name when F is pressed' {
@@ -597,11 +597,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall curl' }).Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
+            $result.Removed | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall curl' }).Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
         }
 
         It 'treats lowercase q as filter text instead of cancel' {
@@ -625,11 +625,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall jq' }).Count | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
+            $result.Removed | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall jq' }).Count | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
         }
     }
 
@@ -647,12 +647,12 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager winget -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $powershell = $result | Where-Object { $_.Name -eq 'PowerShell' }
-            $powershell.Id | Should -Be 'Microsoft.PowerShell'
-            $powershell.InstalledVersion | Should -Be '7.4.2'
-            (@($powershell.RemoveArguments) -join '|') | Should -Be 'uninstall|--id|Microsoft.PowerShell|--exact|--source|winget|--accept-source-agreements'
+            $powershell.Id | Should-Be 'Microsoft.PowerShell'
+            $powershell.InstalledVersion | Should-Be '7.4.2'
+            (@($powershell.RemoveArguments) -join '|') | Should-Be 'uninstall|--id|Microsoft.PowerShell|--exact|--source|winget|--accept-source-agreements'
         }
 
         It 'uses winget purge when purge is requested' {
@@ -667,7 +667,7 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager winget -NonInteractive -Purge -CommandRunner $runner)
 
-            (@($result[0].RemoveArguments) -join '|') | Should -Be 'uninstall|--id|Microsoft.PowerShell|--exact|--source|winget|--accept-source-agreements|--purge'
+            (@($result[0].RemoveArguments) -join '|') | Should-Be 'uninstall|--id|Microsoft.PowerShell|--exact|--source|winget|--accept-source-agreements|--purge'
         }
 
         It 'passes the installed package source to winget uninstall commands' {
@@ -694,8 +694,8 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager winget -IncludePackage Git -All -CommandRunner $runner -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source msstore --accept-source-agreements' }).StreamOutput | Should -BeTrue
+            $result.Removed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source msstore --accept-source-agreements' }).StreamOutput | Should-BeTruthy
         }
 
         It 'renders and applies the purge column for winget interactive removals' {
@@ -720,10 +720,10 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Removed | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Microsoft.PowerShell --exact --source winget --accept-source-agreements --purge' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -clike '*Purge*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget purge output' } -Times 1
+            $result.Removed | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Microsoft.PowerShell --exact --source winget --accept-source-agreements --purge' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -clike '*Purge*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget purge output' } -Times 1
         }
 
         It 'keeps picker table rows within the current console width' {
@@ -762,12 +762,12 @@ Describe 'Remove-PlatformPackage' {
                 }
             )
 
-            $tableLines.Count | Should -BeGreaterThan 1
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+Purge\s+' } | Select-Object -First 1) | Should -Match '\bVer\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+Purge\s+' } | Select-Object -First 1) | Should -Match '\bTyp\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+Purge\s+' } | Select-Object -First 1) | Should -Match '\bSrc\b'
-            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\] \[[ p]\]\s+' } | Select-Object -First 1) | Should -Match 'homebrew/core'
-            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should -BeLessOrEqual (Get-TestPickerLineLimit)
+            $tableLines.Count | Should-BeGreaterThan 1
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+Purge\s+' } | Select-Object -First 1) | Should-MatchString '\bVer\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+Purge\s+' } | Select-Object -First 1) | Should-MatchString '\bTyp\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+Purge\s+' } | Select-Object -First 1) | Should-MatchString '\bSrc\b'
+            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\] \[[ p]\]\s+' } | Select-Object -First 1) | Should-MatchString 'homebrew/core'
+            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should-BeLessThanOrEqual (Get-TestPickerLineLimit)
         }
 
         It 'defaults source filter to winget for the winget picker when multiple sources exist' {
@@ -808,7 +808,7 @@ Describe 'Remove-PlatformPackage' {
 
             $null = Remove-PlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
         }
 
         It 'removes only the visible package when filtering duplicate winget ids by source' {
@@ -850,11 +850,11 @@ Describe 'Remove-PlatformPackage' {
 
             $result = Remove-PlatformPackage -PackageManager winget -FilterSource msstore -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.Removed | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source winget --accept-source-agreements' }).Count | Should -Be 0
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source msstore --accept-source-agreements' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
+            $result.Selected | Should-Be 1
+            $result.Removed | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source winget --accept-source-agreements' }).Count | Should-Be 0
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget uninstall --id Git.Git --exact --source msstore --accept-source-agreements' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
         }
     }
 
@@ -871,8 +871,8 @@ Describe 'Remove-PlatformPackage' {
 
             $result = @(Remove-PlatformPackage -PackageManager brew -NonInteractive -IncludePackage 'git*' -ExcludePackage 'git-lfs' -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
         }
 
         It 'honors -WhatIf for remove commands' {
@@ -884,12 +884,12 @@ Describe 'Remove-PlatformPackage' {
             $result = Remove-PlatformPackage -PackageManager brew -IncludePackage git -All -WhatIf -CommandRunner $runner
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Selected | Should -Be 1
-            $result.NotSelected | Should -Be 0
-            $result.Removed | Should -Be 0
-            $result.Skipped | Should -Be 1
+            $result.Selected | Should-Be 1
+            $result.NotSelected | Should-Be 0
+            $result.Removed | Should-Be 0
+            $result.Skipped | Should-Be 1
 
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 0
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Set-PathPermission.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Set-PathPermission.Tests.ps1
@@ -60,30 +60,30 @@ Describe 'Set-PathPermission' {
     It 'is available as a function' {
         $command = Get-Command -Name 'Set-PathPermission' -ErrorAction SilentlyContinue
         $command | Should -Not -BeNullOrEmpty
-        $command.CommandType | Should -Be 'Function'
+        $command.CommandType | Should-Be 'Function'
     }
 
     It 'supports ShouldProcess (WhatIf/Confirm)' {
         $command = Get-Command -Name 'Set-PathPermission' -ErrorAction SilentlyContinue
-        $command.Parameters.ContainsKey('WhatIf') | Should -Be $true
-        $command.Parameters.ContainsKey('Confirm') | Should -Be $true
+        $command.Parameters.ContainsKey('WhatIf') | Should-Be $true
+        $command.Parameters.ContainsKey('Confirm') | Should-Be $true
     }
 
     It 'exposes portable and advanced permission parameters' {
         $command = Get-Command -Name 'Set-PathPermission' -ErrorAction SilentlyContinue
 
-        $command.Parameters.ContainsKey('OwnerPermission') | Should -Be $true
-        $command.Parameters.ContainsKey('GroupPermission') | Should -Be $true
-        $command.Parameters.ContainsKey('OtherPermission') | Should -Be $true
-        $command.Parameters.ContainsKey('Mode') | Should -Be $true
-        $command.Parameters.ContainsKey('Permission') | Should -Be $true
-        $command.Parameters.ContainsKey('Rights') | Should -Be $true
-        $command.Parameters.ContainsKey('Idempotent') | Should -Be $true
+        $command.Parameters.ContainsKey('OwnerPermission') | Should-Be $true
+        $command.Parameters.ContainsKey('GroupPermission') | Should-Be $true
+        $command.Parameters.ContainsKey('OtherPermission') | Should-Be $true
+        $command.Parameters.ContainsKey('Mode') | Should-Be $true
+        $command.Parameters.ContainsKey('Permission') | Should-Be $true
+        $command.Parameters.ContainsKey('Rights') | Should-Be $true
+        $command.Parameters.ContainsKey('Idempotent') | Should-Be $true
     }
 
     It 'has a Recurse switch parameter' {
         $command = Get-Command -Name 'Set-PathPermission' -ErrorAction SilentlyContinue
-        $command.Parameters['Recurse'].SwitchParameter | Should -BeTrue
+        $command.Parameters['Recurse'].SwitchParameter | Should-BeTruthy
     }
 
     It 'writes an error for missing paths and continues processing' {
@@ -94,8 +94,8 @@ Describe 'Set-PathPermission' {
             Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
         )
 
-        $errors.Count | Should -BeGreaterThan 0
-        $errors[0].FullyQualifiedErrorId | Should -Match '^PathNotFound'
+        $errors.Count | Should-BeGreaterThan 0
+        $errors[0].FullyQualifiedErrorId | Should-MatchString '^PathNotFound'
     }
 
     It 'writes an error for non-filesystem providers' {
@@ -104,14 +104,14 @@ Describe 'Set-PathPermission' {
             Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }
         )
 
-        $errors.Count | Should -BeGreaterThan 0
-        $errors[0].FullyQualifiedErrorId | Should -Match '^UnsupportedProvider'
+        $errors.Count | Should-BeGreaterThan 0
+        $errors[0].FullyQualifiedErrorId | Should-MatchString '^UnsupportedProvider'
     }
 
     It 'rejects None combined with another portable permission' {
         {
             Set-PathPermission -Path $script:RegularFile -OwnerPermission None, Read -ErrorAction Stop
-        } | Should -Throw "Permission value 'None' cannot be combined*"
+        } | Should-Throw "Permission value 'None' cannot be combined*"
     }
 
     Context 'Portable Unix permission changes' -Skip:$script:SkipUnixContext {
@@ -119,29 +119,29 @@ Describe 'Set-PathPermission' {
             Set-PathPermission -Path $script:RegularFile -OwnerPermission Read, Write -GroupPermission Read -OtherPermission None
 
             $result = Get-PathPermission -Path $script:RegularFile
-            $result.Octal | Should -Be '640'
+            $result.Octal | Should-Be '640'
         }
 
         It 'preserves unspecified role permissions' {
             Set-PathPermission -Path $script:RegularFile -OwnerPermission Read, Write, Execute
 
             $result = Get-PathPermission -Path $script:RegularFile
-            $result.Octal | Should -Be '744'
+            $result.Octal | Should-Be '744'
         }
 
         It 'supports literal paths containing wildcard characters with the portable API' {
             Set-PathPermission -LiteralPath $script:LiteralWildcardFile -OwnerPermission Read, Write -GroupPermission Read -OtherPermission None
 
             $result = Get-PathPermission -LiteralPath $script:LiteralWildcardFile
-            $result.Octal | Should -Be '640'
+            $result.Octal | Should-Be '640'
         }
 
         It 'applies the requested portable permissions recursively' {
             Set-PathPermission -Path $script:SampleDirectory -OwnerPermission Read, Write, Execute -GroupPermission None -OtherPermission None -Recurse
 
             $results = @(Get-PathPermission -Path $script:SampleDirectory -Recurse)
-            $results.Count | Should -Be 4
-            @($results.Octal | Select-Object -Unique) | Should -Be @('700')
+            $results.Count | Should-Be 4
+            @($results.Octal | Select-Object -Unique) | Should-BeCollection @('700')
         }
 
         It 'does not change permissions when -WhatIf is used with the portable API' {
@@ -150,41 +150,41 @@ Describe 'Set-PathPermission' {
             Set-PathPermission -Path $script:RegularFile -OwnerPermission Read, Write -GroupPermission Read -OtherPermission None -WhatIf
 
             $after = Get-PathPermission -Path $script:RegularFile
-            $after.Octal | Should -Be $before.Octal
+            $after.Octal | Should-Be $before.Octal
         }
 
         It 'returns summary objects with -PassThru for the portable API' {
             $result = Set-PathPermission -Path $script:RegularFile -OwnerPermission Read, Write -GroupPermission Read -OtherPermission None -PassThru
 
-            $result.Path | Should -Be ([System.IO.Path]::GetFullPath($script:RegularFile))
-            $result.Operation | Should -Be 'SetPortablePermission'
-            $result.Applied | Should -BeTrue
-            $result.Skipped | Should -BeFalse
-            $result.OwnerPermission | Should -Be 'Read, Write'
-            $result.GroupPermission | Should -Be 'Read'
-            $result.OtherPermission | Should -Be 'None'
-            $result.Mode | Should -Be '0640'
-            $result.Platform | Should -Be 'Unix'
+            $result.Path | Should-Be ([System.IO.Path]::GetFullPath($script:RegularFile))
+            $result.Operation | Should-Be 'SetPortablePermission'
+            $result.Applied | Should-BeTruthy
+            $result.Skipped | Should-BeFalsy
+            $result.OwnerPermission | Should-Be 'Read, Write'
+            $result.GroupPermission | Should-Be 'Read'
+            $result.OtherPermission | Should-Be 'None'
+            $result.Mode | Should-Be '0640'
+            $result.Platform | Should-Be 'Unix'
         }
 
         It 'skips portable updates that are already compliant when -Idempotent is used' {
             $result = Set-PathPermission -Path $script:RegularFile -OwnerPermission Read, Write -GroupPermission Read -OtherPermission Read -Idempotent -PassThru
 
-            $result.Path | Should -Be ([System.IO.Path]::GetFullPath($script:RegularFile))
-            $result.Operation | Should -Be 'SetPortablePermission'
-            $result.Applied | Should -BeFalse
-            $result.Skipped | Should -BeTrue
-            $result.Reason | Should -Be 'AlreadyCompliant'
-            $result.Mode | Should -Be '0644'
+            $result.Path | Should-Be ([System.IO.Path]::GetFullPath($script:RegularFile))
+            $result.Operation | Should-Be 'SetPortablePermission'
+            $result.Applied | Should-BeFalsy
+            $result.Skipped | Should-BeTruthy
+            $result.Reason | Should-Be 'AlreadyCompliant'
+            $result.Mode | Should-Be '0644'
 
-            (Get-PathPermission -Path $script:RegularFile).Octal | Should -Be '644'
+            (Get-PathPermission -Path $script:RegularFile).Octal | Should-Be '644'
         }
 
         It 'keeps the raw mode escape hatch available' {
             Set-PathPermission -Path $script:RegularFile -Mode 600
 
             $result = Get-PathPermission -Path $script:RegularFile
-            $result.Octal | Should -Be '600'
+            $result.Octal | Should-Be '600'
         }
 
         It 'selects a single chmod executable when multiple application matches are returned' {
@@ -206,23 +206,23 @@ Describe 'Set-PathPermission' {
             Set-PathPermission -Path $script:RegularFile -Mode 600
 
             $result = Get-PathPermission -Path $script:RegularFile
-            $result.Octal | Should -Be '600'
+            $result.Octal | Should-Be '600'
         }
 
         It 'skips raw numeric mode updates that are already compliant when -Idempotent is used' {
             $result = Set-PathPermission -Path $script:RegularFile -Mode 0644 -Idempotent -PassThru
 
-            $result.Operation | Should -Be 'SetMode'
-            $result.Applied | Should -BeFalse
-            $result.Skipped | Should -BeTrue
-            $result.Reason | Should -Be 'AlreadyCompliant'
-            $result.Mode | Should -Be '0644'
+            $result.Operation | Should-Be 'SetMode'
+            $result.Applied | Should-BeFalsy
+            $result.Skipped | Should-BeTruthy
+            $result.Reason | Should-Be 'AlreadyCompliant'
+            $result.Mode | Should-Be '0644'
         }
 
         It 'rejects symbolic raw modes when -Idempotent is used' {
             {
                 Set-PathPermission -Path $script:RegularFile -Mode 'u=rw,go=r' -Idempotent -ErrorAction Stop
-            } | Should -Throw '*numeric octal permissions*'
+            } | Should-Throw '*numeric octal permissions*'
         }
     }
 
@@ -239,7 +239,7 @@ Describe 'Set-PathPermission' {
                     ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::Read) -eq [System.Security.AccessControl.FileSystemRights]::Read -and
                     ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::Write) -eq [System.Security.AccessControl.FileSystemRights]::Write
                 }
-            ).Count | Should -BeGreaterThan 0
+            ).Count | Should-BeGreaterThan 0
 
             @(
                 $result.AccessRules | Where-Object {
@@ -247,17 +247,17 @@ Describe 'Set-PathPermission' {
                     [String]$_.AccessControlType -eq 'Allow' -and
                     ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::Read) -eq [System.Security.AccessControl.FileSystemRights]::Read
                 }
-            ).Count | Should -BeGreaterThan 0
+            ).Count | Should-BeGreaterThan 0
         }
 
         It 'returns portable summary objects with -PassThru on Windows' {
             $result = Set-PathPermission -Path $script:RegularFile -OwnerPermission Read, Write -OtherPermission Read -PassThru
 
-            $result.Path | Should -Be ([System.IO.Path]::GetFullPath($script:RegularFile))
-            $result.Operation | Should -Be 'SetPortablePermission'
-            $result.OwnerPermission | Should -Be 'Read, Write'
-            $result.OtherPermission | Should -Be 'Read'
-            $result.Platform | Should -Be 'Windows'
+            $result.Path | Should-Be ([System.IO.Path]::GetFullPath($script:RegularFile))
+            $result.Operation | Should-Be 'SetPortablePermission'
+            $result.OwnerPermission | Should-Be 'Read, Write'
+            $result.OtherPermission | Should-Be 'Read'
+            $result.Platform | Should-Be 'Windows'
         }
 
         It 'supports named permissions for a specific identity' {
@@ -265,12 +265,12 @@ Describe 'Set-PathPermission' {
 
             $result = Set-PathPermission -Path $script:RegularFile -Identity $currentUser -Permission Read -PassThru
 
-            $result.Operation | Should -Be 'SetPermission'
-            $result.Applied | Should -BeTrue
-            $result.Skipped | Should -BeFalse
-            $result.Identity | Should -Be $currentUser
-            $result.Permission | Should -Be 'Read'
-            $result.AccessType | Should -Be 'Allow'
+            $result.Operation | Should-Be 'SetPermission'
+            $result.Applied | Should-BeTruthy
+            $result.Skipped | Should-BeFalsy
+            $result.Identity | Should-Be $currentUser
+            $result.Permission | Should-Be 'Read'
+            $result.AccessType | Should-Be 'Allow'
 
             $aclResult = Get-PathPermission -Path $script:RegularFile -IncludeAcl
             @(
@@ -279,7 +279,7 @@ Describe 'Set-PathPermission' {
                     [String]$_.AccessControlType -eq 'Allow' -and
                     ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::Read) -eq [System.Security.AccessControl.FileSystemRights]::Read
                 }
-            ).Count | Should -BeGreaterThan 0
+            ).Count | Should-BeGreaterThan 0
         }
 
         It 'skips identity permission updates that are already compliant when -Idempotent is used' {
@@ -288,12 +288,12 @@ Describe 'Set-PathPermission' {
 
             $result = Set-PathPermission -Path $script:RegularFile -Identity $currentUser -Permission Read -Idempotent -PassThru
 
-            $result.Operation | Should -Be 'SetPermission'
-            $result.Applied | Should -BeFalse
-            $result.Skipped | Should -BeTrue
-            $result.Reason | Should -Be 'AlreadyCompliant'
-            $result.Identity | Should -Be $currentUser
-            $result.Permission | Should -Be 'Read'
+            $result.Operation | Should-Be 'SetPermission'
+            $result.Applied | Should-BeFalsy
+            $result.Skipped | Should-BeTruthy
+            $result.Reason | Should-Be 'AlreadyCompliant'
+            $result.Identity | Should-Be $currentUser
+            $result.Permission | Should-Be 'Read'
         }
 
         It 'keeps the raw rights escape hatch available' {
@@ -301,10 +301,10 @@ Describe 'Set-PathPermission' {
 
             $result = Set-PathPermission -Path $script:RegularFile -Identity $currentUser -Rights Delete -PassThru
 
-            $result.Operation | Should -Be 'SetAccessRule'
-            $result.Applied | Should -BeTrue
-            $result.Skipped | Should -BeFalse
-            $result.Rights | Should -Match 'Delete'
+            $result.Operation | Should-Be 'SetAccessRule'
+            $result.Applied | Should-BeTruthy
+            $result.Skipped | Should-BeFalsy
+            $result.Rights | Should-MatchString 'Delete'
 
             $aclResult = Get-PathPermission -Path $script:RegularFile -IncludeAcl
             @(
@@ -313,7 +313,7 @@ Describe 'Set-PathPermission' {
                     [String]$_.AccessControlType -eq 'Allow' -and
                     ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::Delete) -eq [System.Security.AccessControl.FileSystemRights]::Delete
                 }
-            ).Count | Should -BeGreaterThan 0
+            ).Count | Should-BeGreaterThan 0
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Set-TlsSecurityProtocol.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Set-TlsSecurityProtocol.Tests.ps1
@@ -263,7 +263,7 @@ Describe 'Set-TlsSecurityProtocol' {
             $verboseOutput = Set-TlsSecurityProtocol -Protocol 'Tls12' -Verbose 4>&1
 
             $verboseOutput | Should -Not -BeNullOrEmpty
-            $verboseOutput | Should-MatchString 'TLS|protocol|security'
+            ($verboseOutput | Out-String) | Should-MatchString 'TLS|protocol|security'
         }
     }
 

--- a/Tests/Unit/SystemAdministration/Set-TlsSecurityProtocol.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Set-TlsSecurityProtocol.Tests.ps1
@@ -45,7 +45,7 @@ Describe 'Set-TlsSecurityProtocol' {
         }
 
         It 'Should reject invalid Protocol values' {
-            { Set-TlsSecurityProtocol -Protocol 'InvalidTls' } | Should -Throw
+            { Set-TlsSecurityProtocol -Protocol 'InvalidTls' } | Should-Throw
         }
 
         It 'Should have SystemDefault as default Protocol' {
@@ -64,7 +64,7 @@ Describe 'Set-TlsSecurityProtocol' {
 
             if ([enum]::GetNames([Net.SecurityProtocolType]) -contains 'SystemDefault')
             {
-                $current | Should -Be ([Net.SecurityProtocolType]::SystemDefault)
+                $current | Should-Be ([Net.SecurityProtocolType]::SystemDefault)
             }
             else
             {
@@ -88,8 +88,8 @@ Describe 'Set-TlsSecurityProtocol' {
             Set-TlsSecurityProtocol -Protocol 'Tls12'
 
             $current = [Net.ServicePointManager]::SecurityProtocol
-            ($current -band [Net.SecurityProtocolType]::Tls12) | Should -Not -Be 0
-            ($current -band [Net.SecurityProtocolType]::Tls) | Should -Be 0
+            ($current -band [Net.SecurityProtocolType]::Tls12) | Should-NotBe 0
+            ($current -band [Net.SecurityProtocolType]::Tls) | Should-Be 0
         }
 
         It 'Should not update protocol when already secure' {
@@ -99,7 +99,7 @@ Describe 'Set-TlsSecurityProtocol' {
             Set-TlsSecurityProtocol -Protocol 'Tls12'
 
             $current = [Net.ServicePointManager]::SecurityProtocol
-            $current | Should -Be $originalProtocol
+            $current | Should-Be $originalProtocol
         }
 
         It 'Should force update when Force parameter is used' {
@@ -116,7 +116,7 @@ Describe 'Set-TlsSecurityProtocol' {
             Set-TlsSecurityProtocol -Protocol 'Tls12' -Force
 
             $current = [Net.ServicePointManager]::SecurityProtocol
-            $current | Should -Be ([Net.SecurityProtocolType]::Tls12)
+            $current | Should-Be ([Net.SecurityProtocolType]::Tls12)
         }
 
         It 'Should leave SystemDefault unchanged unless Force is specified' {
@@ -130,7 +130,7 @@ Describe 'Set-TlsSecurityProtocol' {
 
             Set-TlsSecurityProtocol -Protocol 'Tls12'
 
-            [Net.ServicePointManager]::SecurityProtocol | Should -Be ([Net.SecurityProtocolType]::SystemDefault)
+            [Net.ServicePointManager]::SecurityProtocol | Should-Be ([Net.SecurityProtocolType]::SystemDefault)
         }
 
         It 'Should pin an explicit protocol from SystemDefault when Force is used' {
@@ -144,7 +144,7 @@ Describe 'Set-TlsSecurityProtocol' {
 
             Set-TlsSecurityProtocol -Protocol 'Tls12' -Force
 
-            [Net.ServicePointManager]::SecurityProtocol | Should -Be ([Net.SecurityProtocolType]::Tls12)
+            [Net.ServicePointManager]::SecurityProtocol | Should-Be ([Net.SecurityProtocolType]::Tls12)
         }
     }
 
@@ -152,8 +152,8 @@ Describe 'Set-TlsSecurityProtocol' {
         It 'Should return SecurityProtocol when PassThru is specified' {
             $result = Set-TlsSecurityProtocol -Protocol 'Tls12' -PassThru
 
-            $result | Should -BeOfType [System.Net.SecurityProtocolType]
-            $result | Should -Be ([Net.ServicePointManager]::SecurityProtocol)
+            $result | Should-HaveType ([System.Net.SecurityProtocolType])
+            $result | Should-Be ([Net.ServicePointManager]::SecurityProtocol)
         }
 
         It 'Should not return anything when PassThru is not specified' {
@@ -191,7 +191,7 @@ Describe 'Set-TlsSecurityProtocol' {
             $hasTls12 = ($current -band [Net.SecurityProtocolType]::Tls12) -ne 0
             $hasTls13 = try { ($current -band [Net.SecurityProtocolType]::Tls13) -ne 0 } catch { $false }
 
-            ($hasTls12 -or $hasTls13) | Should -Be $true
+            ($hasTls12 -or $hasTls13) | Should-Be $true
         }
     }
 
@@ -219,12 +219,12 @@ Describe 'Set-TlsSecurityProtocol' {
             Set-TlsSecurityProtocol -Protocol 'Tls12'
 
             $current = [Net.ServicePointManager]::SecurityProtocol
-            ($current -band [Net.SecurityProtocolType]::Tls12) | Should -Not -Be 0
-            ($current -band [Net.SecurityProtocolType]::Tls11) | Should -Be 0
+            ($current -band [Net.SecurityProtocolType]::Tls12) | Should-NotBe 0
+            ($current -band [Net.SecurityProtocolType]::Tls11) | Should-Be 0
 
             if ($hadTls13)
             {
-                ($current -band [Net.SecurityProtocolType]::Tls13) | Should -Not -Be 0
+                ($current -band [Net.SecurityProtocolType]::Tls13) | Should-NotBe 0
             }
         }
     }
@@ -232,9 +232,9 @@ Describe 'Set-TlsSecurityProtocol' {
     Context 'Error Handling' {
         It 'Should handle ServicePointManager access errors gracefully' {
             $functionContent = Get-Content "$PSScriptRoot/../../../Functions/SystemAdministration/Set-TlsSecurityProtocol.ps1" -Raw
-            $functionContent | Should -Match 'try\s*\{'
-            $functionContent | Should -Match 'catch\s*\{'
-            $functionContent | Should -Match 'ThrowTerminatingError|throw'
+            $functionContent | Should-MatchString 'try\s*\{'
+            $functionContent | Should-MatchString 'catch\s*\{'
+            $functionContent | Should-MatchString 'ThrowTerminatingError|throw'
         }
     }
 
@@ -254,7 +254,7 @@ Describe 'Set-TlsSecurityProtocol' {
 
             Set-TlsSecurityProtocol -Protocol 'Tls12' -WhatIf
 
-            [Net.ServicePointManager]::SecurityProtocol | Should -Be $originalProtocol
+            [Net.ServicePointManager]::SecurityProtocol | Should-Be $originalProtocol
         }
     }
 
@@ -263,7 +263,7 @@ Describe 'Set-TlsSecurityProtocol' {
             $verboseOutput = Set-TlsSecurityProtocol -Protocol 'Tls12' -Verbose 4>&1
 
             $verboseOutput | Should -Not -BeNullOrEmpty
-            $verboseOutput | Should -Match 'TLS|protocol|security'
+            $verboseOutput | Should-MatchString 'TLS|protocol|security'
         }
     }
 
@@ -287,7 +287,7 @@ Describe 'Set-TlsSecurityProtocol' {
                 $hasTls12 = ($current -band [Net.SecurityProtocolType]::Tls12) -ne 0
                 $hasTls13 = try { ($current -band [Net.SecurityProtocolType]::Tls13) -ne 0 } catch { $false }
 
-                ($hasTls12 -or $hasTls13) | Should -Be $true
+                ($hasTls12 -or $hasTls13) | Should-Be $true
             }
             else
             {
@@ -296,7 +296,7 @@ Describe 'Set-TlsSecurityProtocol' {
                 $hasTls12 = ($current -band [Net.SecurityProtocolType]::Tls12) -ne 0
                 $hasTls13 = try { ($current -band [Net.SecurityProtocolType]::Tls13) -ne 0 } catch { $false }
 
-                ($hasTls12 -or $hasTls13) | Should -Be $true
+                ($hasTls12 -or $hasTls13) | Should-Be $true
             }
         }
     }

--- a/Tests/Unit/SystemAdministration/Show-InstalledPlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-InstalledPlatformPackage.Tests.ps1
@@ -28,9 +28,9 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
-            ($result | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should -Be '2.44.0'
-            ($result | Where-Object { $_.Name -eq 'git' }).Publisher | Should -Be 'Homebrew'
+            $result.Count | Should-Be 2
+            ($result | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should-Be '2.44.0'
+            ($result | Where-Object { $_.Name -eq 'git' }).Publisher | Should-Be 'Homebrew'
         }
 
         It 'keeps AsObject as an alias for NonInteractive output' {
@@ -41,10 +41,10 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -AsObject -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            $result[0].PackageManager | Should -Be 'brew'
-            Should -Invoke -CommandName Write-Host -Times 0 -Exactly
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            $result[0].PackageManager | Should-Be 'brew'
+            Should-Invoke -CommandName Write-Host -Times 0 -Exactly
         }
 
         It 'exports installed packages to inferred JSON without opening the picker' {
@@ -56,15 +56,15 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportPath = Join-Path -Path $TestDrive -ChildPath 'installed-packages.json'
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -ExportPath $exportPath)
 
-            $result.Count | Should -Be 1
-            $result[0].Format | Should -Be 'JSON'
-            $result[0].Count | Should -Be 2
-            $result[0].DependencyMode | Should -Be 'None'
-            Test-Path -LiteralPath $exportPath | Should -BeTrue
+            $result.Count | Should-Be 1
+            $result[0].Format | Should-Be 'JSON'
+            $result[0].Count | Should-Be 2
+            $result[0].DependencyMode | Should-Be 'None'
+            Test-Path -LiteralPath $exportPath | Should-BeTruthy
             $exportedPackages = Get-Content -LiteralPath $exportPath -Raw | ConvertFrom-Json
-            $exportedPackages.Count | Should -Be 2
-            ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should -Be '2.44.0'
-            Should -Invoke -CommandName Write-Host -Times 0 -Exactly
+            $exportedPackages.Count | Should-Be 2
+            ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should-Be '2.44.0'
+            Should-Invoke -CommandName Write-Host -Times 0 -Exactly
         }
 
         It 'exports installed packages to explicit CSV with dependency relationships' {
@@ -106,16 +106,16 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportPath = Join-Path -Path $TestDrive -ChildPath 'installed-packages-export'
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -ExportPath $exportPath -ExportFormat Csv -ExportDependencyMode Both)
 
-            $result.Count | Should -Be 1
-            $result[0].Format | Should -Be 'CSV'
-            $result[0].DependencyMode | Should -Be 'Both'
+            $result.Count | Should-Be 1
+            $result[0].Format | Should-Be 'CSV'
+            $result[0].DependencyMode | Should-Be 'Both'
             $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
-            $exportedPackages.Count | Should -Be 1
-            $exportedPackages[0].DependsOn | Should -Be 'openssl'
-            $exportedPackages[0].RequiredBy | Should -Be 'git-extras'
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Should -Invoke -CommandName Write-Host -Times 0 -Exactly
+            $exportedPackages.Count | Should-Be 1
+            $exportedPackages[0].DependsOn | Should-Be 'openssl'
+            $exportedPackages[0].RequiredBy | Should-Be 'git-extras'
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should-Invoke -CommandName Write-Host -Times 0 -Exactly
         }
 
         It 'shows dependency resolution progress when export progress is requested' {
@@ -145,11 +145,11 @@ Describe 'Show-InstalledPlatformPackage' {
             $exportPath = Join-Path -Path $TestDrive -ChildPath 'installed-packages-progress.csv'
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -ExportPath $exportPath -ExportFormat Csv -ExportDependencyMode Both -ShowExportProgress)
 
-            $result.Count | Should -Be 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Exporting installed packages...' -and $ForegroundColor -eq 'Cyan' } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Package: 1 of 1 - git' -and $ForegroundColor -eq 'White' } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: DependsOn' -and $ForegroundColor -eq 'White' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: RequiredBy' -and $ForegroundColor -eq 'White' } -Times 1
+            $result.Count | Should-Be 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Exporting installed packages...' -and $ForegroundColor -eq 'Cyan' } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Package: 1 of 1 - git' -and $ForegroundColor -eq 'White' } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: DependsOn' -and $ForegroundColor -eq 'White' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving: RequiredBy' -and $ForegroundColor -eq 'White' } -Times 1
         }
     }
 
@@ -166,11 +166,11 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  filter: all" -and $ForegroundColor -eq 'White' } -Times 1
-            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 2
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  filter: all" -and $ForegroundColor -eq 'White' } -Times 1
+            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should-Be 2
         }
 
         It 'does not exit when Enter is pressed in browse mode' {
@@ -190,8 +190,8 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
         }
 
         It 'ignores Backspace and Delete as manager navigation when not launched by the manager' {
@@ -212,9 +212,9 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 3
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0 -Exactly
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 3
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 0 -Exactly
         }
 
         It 'returns to the manager menu on <Name> when manager navigation is enabled' -TestCases @(
@@ -234,9 +234,9 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
         }
 
         It 'renders only the current viewport for long package lists' {
@@ -256,10 +256,10 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $null = Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PickerPageSize 2
 
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
         }
 
         It 'returns selected packages when PassThru is used' {
@@ -279,9 +279,9 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PassThru)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
         }
 
         It 'returns the current package when PassThru is used without a selection' {
@@ -296,10 +296,10 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PassThru)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: S: [All]  Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: Space select  Enter return  D deps  V details  E export  R remove  U upgrade  A toggle all  F: [all]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Nav: S: [All]  Home/End/PgUp/PgDn  ?: help  Q/Esc/Ctrl+C exit' } -Times 1
         }
 
         It 'shows keyboard help from the picker when question mark is pressed' {
@@ -320,16 +320,16 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Help' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'D: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'open or close the dependency view for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the package list from the dependency view' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'V: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'load a missing winget description when available' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'export visible packages, or selected packages when any are selected, to JSON or CSV' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Help' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'D: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'open or close the dependency view for the current package' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the package list from the dependency view' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'V: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'load a missing winget description when available' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'export visible packages, or selected packages when any are selected, to JSON or CSV' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'loads missing winget descriptions only when V is pressed' {
@@ -369,11 +369,11 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'winget show --id Git.Git --exact --accept-source-agreements --output json' }).Count | Should -Be 1
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: <press V to load>' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: retrieving description...' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'winget show --id Git.Git --exact --accept-source-agreements --output json' }).Count | Should-Be 1
         }
 
         It 'defaults source filter to winget for the winget picker when multiple sources exist' {
@@ -408,8 +408,8 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[winget\]' } -Times 1
         }
 
         It 'keeps picker table rows within the current console width' {
@@ -447,12 +447,12 @@ Describe 'Show-InstalledPlatformPackage' {
                 }
             )
 
-            $tableLines.Count | Should -BeGreaterThan 1
-            ($tableLines | Where-Object { $_ -match '^\s+Name\s+' } | Select-Object -First 1) | Should -Match '\bVer\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Name\s+' } | Select-Object -First 1) | Should -Match '\bTyp\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Name\s+' } | Select-Object -First 1) | Should -Match '\bSrc\b'
-            ($tableLines | Where-Object { $_ -match '^>\s+' } | Select-Object -First 1) | Should -Match 'homebrew/core'
-            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should -BeLessOrEqual (Get-TestPickerLineLimit)
+            $tableLines.Count | Should-BeGreaterThan 1
+            ($tableLines | Where-Object { $_ -match '^\s+Name\s+' } | Select-Object -First 1) | Should-MatchString '\bVer\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Name\s+' } | Select-Object -First 1) | Should-MatchString '\bTyp\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Name\s+' } | Select-Object -First 1) | Should-MatchString '\bSrc\b'
+            ($tableLines | Where-Object { $_ -match '^>\s+' } | Select-Object -First 1) | Should-MatchString 'homebrew/core'
+            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should-BeLessThanOrEqual (Get-TestPickerLineLimit)
         }
 
         It 'shows both dependency directions from the picker with D' {
@@ -488,15 +488,15 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 1
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Resolving dependencies...' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn + RequiredBy]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [DependsOn]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Dependencies [RequiredBy]' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 1
         }
 
         It 'returns from dependency view to the package list on <Name> when manager navigation is enabled' -TestCases @(
@@ -533,10 +533,10 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 2
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Keys: D deps  V details  E export  R remove  U upgrade  F: [all]' } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage Dependencies - Homebrew' } -Times 2
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Press B/Backspace/Delete/LeftArrow to return to the package list.' } -Times 2
         }
 
         It 'invokes Remove-PlatformPackage from the picker when R is confirmed' {
@@ -565,14 +565,14 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Remove-PlatformPackage -ParameterFilter {
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Remove-PlatformPackage -ParameterFilter {
                 $PackageManager -eq 'brew' -and
                 $All -and
                 @($IncludePackage).Count -eq 1 -and
                 @($IncludePackage)[0] -eq 'git'
             } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Removed: 1, Failed: 0, Skipped: 0' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Removed: 1, Failed: 0, Skipped: 0' } -Times 1
         }
 
         It 'shows winget remediation text after a browser-launched remove failure' {
@@ -610,11 +610,11 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey -WarningAction SilentlyContinue)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
             $visibleOutput = ($script:HostOutput | ForEach-Object { "$_" }) -join "`n"
-            $visibleOutput | Should -Match 'Status: Removed: 0, Failed: 1, Skipped: 0'
-            $visibleOutput | Should -Match 'winget uninstall --id JohnMacFarlane\.Pandoc --exact --source winget --accept-source-agreements'
-            $visibleOutput | Should -Match 'Remediation: close running Pandoc processes and retry the uninstall'
+            $visibleOutput | Should-MatchString 'Status: Removed: 0, Failed: 1, Skipped: 0'
+            $visibleOutput | Should-MatchString 'winget uninstall --id JohnMacFarlane\.Pandoc --exact --source winget --accept-source-agreements'
+            $visibleOutput | Should-MatchString 'Remediation: close running Pandoc processes and retry the uninstall'
         }
 
         It 'invokes Upgrade-PlatformPackage from the picker when U is confirmed' {
@@ -643,15 +643,15 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Should -Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
+            $result.Count | Should-Be 0
+            Should-Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
                 $PackageManager -eq 'brew' -and
                 $All -and
                 $SkipRefresh -and
                 @($IncludePackage).Count -eq 1 -and
                 @($IncludePackage)[0] -eq 'git'
             } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Upgraded: 1, Failed: 0, Skipped: 0' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Status: Upgraded: 1, Failed: 0, Skipped: 0' } -Times 1
         }
 
         It 'shows winget remediation text after a browser-launched upgrade failure' {
@@ -704,13 +704,13 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager winget -CommandRunner $runner -KeyReader $keyReader -ReturnToPlatformPackageManagerOnBackKey -WarningAction SilentlyContinue)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
             $visibleOutput = ($script:HostOutput | ForEach-Object { "$_" }) -join "`n"
-            $visibleOutput | Should -Match 'Status: Upgraded: 0, Failed: 1, Skipped: 0'
-            $visibleOutput | Should -Match 'APPINSTALLER_CLI_ERROR_EXEC_UNINSTALL_COMMAND_FAILED'
-            $visibleOutput | Should -Match 'Running uninstall command failed'
-            $visibleOutput | Should -Match 'winget uninstall --id JohnMacFarlane\.Pandoc --exact --source winget'
-            $visibleOutput | Should -Match 'winget install --id JohnMacFarlane\.Pandoc --exact --source winget'
+            $visibleOutput | Should-MatchString 'Status: Upgraded: 0, Failed: 1, Skipped: 0'
+            $visibleOutput | Should-MatchString 'APPINSTALLER_CLI_ERROR_EXEC_UNINSTALL_COMMAND_FAILED'
+            $visibleOutput | Should-MatchString 'Running uninstall command failed'
+            $visibleOutput | Should-MatchString 'winget uninstall --id JohnMacFarlane\.Pandoc --exact --source winget'
+            $visibleOutput | Should-MatchString 'winget install --id JohnMacFarlane\.Pandoc --exact --source winget'
         }
 
         It 'exports visible packages to JSON from the picker when E is used' {
@@ -735,13 +735,13 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
-            Test-Path -LiteralPath $exportPath | Should -BeTrue
+            $result.Count | Should-Be 0
+            Test-Path -LiteralPath $exportPath | Should-BeTruthy
             $exportedPackages = Get-Content -LiteralPath $exportPath -Raw | ConvertFrom-Json
-            $exportedPackages.Count | Should -Be 2
-            ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should -Be '2.44.0'
-            ($exportedPackages | Where-Object { $_.Name -eq 'curl' }).PackageManager | Should -Be 'brew'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 2 package(s) to *installed-packages.json (JSON)' } -Times 1
+            $exportedPackages.Count | Should-Be 2
+            ($exportedPackages | Where-Object { $_.Name -eq 'git' }).InstalledVersion | Should-Be '2.44.0'
+            ($exportedPackages | Where-Object { $_.Name -eq 'curl' }).PackageManager | Should-Be 'brew'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 2 package(s) to *installed-packages.json (JSON)' } -Times 1
         }
 
         It 'exports selected packages to CSV with dependencies from the picker' {
@@ -797,16 +797,16 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PassThru)
 
-            $result.Count | Should -Be 0
-            Test-Path -LiteralPath $exportPath | Should -BeTrue
+            $result.Count | Should-Be 0
+            Test-Path -LiteralPath $exportPath | Should-BeTruthy
             $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
-            $exportedPackages.Count | Should -Be 1
-            $exportedPackages[0].Name | Should -Be 'curl'
-            $exportedPackages[0].DependsOn | Should -Be 'openssl'
-            $exportedPackages[0].RequiredBy | Should -Be 'git-extras'
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 1 package(s) with dependencies and required-by relationships to *selected-packages.csv (CSV)' } -Times 1
+            $exportedPackages.Count | Should-Be 1
+            $exportedPackages[0].Name | Should-Be 'curl'
+            $exportedPackages[0].DependsOn | Should-Be 'openssl'
+            $exportedPackages[0].RequiredBy | Should-Be 'git-extras'
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Status: Exported 1 package(s) with dependencies and required-by relationships to *selected-packages.csv (CSV)' } -Times 1
         }
 
         It 'exports direct dependencies without resolving required-by relationships' {
@@ -849,12 +849,12 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
             $exportedPackages = @(Import-Csv -LiteralPath $exportPath)
-            $exportedPackages[0].DependsOn | Should -Be 'openssl'
-            $exportedPackages[0].RequiredBy | Should -Be ''
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
-            Should -Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0 -Exactly
+            $exportedPackages[0].DependsOn | Should-Be 'openssl'
+            $exportedPackages[0].RequiredBy | Should-Be ''
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'DependsOn' } -Times 1
+            Should-Invoke -CommandName Get-PlatformPackageDependency -ParameterFilter { $Direction -eq 'RequiredBy' } -Times 0 -Exactly
         }
 
         It 'filters picker results by package name when F is pressed' {
@@ -876,10 +876,10 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PassThru)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
         }
 
         It 'treats lowercase q as filter text instead of cancel' {
@@ -901,10 +901,10 @@ Describe 'Show-InstalledPlatformPackage' {
 
             $result = @(Show-InstalledPlatformPackage -PackageManager brew -CommandRunner $runner -KeyReader $keyReader -PassThru)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'jq'
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'jq'
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-PlatformPackageManager.Tests.ps1
@@ -24,13 +24,13 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Manager: Auto -> *' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Installed packages*' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Export installed*' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0 -Exactly
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Dependencies*' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Manager: Auto -> *' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Installed packages*' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Export installed*' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0 -Exactly
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Dependencies*' } -Times 1
     }
 
     It 'selects the upgrade workflow by default' {
@@ -45,34 +45,34 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Upgrade-PlatformPackage -Times 1
-        Should -Invoke -CommandName Install-PlatformPackage -Times 0 -Exactly
-        Should -Invoke -CommandName Show-InstalledPlatformPackage -Times 0 -Exactly
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Upgrade-PlatformPackage -Times 1
+        Should-Invoke -CommandName Install-PlatformPackage -Times 0 -Exactly
+        Should-Invoke -CommandName Show-InstalledPlatformPackage -Times 0 -Exactly
     }
 
     It 'exposes ShouldProcess safety switches for delegated operations' {
         $command = Get-Command -Name Show-PlatformPackageManager
 
-        $command.Parameters.Keys | Should -Contain 'WhatIf'
-        $command.Parameters.Keys | Should -Contain 'Confirm'
+        $command.Parameters.Keys | Should-ContainCollection 'WhatIf'
+        $command.Parameters.Keys | Should-ContainCollection 'Confirm'
     }
 
     It 'rejects winget-only manager options for other package managers' {
         $promptReader = & $script:NewPromptReader @('q')
 
         { Show-PlatformPackageManager -PackageManager brew -Interactive -PromptReader $promptReader } |
-            Should -Throw -ExpectedMessage "*Parameter -Interactive*package manager 'brew'*only supported by winget*"
+            Should-Throw -ExceptionMessage "*Parameter -Interactive*package manager 'brew'*only supported by winget*"
 
         { Show-PlatformPackageManager -PackageManager apt -UninstallPrevious -PromptReader $promptReader } |
-            Should -Throw -ExpectedMessage "*Parameter -UninstallPrevious*package manager 'apt'*only supported by winget*"
+            Should-Throw -ExceptionMessage "*Parameter -UninstallPrevious*package manager 'apt'*only supported by winget*"
     }
 
     It 'rejects NoSudo for managers that do not use sudo' {
         $promptReader = & $script:NewPromptReader @('q')
 
         { Show-PlatformPackageManager -PackageManager winget -NoSudo -PromptReader $promptReader } |
-            Should -Throw -ExpectedMessage "*Parameter -NoSudo*package manager 'winget'*only supported by apt and apk*"
+            Should-Throw -ExceptionMessage "*Parameter -NoSudo*package manager 'winget'*only supported by apt and apk*"
     }
 
     It 'routes installed package browsing through Show-InstalledPlatformPackage without extra prompts' {
@@ -108,16 +108,16 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Show-InstalledPlatformPackage -ParameterFilter {
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Show-InstalledPlatformPackage -ParameterFilter {
             $PackageManager -eq 'brew' -and
             $null -ne $CommandRunner -and
             $null -ne $KeyReader -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*git*' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*gh*' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*git*' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*gh*' } -Times 1
     }
 
     It 'returns from the installed package browser to the manager menu on Backspace' {
@@ -134,11 +134,11 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage - Homebrew' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 0 -Exactly
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Show-InstalledPlatformPackage - Homebrew' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Installed Packages' } -Times 0 -Exactly
     }
 
     It 'does not expose numbers outside 1-6 as valid actions' {
@@ -146,9 +146,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0 -Exactly
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Choose 1-6 or Q.' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Direct install*' } -Times 0 -Exactly
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Choose 1-6 or Q.' } -Times 1
     }
 
     It 'supports arrow key navigation in the manager menu' {
@@ -174,8 +174,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $Query -eq 'git' -and
             $PackageManager -eq 'apt' -and
             $NoSudo -and
@@ -193,12 +193,12 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'browse installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'export installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'B: ' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'browse installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'E: ' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'export installed packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
     }
 
     It 'routes installed package export through Show-InstalledPlatformPackage from the manager shortcut' {
@@ -222,8 +222,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner { } -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Show-InstalledPlatformPackage -ParameterFilter {
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Show-InstalledPlatformPackage -ParameterFilter {
             $PackageManager -eq 'brew' -and
             $ExportPath -eq $exportPath -and
             $ExportFormat -eq 'Json' -and
@@ -232,8 +232,8 @@ Describe 'Show-PlatformPackageManager' {
             $null -ne $ExportCancelRequested -and
             $NonInteractive
         } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Export Installed Packages' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Export completed.' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Export Installed Packages' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Export completed.' } -Times 1
     }
 
     It 'shows keyboard help from a manager result screen' {
@@ -260,10 +260,10 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Any key or Enter: ' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the manager menu' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager Help' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Any key or Enter: ' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'return to the manager menu' -and $ForegroundColor -eq 'DarkGray' } -Times 1
     }
 
     It 'routes search installs through Install-PlatformPackage with NoSudo forwarded' {
@@ -284,8 +284,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $Query -eq 'git' -and
             $PackageManager -eq 'apt' -and
             $NoSudo -and
@@ -325,19 +325,19 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -FilterSource msstore -SkipRefresh -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $Query -eq 'git' -and
             $PackageManager -eq 'winget' -and
             $FilterSource -eq 'msstore' -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Should -Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
+        Should-Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'winget' -and
             $FilterSource -eq 'msstore' -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*FilterSource=msstore*' } -Times 3
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*FilterSource=msstore*' } -Times 3
     }
 
     It 'forwards interactive mode to winget install and upgrade workflows' {
@@ -347,14 +347,14 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -Interactive -SkipRefresh -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Install-PlatformPackage -ParameterFilter {
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Install-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'winget' -and $Interactive
         } -Times 1
-        Should -Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
+        Should-Invoke -CommandName Upgrade-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'winget' -and $Interactive
         } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Interactive*' } -Times 3
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Interactive*' } -Times 3
     }
 
     It 'routes upgrade options and forwards winget uninstall-previous' {
@@ -377,10 +377,10 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -SkipRefresh -UninstallPrevious -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --uninstall-previous' }).StreamOutput | Should -BeTrue
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget upgrade output' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded' } -Times 1
+        $result.Count | Should-Be 0
+        ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --uninstall-previous' }).StreamOutput | Should-BeTruthy
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'winget upgrade output' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded' } -Times 1
     }
 
     It 'routes remove options and forwards purge behavior' {
@@ -404,10 +404,10 @@ Describe 'Show-PlatformPackageManager' {
             }
         )
 
-        $result.Count | Should -Be 0
-        ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall --cask --zap visual-studio-code' }).StreamOutput | Should -BeTrue
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Removed' } -Times 1
+        $result.Count | Should-Be 0
+        ($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall --cask --zap visual-studio-code' }).StreamOutput | Should-BeTruthy
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew zap output' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Removed' } -Times 1
     }
 
     It 'returns from the removal picker to the manager menu on Delete' {
@@ -429,11 +429,11 @@ Describe 'Show-PlatformPackageManager' {
             }
         )
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage - Homebrew' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
-        @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should -Be 0
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 2
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Remove-PlatformPackage - Homebrew' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Backspace/Delete: manager menu' } -Times 1
+        @($script:Invocations | Where-Object { $_.Key -eq 'brew uninstall git' }).Count | Should-Be 0
     }
 
     It 'shows a green status indicator after a successful upgrade' {
@@ -456,9 +456,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -SkipRefresh -CommandRunner $runner -PromptReader $promptReader -KeyReader $keyReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded: 1' -and $ForegroundColor -eq 'Green' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 0' -and $ForegroundColor -eq 'Green' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Upgraded: 1' -and $ForegroundColor -eq 'Green' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 0' -and $ForegroundColor -eq 'Green' } -Times 1
     }
 
     It 'shows a green status indicator after a successful install' {
@@ -479,8 +479,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Green' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Green' } -Times 1
     }
 
     It 'shows captured informational output on the manager result screen' {
@@ -512,10 +512,10 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Additional output' -and $ForegroundColor -eq 'Cyan' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'python' -and $ForegroundColor -eq 'White' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq '  ==> Caveats' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Additional output' -and $ForegroundColor -eq 'Cyan' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'python' -and $ForegroundColor -eq 'White' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq '  ==> Caveats' -and $ForegroundColor -eq 'DarkGray' } -Times 1
     }
 
     It 'keeps detail rows within the separator width while retaining the full additional output' {
@@ -560,7 +560,7 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -SkipRefresh -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
+        $result.Count | Should-Be 0
         $detailSeparator = @($script:RenderedOutput | Where-Object { "$_" -match '^-{40,}$' })[0]
         $detailTable = @($script:RenderedOutput | Where-Object { "$_" -match 'InstalledVersion' })[0]
         $detailSeparator | Should -Not -BeNullOrEmpty
@@ -568,9 +568,9 @@ Describe 'Show-PlatformPackageManager' {
         @(
             "$detailTable" -split "`r?`n" |
             Where-Object { -not [String]::IsNullOrWhiteSpace($_) -and $_.Length -gt $detailSeparator.Length }
-        ) | Should -HaveCount 0
-        $detailTable | Should -Not -Match ([Regex]::Escape($script:FullFailureMessage))
-        Should -Invoke -CommandName Write-Host -ParameterFilter {
+        ) | Should-BeCollection -Count 0
+        $detailTable | Should-NotMatchString ([Regex]::Escape($script:FullFailureMessage))
+        Should-Invoke -CommandName Write-Host -ParameterFilter {
             $Object -eq "  $script:FullFailureMessage" -and $ForegroundColor -eq 'DarkGray'
         } -Times 1
     }
@@ -593,9 +593,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Failed: 1' -and $ForegroundColor -eq 'Red' } -Times 1
     }
 
     It 'shows a yellow status indicator when packages were skipped but none failed' {
@@ -616,9 +616,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager apt -NoSudo -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 2' -and $ForegroundColor -eq 'Yellow' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Skipped: 1' -and $ForegroundColor -eq 'Yellow' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed: 2' -and $ForegroundColor -eq 'Yellow' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Skipped: 1' -and $ForegroundColor -eq 'Yellow' } -Times 1
     }
 
     It 'does not show a status indicator for dependency lookups' {
@@ -629,8 +629,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed:|Upgraded:|Removed:' } -Times 0 -Exactly
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'Installed:|Upgraded:|Removed:' } -Times 0 -Exactly
     }
 
     It 'returns directly to the menu without a result screen when a search query is cancelled' {
@@ -638,8 +638,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager apt -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0 -Exactly
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0 -Exactly
     }
 
     It 'returns directly to the menu without a result screen when no packages are selected in the picker' {
@@ -660,9 +660,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager apt -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Install-PlatformPackage -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0 -Exactly
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Install-PlatformPackage -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Search and Install Packages' } -Times 0 -Exactly
     }
 
     It 'shows a notification in the menu when search returns no matches' {
@@ -683,9 +683,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Install-PlatformPackage -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Install-PlatformPackage -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
     }
 
     It 'shows a notification in the menu when winget search returns no registry matches' {
@@ -697,8 +697,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -CommandRunner $runner -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages matched the requested search query*' } -Times 1
     }
 
     It 'shows a notification in the menu when no packages are available for upgrade' {
@@ -719,9 +719,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -SkipRefresh -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Upgrade-PlatformPackage -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages are currently available for upgrade*' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Upgrade-PlatformPackage -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages are currently available for upgrade*' } -Times 1
     }
 
     It 'shows a notification in the menu when no installed packages matched for removal' {
@@ -747,12 +747,12 @@ Describe 'Show-PlatformPackageManager' {
             }
         )
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Remove-PlatformPackage -ParameterFilter {
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Remove-PlatformPackage -ParameterFilter {
             $PackageManager -eq 'brew' -and
             $ReturnToPlatformPackageManagerOnBackKey
         } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No installed packages matched the requested filters*' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No installed packages matched the requested filters*' } -Times 1
     }
 
     It 'does not show a notification when no packages are selected in the picker but packages are available' {
@@ -773,8 +773,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -SkipRefresh -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages*' } -Times 0 -Exactly
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*No packages*' } -Times 0 -Exactly
     }
 
     It 'shows dependency records from the manager' {
@@ -785,9 +785,9 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Relationship*' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*Relationship*' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*git -> gettext*' } -Times 1
     }
 
     It 'explains that winget reverse dependency lookup is unavailable' {
@@ -795,8 +795,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*winget does not expose reverse dependency metadata*' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*winget does not expose reverse dependency metadata*' } -Times 1
     }
 
     It 'rejects partial Both dependency lookup for winget' {
@@ -804,8 +804,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager winget -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*Direction 'Both' is not supported by winget*Choose DependsOn*" } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like "*Direction 'Both' is not supported by winget*Choose DependsOn*" } -Times 1
     }
 
     It 'keeps action results on a dedicated screen until the next action is chosen' {
@@ -816,8 +816,8 @@ Describe 'Show-PlatformPackageManager' {
 
         $result = @(Show-PlatformPackageManager -PackageManager brew -CommandRunner $runner -PromptReader $promptReader)
 
-        $result.Count | Should -Be 0
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
-        Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Package Dependencies' } -Times 1
+        $result.Count | Should-Be 0
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Platform Package Manager' } -Times 1
+        Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Package Dependencies' } -Times 1
     }
 }

--- a/Tests/Unit/SystemAdministration/Show-SystemResourceMonitor.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Show-SystemResourceMonitor.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     # Suppress progress bars to prevent freezing in non-interactive environments
     $Global:ProgressPreference = 'SilentlyContinue'
 
@@ -11,35 +11,35 @@ Describe 'Show-SystemResourceMonitor' {
     It 'is available as a function' {
         $command = Get-Command -Name 'Show-SystemResourceMonitor' -ErrorAction SilentlyContinue
         $command | Should -Not -BeNullOrEmpty
-        $command.CommandType | Should -Be 'Function'
+        $command.CommandType | Should-Be 'Function'
     }
 
     It 'returns a non-empty dashboard string in one-shot mode' {
         $result = Show-SystemResourceMonitor -NoContinuous -NoColor -BarWidth 16 -HistoryLength 8
 
-        $result | Should -BeOfType 'System.String'
-        $result.Length | Should -BeGreaterThan 0
-        $result | Should -Match 'System Resource Monitor'
-        $result | Should -Match '(?m)^CPU'
-        $result | Should -Match '(?m)^Memory'
-        $result | Should -Match '(?m)^Disk'
-        $result | Should -Match '(?m)^Network'
+        $result | Should-HaveType ([System.String])
+        $result.Length | Should-BeGreaterThan 0
+        $result | Should-MatchString 'System Resource Monitor'
+        $result | Should-MatchString '(?m)^CPU'
+        $result | Should-MatchString '(?m)^Memory'
+        $result | Should-MatchString '(?m)^Disk'
+        $result | Should-MatchString '(?m)^Network'
     }
 
     It 'includes CPU core busy readout in one-shot output' {
         $result = Show-SystemResourceMonitor -NoContinuous -NoColor -BarWidth 16 -HistoryLength 8
 
-        $result | Should -Match '(?m)^CPU.+\S+/\S+ logical cores busy\r?$'
+        $result | Should-MatchString '(?m)^CPU.+\S+/\S+ logical cores busy\r?$'
     }
 
     It 'includes overall summary in title and status metadata in one-shot output' {
         $result = Show-SystemResourceMonitor -NoContinuous -NoColor -BarWidth 16 -HistoryLength 8
 
-        $result | Should -Match '(?m)^System Resource Monitor.+\[[ABCDF]\]'
-        $result | Should -Match '(?m)^Status +\[Platform\].+\[Updated\].+\[Collect\]'
-        $result | Should -Match '(?m)^History +\[Window\] +\d+ samples .+ \[Order\] +oldest (?:→|->) newest\r?$'
-        $result | Should -Match '(?m)^ +[│|] +\[Trend\] +(?:↗ up \| → steady \| ↘ down|\^ up \| = steady \| v down)\r?$'
-        $result | Should -Not -Match '(?m)^Health +Overall:'
+        $result | Should-MatchString '(?m)^System Resource Monitor.+\[[ABCDF]\]'
+        $result | Should-MatchString '(?m)^Status +\[Platform\].+\[Updated\].+\[Collect\]'
+        $result | Should-MatchString '(?m)^History +\[Window\] +\d+ samples .+ \[Order\] +oldest (?:→|->) newest\r?$'
+        $result | Should-MatchString '(?m)^ +[│|] +\[Trend\] +(?:↗ up \| → steady \| ↘ down|\^ up \| = steady \| v down)\r?$'
+        $result | Should-NotMatchString '(?m)^Health +Overall:'
 
         $lines = @($result -split '\r?\n')
         $statusLine = @($lines | Where-Object { $_ -match '^Status +\[Platform\].+\[Updated\].+\[Collect\]' }) | Select-Object -First 1
@@ -58,35 +58,35 @@ Describe 'Show-SystemResourceMonitor' {
         $statusLine | Should -Not -BeNullOrEmpty
         $historyLine | Should -Not -BeNullOrEmpty
         $historyTrendLine | Should -Not -BeNullOrEmpty
-        $dividerIndices.Count | Should -BeGreaterOrEqual 2
+        $dividerIndices.Count | Should-BeGreaterThanOrEqual 2
 
         $statusIndex = [Array]::IndexOf($lines, $statusLine)
         $historyIndex = [Array]::IndexOf($lines, $historyLine)
         $historyTrendIndex = [Array]::IndexOf($lines, $historyTrendLine)
 
-        $statusIndex | Should -Be ($dividerIndices[1] + 2)
-        $lines[$dividerIndices[1] + 1] | Should -Be ''
-        $historyIndex | Should -Be ($statusIndex + 1)
-        $historyTrendIndex | Should -Be ($historyIndex + 1)
+        $statusIndex | Should-Be ($dividerIndices[1] + 2)
+        $lines[$dividerIndices[1] + 1] | Should-Be ''
+        $historyIndex | Should-Be ($statusIndex + 1)
+        $historyTrendIndex | Should-Be ($historyIndex + 1)
     }
 
     It 'returns structured output with -AsObject' {
         $result = Show-SystemResourceMonitor -AsObject -NoContinuous
 
         $result | Should -Not -BeNullOrEmpty
-        $result.Timestamp | Should -BeOfType 'DateTime'
-        $result.PSObject.Properties.Name | Should -Contain 'CpuUsagePercent'
-        $result.PSObject.Properties.Name | Should -Contain 'MemoryUsagePercent'
-        $result.PSObject.Properties.Name | Should -Contain 'DiskUsagePercent'
-        $result.PSObject.Properties.Name | Should -Contain 'NetworkReceiveBytesPerSecond'
-        $result.PSObject.Properties.Name | Should -Contain 'NetworkSendBytesPerSecond'
-        $result.PSObject.Properties.Name | Should -Contain 'NetworkTotalBytesPerSecond'
-        $result.PSObject.Properties.Name | Should -Contain 'NetworkActiveInterfaces'
-        $result.PSObject.Properties.Name | Should -Contain 'Platform'
-        $result.PSObject.Properties.Name | Should -Contain 'OverallLoadPercent'
-        $result.PSObject.Properties.Name | Should -Contain 'HealthGrade'
-        $result.PSObject.Properties.Name | Should -Contain 'Findings'
-        $result.PSObject.Properties.Name | Should -Contain 'CollectMs'
+        $result.Timestamp | Should-HaveType ([DateTime])
+        $result.PSObject.Properties.Name | Should-ContainCollection 'CpuUsagePercent'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'MemoryUsagePercent'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'DiskUsagePercent'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'NetworkReceiveBytesPerSecond'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'NetworkSendBytesPerSecond'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'NetworkTotalBytesPerSecond'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'NetworkActiveInterfaces'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'Platform'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'OverallLoadPercent'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'HealthGrade'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'Findings'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'CollectMs'
     }
 
     It 'returns top processes in structured output by default' {
@@ -94,15 +94,15 @@ Describe 'Show-SystemResourceMonitor' {
         $topProcesses = @($result.TopProcesses)
 
         $result | Should -Not -BeNullOrEmpty
-        $result.PSObject.Properties.Name | Should -Contain 'TopProcesses'
-        $topProcesses.Count | Should -BeLessOrEqual 3
+        $result.PSObject.Properties.Name | Should-ContainCollection 'TopProcesses'
+        $topProcesses.Count | Should-BeLessThanOrEqual 3
 
         if ($topProcesses.Count -gt 0)
         {
-            $topProcesses[0].PSObject.Properties.Name | Should -Contain 'Name'
-            $topProcesses[0].PSObject.Properties.Name | Should -Contain 'Id'
-            $topProcesses[0].PSObject.Properties.Name | Should -Contain 'CpuSeconds'
-            $topProcesses[0].PSObject.Properties.Name | Should -Contain 'WorkingSetMiB'
+            $topProcesses[0].PSObject.Properties.Name | Should-ContainCollection 'Name'
+            $topProcesses[0].PSObject.Properties.Name | Should-ContainCollection 'Id'
+            $topProcesses[0].PSObject.Properties.Name | Should-ContainCollection 'CpuSeconds'
+            $topProcesses[0].PSObject.Properties.Name | Should-ContainCollection 'WorkingSetMiB'
         }
     }
 
@@ -116,10 +116,10 @@ Describe 'Show-SystemResourceMonitor' {
         $result = Show-SystemResourceMonitor -AsObject -NoContinuous -TopProcessCount 10 -TopProcessName $namePattern
         $topProcesses = @($result.TopProcesses)
 
-        $topProcesses.Count | Should -BeGreaterThan 0
+        $topProcesses.Count | Should-BeGreaterThan 0
         foreach ($processInfo in $topProcesses)
         {
-            $processInfo.Name | Should -BeLike $namePattern
+            $processInfo.Name | Should-BeLikeString $namePattern
         }
     }
 
@@ -128,7 +128,7 @@ Describe 'Show-SystemResourceMonitor' {
         $topProcesses = @($result.TopProcesses)
 
         $result | Should -Not -BeNullOrEmpty
-        $topProcesses.Count | Should -Be 0
+        $topProcesses.Count | Should-Be 0
     }
 
     It 'supports process-scoped monitor metrics when process filters are specified' {
@@ -140,10 +140,10 @@ Describe 'Show-SystemResourceMonitor' {
         $result = Show-SystemResourceMonitor -AsObject -NoContinuous -MonitorProcessName $namePattern
 
         $result | Should -Not -BeNullOrEmpty
-        $result.PSObject.Properties.Name | Should -Contain 'MonitorProcessName'
-        $result.PSObject.Properties.Name | Should -Contain 'MonitorProcessMatchCount'
-        @($result.MonitorProcessName) | Should -Contain $namePattern
-        [Int32]$result.MonitorProcessMatchCount | Should -BeGreaterOrEqual 1
+        $result.PSObject.Properties.Name | Should-ContainCollection 'MonitorProcessName'
+        $result.PSObject.Properties.Name | Should-ContainCollection 'MonitorProcessMatchCount'
+        @($result.MonitorProcessName) | Should-ContainCollection $namePattern
+        [Int32]$result.MonitorProcessMatchCount | Should-BeGreaterThanOrEqual 1
         $result.DiskUsagePercent | Should -BeNullOrEmpty
         $result.NetworkTotalBytesPerSecond | Should -BeNullOrEmpty
     }
@@ -166,17 +166,17 @@ Describe 'Show-SystemResourceMonitor' {
         $result = Show-SystemResourceMonitor -AsObject -NoContinuous -MonitorProcessName $plainFilter
 
         $result | Should -Not -BeNullOrEmpty
-        @($result.MonitorProcessName) | Should -Contain $plainFilter
-        [Int32]$result.MonitorProcessMatchCount | Should -BeGreaterOrEqual 1
+        @($result.MonitorProcessName) | Should-ContainCollection $plainFilter
+        [Int32]$result.MonitorProcessMatchCount | Should-BeGreaterThanOrEqual 1
     }
 
     It 'reports zero scoped CPU and memory when process filter has no matches' {
         $result = Show-SystemResourceMonitor -AsObject -NoContinuous -MonitorProcessName '__definitely_not_a_real_process_name_*'
 
         $result | Should -Not -BeNullOrEmpty
-        [Int32]$result.MonitorProcessMatchCount | Should -Be 0
-        $result.CpuUsagePercent | Should -Be 0
-        $result.MemoryUsedGiB | Should -Be 0
+        [Int32]$result.MonitorProcessMatchCount | Should-Be 0
+        $result.CpuUsagePercent | Should-Be 0
+        $result.MemoryUsedGiB | Should-Be 0
     }
 
     It 'does not report intentionally omitted disk as a process-scoped issue' {
@@ -185,9 +185,9 @@ Describe 'Show-SystemResourceMonitor' {
         $dashboard = Show-SystemResourceMonitor -NoContinuous -NoColor -NoTopProcesses -BarWidth 12 -HistoryLength 8 -MonitorProcessName $filter
 
         $sample | Should -Not -BeNullOrEmpty
-        @($sample.Findings) | Should -Not -Contain 'Disk unavailable'
-        $dashboard | Should -Match '(?m)^Findings +\[Issues\] +none\r?$'
-        $dashboard | Should -Not -Match 'Disk unavailable'
+        @($sample.Findings) | Should-NotContainCollection 'Disk unavailable'
+        $dashboard | Should-MatchString '(?m)^Findings +\[Issues\] +none\r?$'
+        $dashboard | Should-NotMatchString 'Disk unavailable'
     }
 
     It 'shows process scope metadata in dashboard output' {
@@ -196,36 +196,36 @@ Describe 'Show-SystemResourceMonitor' {
         $diskLine = @($lines | Where-Object { $_ -match '^Disk' }) | Select-Object -First 1
         $networkLine = @($lines | Where-Object { $_ -match '^Network' }) | Select-Object -First 1
 
-        $result | Should -BeOfType 'System.String'
-        $result | Should -Match '(?m)^Scope +\[Filter\] +__definitely_not_a_real_process_name_\*.+\[Matches\] +0\r?$'
-        $result | Should -Match '(?m)^CPU.+0\.0%'
-        $result | Should -Match '(?m)^Disk.+n/a.+on n/a\r?$'
-        $result | Should -Match '(?m)^Network.+n/a'
-        $diskLine | Should -Not -Match '\?'
-        $networkLine | Should -Not -Match '\?'
+        $result | Should-HaveType ([System.String])
+        $result | Should-MatchString '(?m)^Scope +\[Filter\] +__definitely_not_a_real_process_name_\*.+\[Matches\] +0\r?$'
+        $result | Should-MatchString '(?m)^CPU.+0\.0%'
+        $result | Should-MatchString '(?m)^Disk.+n/a.+on n/a\r?$'
+        $result | Should-MatchString '(?m)^Network.+n/a'
+        $diskLine | Should-NotMatchString '\?'
+        $networkLine | Should-NotMatchString '\?'
     }
 
     It 'supports ASCII-only rendering mode' {
         $result = Show-SystemResourceMonitor -NoContinuous -NoColor -Ascii -BarWidth 12 -HistoryLength 8
 
-        $result | Should -BeOfType 'System.String'
-        $result | Should -Match '(?m)^CPU'
-        $result | Should -Match '(?m)^Status +\[Platform\]'
+        $result | Should-HaveType ([System.String])
+        $result | Should-MatchString '(?m)^CPU'
+        $result | Should-MatchString '(?m)^Status +\[Platform\]'
     }
 
     It 'includes top process visualization by default' {
         $result = Show-SystemResourceMonitor -NoContinuous -NoColor -BarWidth 12 -HistoryLength 8 -TopProcessCount 3
 
-        $result | Should -BeOfType 'System.String'
-        $result | Should -Match '(?m)^Top Processes \(limit: 3\)\r?$'
-        $result | Should -Match '(?m)^  .+ PID +[0-9]+'
+        $result | Should-HaveType ([System.String])
+        $result | Should-MatchString '(?m)^Top Processes \(limit: 3\)\r?$'
+        $result | Should-MatchString '(?m)^  .+ PID +[0-9]+'
     }
 
     It 'shows top process wildcard filter in visualization heading' {
         $result = Show-SystemResourceMonitor -NoContinuous -NoColor -BarWidth 12 -HistoryLength 8 -TopProcessCount 3 -TopProcessName 'pwsh*'
 
-        $result | Should -BeOfType 'System.String'
-        $result | Should -Match '(?m)^Top Processes \(limit: 3\) \| filter: pwsh\*\r?$'
+        $result | Should-HaveType ([System.String])
+        $result | Should-MatchString '(?m)^Top Processes \(limit: 3\) \| filter: pwsh\*\r?$'
     }
 
     It 'uses process scope filter for top process heading when no top process filter is provided' {
@@ -235,8 +235,8 @@ Describe 'Show-SystemResourceMonitor' {
 
         $result = Show-SystemResourceMonitor -NoContinuous -NoColor -BarWidth 12 -HistoryLength 8 -TopProcessCount 3 -MonitorProcessName $namePattern
 
-        $result | Should -BeOfType 'System.String'
-        $result | Should -Match (('(?m)^Top Processes \(limit: 3\) \| filter: {0}\r?$' -f [Regex]::Escape($namePattern)))
+        $result | Should-HaveType ([System.String])
+        $result | Should-MatchString (('(?m)^Top Processes \(limit: 3\) \| filter: {0}\r?$' -f [Regex]::Escape($namePattern)))
     }
 
     It 'formats disk label details for the current platform' {
@@ -253,29 +253,29 @@ Describe 'Show-SystemResourceMonitor' {
 
         if ($isWindowsPlatform)
         {
-            $result | Should -Match '(?m)^Disk.+on [A-Za-z]:\\\r?$'
+            $result | Should-MatchString '(?m)^Disk.+on [A-Za-z]:\\\r?$'
         }
         else
         {
-            $result | Should -Match '(?m)^Disk.+on / \(root fs\)\r?$'
+            $result | Should-MatchString '(?m)^Disk.+on / \(root fs\)\r?$'
         }
     }
 
     It 'supports bounded continuous mode for automation and tests' {
         $results = @(Show-SystemResourceMonitor -AsObject -IntervalSeconds 1 -MaxIterations 2)
 
-        $results.Count | Should -Be 2
-        $results[0].Timestamp | Should -BeOfType 'DateTime'
-        $results[1].Timestamp | Should -BeOfType 'DateTime'
+        $results.Count | Should-Be 2
+        $results[0].Timestamp | Should-HaveType ([DateTime])
+        $results[1].Timestamp | Should-HaveType ([DateTime])
     }
 
     It 'renders continuous output without timestamp refresh noise' {
         $output = Show-SystemResourceMonitor -NoColor -IntervalSeconds 1 -MaxIterations 1 *>&1 | Out-String
 
-        $output | Should -Match '(?m)^System Resource Monitor.+\[[ABCDF]\]'
-        $output | Should -Not -Match 'Refresh #'
-        $output | Should -Not -Match '(?m)^Health +Overall:'
-        $output | Should -Match 'Press (?:Q or Ctrl\+C|Ctrl\+C or q) to stop monitor\.'
+        $output | Should-MatchString '(?m)^System Resource Monitor.+\[[ABCDF]\]'
+        $output | Should-NotMatchString 'Refresh #'
+        $output | Should-NotMatchString '(?m)^Health +Overall:'
+        $output | Should-MatchString 'Press (?:Q or Ctrl\+C|Ctrl\+C or q) to stop monitor\.'
     }
 
     It 'keeps top processes visible in height-constrained continuous output' {
@@ -291,18 +291,18 @@ Describe 'Show-SystemResourceMonitor' {
             $lines.RemoveAt($lines.Count - 1)
         }
 
-        $lines.Count | Should -BeLessOrEqual 16
-        $output | Should -Match '(?m)^System Resource Monitor.+\[[ABCDF]\]'
-        $output | Should -Match '(?m)^Top Processes \(limit: 5\)(?: \| showing: [0-9]+)?\r?$'
-        $output | Should -Match '(?m)^  .+ PID +[0-9]+'
-        $output | Should -Not -Match 'Press Q or Ctrl\+C to stop monitor\.'
+        $lines.Count | Should-BeLessThanOrEqual 16
+        $output | Should-MatchString '(?m)^System Resource Monitor.+\[[ABCDF]\]'
+        $output | Should-MatchString '(?m)^Top Processes \(limit: 5\)(?: \| showing: [0-9]+)?\r?$'
+        $output | Should-MatchString '(?m)^  .+ PID +[0-9]+'
+        $output | Should-NotMatchString 'Press Q or Ctrl\+C to stop monitor\.'
     }
 
     It 'omits top process sections when -NoTopProcesses is used' {
         $dashboard = Show-SystemResourceMonitor -NoContinuous -NoColor -NoTopProcesses -BarWidth 12 -HistoryLength 8
         $sample = Show-SystemResourceMonitor -AsObject -NoContinuous -NoTopProcesses
 
-        $dashboard | Should -Not -Match '(?m)^Top Processes'
-        $sample.PSObject.Properties.Name | Should -Not -Contain 'TopProcesses'
+        $dashboard | Should-NotMatchString '(?m)^Top Processes'
+        $sample.PSObject.Properties.Name | Should-NotContainCollection 'TopProcesses'
     }
 }

--- a/Tests/Unit/SystemAdministration/Start-KeepAlive.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Start-KeepAlive.Tests.ps1
@@ -233,7 +233,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $job2 = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestKeepAlive2' -WarningVariable warningMessages
 
             $job2 | Should -BeNullOrEmpty
-            $warningMessages | Should-MatchString 'already running'
+            ($warningMessages | Out-String) | Should-MatchString 'already running'
         }
 
         It 'Should clean up completed jobs before starting new ones' {
@@ -268,7 +268,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             Start-KeepAlive -Query -JobName 'NonExistentJob' -WarningVariable warningMessages
 
-            $warningMessages | Should-MatchString "No keep-alive job named 'NonExistentJob' found"
+            ($warningMessages | Out-String) | Should-MatchString "No keep-alive job named 'NonExistentJob' found"
         }
 
         It 'Should include scheduled end time for keep-alive jobs' {
@@ -289,7 +289,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             $output = Start-KeepAlive -Query -JobName 'TestQueryDuplicate' -WarningVariable warningMessages 6>&1 | Out-String
 
-            $warningMessages | Should-MatchString "Multiple jobs named 'TestQueryDuplicate' were found"
+            ($warningMessages | Out-String) | Should-MatchString "Multiple jobs named 'TestQueryDuplicate' were found"
             $output | Should-MatchString "Job Status for 'TestQueryDuplicate'"
         }
 
@@ -323,7 +323,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             Start-KeepAlive -EndJob -JobName 'NonExistentEndJob' -WarningVariable warningMessages
 
-            $warningMessages | Should-MatchString "No keep-alive job named 'NonExistentEndJob' found"
+            ($warningMessages | Out-String) | Should-MatchString "No keep-alive job named 'NonExistentEndJob' found"
         }
 
         It 'Should successfully stop and remove running job' {
@@ -346,7 +346,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             $output = Start-KeepAlive -EndJob -JobName 'TestEndDuplicate' -WarningVariable warningMessages 6>&1 | Out-String
 
-            $warningMessages | Should-MatchString "Multiple jobs named 'TestEndDuplicate' were found"
+            ($warningMessages | Out-String) | Should-MatchString "Multiple jobs named 'TestEndDuplicate' were found"
             $output | Should-MatchString "Removed 2 matching jobs named 'TestEndDuplicate'"
             Get-Job -Name 'TestEndDuplicate' -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
         }
@@ -375,8 +375,8 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $job = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestVerbose1' -Verbose 4>&1
 
             $verboseOutput = $job | Out-String
-            $verboseOutput | Should-MatchString 'Starting Start-KeepAlive function'
-            $verboseOutput | Should-MatchString 'Starting new keep-alive job'
+            ($verboseOutput | Out-String) | Should-MatchString 'Starting Start-KeepAlive function'
+            ($verboseOutput | Out-String) | Should-MatchString 'Starting new keep-alive job'
 
             # Clean up
             Get-Job -Name 'TestVerbose1' | Remove-Job -Force

--- a/Tests/Unit/SystemAdministration/Start-KeepAlive.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Start-KeepAlive.Tests.ps1
@@ -47,15 +47,15 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
 
         It 'Should be available as a function' {
             Get-Command Start-KeepAlive | Should -Not -BeNullOrEmpty
-            Get-Command Start-KeepAlive | Should -BeOfType [System.Management.Automation.FunctionInfo]
+            Get-Command Start-KeepAlive | Should-HaveType ([System.Management.Automation.FunctionInfo])
         }
 
         It 'Should have correct parameter sets' {
             $command = Get-Command Start-KeepAlive
-            $command.ParameterSets.Count | Should -Be 3
-            $command.ParameterSets.Name | Should -Contain 'Start'
-            $command.ParameterSets.Name | Should -Contain 'Query'
-            $command.ParameterSets.Name | Should -Contain 'End'
+            $command.ParameterSets.Count | Should-Be 3
+            $command.ParameterSets.Name | Should-ContainCollection 'Start'
+            $command.ParameterSets.Name | Should-ContainCollection 'Query'
+            $command.ParameterSets.Name | Should-ContainCollection 'End'
         }
 
         It 'Should work on all platforms' {
@@ -94,7 +94,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             # On Windows CI, we should not get a platform error
             if ($script:IsWindowsTest)
             {
-                $result | Should -Not -Be 'Platform-Error'
+                $result | Should-NotBe 'Platform-Error'
             }
 
             # Clean up any jobs that might have been created
@@ -105,24 +105,24 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
     Context 'Parameter Validation' {
 
         It 'Should validate KeepAliveHours range' {
-            { Start-KeepAlive -KeepAliveHours 0.05 -ErrorAction Stop } | Should -Throw
-            { Start-KeepAlive -KeepAliveHours 50 -ErrorAction Stop } | Should -Throw
+            { Start-KeepAlive -KeepAliveHours 0.05 -ErrorAction Stop } | Should-Throw
+            { Start-KeepAlive -KeepAliveHours 50 -ErrorAction Stop } | Should-Throw
             # These should not throw with valid ranges (but may start jobs)
             { $job1 = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestRange1'; if ($job1) { Remove-Job $job1 -Force -ErrorAction SilentlyContinue } } | Should -Not -Throw
             { $job2 = Start-KeepAlive -KeepAliveHours 48 -JobName 'TestRange2'; if ($job2) { Remove-Job $job2 -Force -ErrorAction SilentlyContinue } } | Should -Not -Throw
         }
 
         It 'Should validate SleepSeconds range' {
-            { Start-KeepAlive -SleepSeconds 20 -ErrorAction Stop } | Should -Throw
-            { Start-KeepAlive -SleepSeconds 4000 -ErrorAction Stop } | Should -Throw
+            { Start-KeepAlive -SleepSeconds 20 -ErrorAction Stop } | Should-Throw
+            { Start-KeepAlive -SleepSeconds 4000 -ErrorAction Stop } | Should-Throw
             { $job1 = Start-KeepAlive -SleepSeconds 30 -KeepAliveHours 0.1 -JobName 'TestSleep1'; if ($job1) { Remove-Job $job1 -Force -ErrorAction SilentlyContinue } } | Should -Not -Throw
             { $job2 = Start-KeepAlive -SleepSeconds 3600 -KeepAliveHours 0.1 -JobName 'TestSleep2'; if ($job2) { Remove-Job $job2 -Force -ErrorAction SilentlyContinue } } | Should -Not -Throw
         }
 
         It 'Should validate JobName pattern' {
             { $job1 = Start-KeepAlive -JobName 'Valid-Name_123' -KeepAliveHours 0.1; if ($job1) { Remove-Job $job1 -Force -ErrorAction SilentlyContinue } } | Should -Not -Throw
-            { Start-KeepAlive -JobName 'Invalid Name!' -ErrorAction Stop } | Should -Throw
-            { Start-KeepAlive -JobName 'Invalid@Name' -ErrorAction Stop } | Should -Throw
+            { Start-KeepAlive -JobName 'Invalid Name!' -ErrorAction Stop } | Should-Throw
+            { Start-KeepAlive -JobName 'Invalid@Name' -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should have correct default values' {
@@ -141,10 +141,10 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $keyToPressParam | Should -Not -BeNullOrEmpty
 
             # Verify parameter types
-            $keepAliveHoursParam.ParameterType | Should -Be ([Double])
-            $sleepSecondsParam.ParameterType | Should -Be ([Int32])
-            $jobNameParam.ParameterType | Should -Be ([String])
-            $keyToPressParam.ParameterType | Should -Be ([String])
+            $keepAliveHoursParam.ParameterType | Should-Be ([Double])
+            $sleepSecondsParam.ParameterType | Should-Be ([Int32])
+            $jobNameParam.ParameterType | Should-Be ([String])
+            $keyToPressParam.ParameterType | Should-Be ([String])
         }
     }
 
@@ -156,7 +156,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
                 throw 'COM object not available'
             }
 
-            { Start-KeepAlive -KeepAliveHours 0.1 } | Should -Throw -ExpectedMessage '*WScript.Shell COM object not available*'
+            { Start-KeepAlive -KeepAliveHours 0.1 } | Should-Throw -ExceptionMessage '*WScript.Shell COM object not available*'
         }
 
         It 'Should validate macOS caffeinate availability' -Skip:($script:IsWindowsTest -or $PSVersionTable.PSVersion.Major -lt 6 -or -not $IsMacOS) {
@@ -172,7 +172,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $hasXdotool = $null -ne (Get-Command xdotool -ErrorAction SilentlyContinue)
 
             $hasEither = $hasSystemdInhibit -or $hasXdotool
-            $hasEither | Should -Be $true -Because 'Linux requires either systemd-inhibit or xdotool'
+            $hasEither | Should-Be $true -Because 'Linux requires either systemd-inhibit or xdotool'
         }
     }
 
@@ -209,38 +209,38 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $job = Start-KeepAlive -KeepAliveHours 0.1 -SleepSeconds 30 -JobName 'TestKeepAlive1'
 
             $job | Should -Not -BeNullOrEmpty
-            $job | Should -BeOfType [System.Management.Automation.Job]
-            $job.Name | Should -Be 'TestKeepAlive1'
-            $job.State | Should -Be 'Running'
+            $job | Should-HaveType ([System.Management.Automation.Job])
+            $job.Name | Should-Be 'TestKeepAlive1'
+            $job.State | Should-Be 'Running'
         }
 
         It 'Should stamp keep-alive metadata on started jobs' {
             $job = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestKeepAliveMeta'
 
             $job.PSObject.Properties['KeepAliveJob'] | Should -Not -BeNullOrEmpty
-            $job.KeepAliveJob | Should -Be $true
+            $job.KeepAliveJob | Should-Be $true
             $job.PSObject.Properties['KeepAliveEndTime'] | Should -Not -BeNullOrEmpty
-            $job.KeepAliveEndTime | Should -BeOfType [DateTime]
+            $job.KeepAliveEndTime | Should-HaveType ([DateTime])
         }
 
         It 'Should prevent starting duplicate jobs' {
             # Start first job
             $job1 = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestKeepAlive2'
-            $job1.State | Should -Be 'Running'
+            $job1.State | Should-Be 'Running'
 
             # Try to start second job with same name
             $warningMessages = @()
             $job2 = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestKeepAlive2' -WarningVariable warningMessages
 
             $job2 | Should -BeNullOrEmpty
-            $warningMessages | Should -Match 'already running'
+            $warningMessages | Should-MatchString 'already running'
         }
 
         It 'Should clean up completed jobs before starting new ones' {
             # Start a real job - it should clean up the old one
             $job = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestKeepAlive3'
             $job | Should -Not -BeNullOrEmpty
-            $job.State | Should -Be 'Running'
+            $job.State | Should-Be 'Running'
         }
     }
 
@@ -268,7 +268,7 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             Start-KeepAlive -Query -JobName 'NonExistentJob' -WarningVariable warningMessages
 
-            $warningMessages | Should -Match "No keep-alive job named 'NonExistentJob' found"
+            $warningMessages | Should-MatchString "No keep-alive job named 'NonExistentJob' found"
         }
 
         It 'Should include scheduled end time for keep-alive jobs' {
@@ -277,8 +277,8 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
 
             $output = Start-KeepAlive -Query -JobName 'TestQueryScheduled' 6>&1 | Out-String
 
-            $output | Should -Match "Job Status for 'TestQueryScheduled'"
-            $output | Should -Match 'Scheduled End:'
+            $output | Should-MatchString "Job Status for 'TestQueryScheduled'"
+            $output | Should-MatchString 'Scheduled End:'
         }
 
         It 'Should warn when multiple jobs share the same name' {
@@ -289,8 +289,8 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             $output = Start-KeepAlive -Query -JobName 'TestQueryDuplicate' -WarningVariable warningMessages 6>&1 | Out-String
 
-            $warningMessages | Should -Match "Multiple jobs named 'TestQueryDuplicate' were found"
-            $output | Should -Match "Job Status for 'TestQueryDuplicate'"
+            $warningMessages | Should-MatchString "Multiple jobs named 'TestQueryDuplicate' were found"
+            $output | Should-MatchString "Job Status for 'TestQueryDuplicate'"
         }
 
         It 'Should clean up completed jobs when queried' {
@@ -323,17 +323,17 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             Start-KeepAlive -EndJob -JobName 'NonExistentEndJob' -WarningVariable warningMessages
 
-            $warningMessages | Should -Match "No keep-alive job named 'NonExistentEndJob' found"
+            $warningMessages | Should-MatchString "No keep-alive job named 'NonExistentEndJob' found"
         }
 
         It 'Should successfully stop and remove running job' {
             # Start a job
             $job = Start-KeepAlive -KeepAliveHours 1 -JobName 'TestEnd1'
-            $job.State | Should -Be 'Running'
+            $job.State | Should-Be 'Running'
 
             # End the job
             $output = Start-KeepAlive -EndJob -JobName 'TestEnd1' 6>&1 | Out-String
-            $output | Should -Match 'stopped and removed'
+            $output | Should-MatchString 'stopped and removed'
 
             # Verify job is gone
             Get-Job -Name 'TestEnd1' -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
@@ -346,8 +346,8 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $warningMessages = @()
             $output = Start-KeepAlive -EndJob -JobName 'TestEndDuplicate' -WarningVariable warningMessages 6>&1 | Out-String
 
-            $warningMessages | Should -Match "Multiple jobs named 'TestEndDuplicate' were found"
-            $output | Should -Match "Removed 2 matching jobs named 'TestEndDuplicate'"
+            $warningMessages | Should-MatchString "Multiple jobs named 'TestEndDuplicate' were found"
+            $output | Should-MatchString "Removed 2 matching jobs named 'TestEndDuplicate'"
             Get-Job -Name 'TestEndDuplicate' -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
         }
     }
@@ -359,13 +359,13 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
                 throw 'Failed to start job'
             }
 
-            { Start-KeepAlive -KeepAliveHours 0.1 } | Should -Throw -ExpectedMessage '*Failed to start keep-alive job*'
+            { Start-KeepAlive -KeepAliveHours 0.1 } | Should-Throw -ExceptionMessage '*Failed to start keep-alive job*'
         }
 
         It 'Should validate parameter combinations' {
             # EndJob and Query should not be used with Start parameters
-            { Start-KeepAlive -EndJob -KeepAliveHours 1 } | Should -Throw
-            { Start-KeepAlive -Query -SleepSeconds 60 } | Should -Throw
+            { Start-KeepAlive -EndJob -KeepAliveHours 1 } | Should-Throw
+            { Start-KeepAlive -Query -SleepSeconds 60 } | Should-Throw
         }
     }
 
@@ -375,8 +375,8 @@ Describe 'Start-KeepAlive Function Tests' -Tag 'Unit' {
             $job = Start-KeepAlive -KeepAliveHours 0.1 -JobName 'TestVerbose1' -Verbose 4>&1
 
             $verboseOutput = $job | Out-String
-            $verboseOutput | Should -Match 'Starting Start-KeepAlive function'
-            $verboseOutput | Should -Match 'Starting new keep-alive job'
+            $verboseOutput | Should-MatchString 'Starting Start-KeepAlive function'
+            $verboseOutput | Should-MatchString 'Starting new keep-alive job'
 
             # Clean up
             Get-Job -Name 'TestVerbose1' | Remove-Job -Force

--- a/Tests/Unit/SystemAdministration/Test-Admin.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Test-Admin.Tests.ps1
@@ -128,27 +128,27 @@ Describe 'Test-Admin' {
         $command = Get-Command -Name 'Test-Admin' -ErrorAction SilentlyContinue
 
         $command | Should -Not -BeNullOrEmpty
-        $command.CommandType | Should -Be 'Function'
+        $command.CommandType | Should-Be 'Function'
     }
 
     It 'returns a boolean result' {
         $result = Test-Admin
 
-        $result | Should -BeOfType [System.Boolean]
+        $result | Should-HaveType ([System.Boolean])
     }
 
     It 'creates the Test-Root alias' {
         $alias = Get-Alias -Name 'Test-Root' -ErrorAction SilentlyContinue
 
         $alias | Should -Not -BeNullOrEmpty
-        $alias.Definition | Should -Be 'Test-Admin'
+        $alias.Definition | Should-Be 'Test-Admin'
     }
 
     It 'creates the Test-Sudo alias' {
         $alias = Get-Alias -Name 'Test-Sudo' -ErrorAction SilentlyContinue
 
         $alias | Should -Not -BeNullOrEmpty
-        $alias.Definition | Should -Be 'Test-Admin'
+        $alias.Definition | Should-Be 'Test-Admin'
     }
 
     It 'does not leak platform variables into the caller script scope' {
@@ -161,35 +161,35 @@ Describe 'Test-Admin' {
 
     Context 'Unix privilege detection' -Skip:$script:SkipUnixContext {
         It 'matches the current process effective user ID' -Skip:(-not $script:HasUnixIdCommand) {
-            Test-Admin | Should -Be $script:IsUnixElevatedSession
+            Test-Admin | Should-Be $script:IsUnixElevatedSession
         }
 
         It 'does not treat SUDO_* environment variables as proof of elevation' -Skip:(-not $script:HasUnixIdCommand -or $script:IsUnixElevatedSession) {
             $env:SUDO_USER = 'root'
             $env:SUDO_UID = '0'
 
-            Test-Admin | Should -BeFalse
+            Test-Admin | Should-BeFalsy
         }
 
         It 'does not treat sudo capability as elevation unless AllowSudo is specified' {
             $script:NativeCommandTestDir = & $script:NewNativeCommandDirectory -IdOutput '501' -IncludeSudo -SudoExitCode 0
             $env:PATH = $script:NativeCommandTestDir
 
-            Test-Admin | Should -BeFalse
+            Test-Admin | Should-BeFalsy
         }
 
         It 'returns true with AllowSudo when non-interactive sudo succeeds' {
             $script:NativeCommandTestDir = & $script:NewNativeCommandDirectory -IdOutput '501' -IncludeSudo -SudoExitCode 0
             $env:PATH = $script:NativeCommandTestDir
 
-            Test-Admin -AllowSudo | Should -BeTrue
+            Test-Admin -AllowSudo | Should-BeTruthy
         }
 
         It 'returns false with AllowSudo when non-interactive sudo fails' {
             $script:NativeCommandTestDir = & $script:NewNativeCommandDirectory -IdOutput '501' -IncludeSudo -SudoExitCode 1
             $env:PATH = $script:NativeCommandTestDir
 
-            Test-Admin -AllowSudo | Should -BeFalse
+            Test-Admin -AllowSudo | Should-BeFalsy
         }
 
         It 'writes a warning and returns false when the id command cannot be resolved' {
@@ -198,9 +198,9 @@ Describe 'Test-Admin' {
 
             $result = Test-Admin -WarningAction Continue -WarningVariable warnings
 
-            $result | Should -BeFalse
-            @($warnings).Count | Should -BeGreaterThan 0
-            ($warnings | Out-String) | Should -Match 'Failed to determine privilege status'
+            $result | Should-BeFalsy
+            @($warnings).Count | Should-BeGreaterThan 0
+            ($warnings | Out-String) | Should-MatchString 'Failed to determine privilege status'
         }
 
         It 'suppresses warning output with Quiet when the id command cannot be resolved' {
@@ -209,8 +209,8 @@ Describe 'Test-Admin' {
 
             $result = Test-Admin -Quiet -WarningAction Continue -WarningVariable warnings
 
-            $result | Should -BeFalse
-            @($warnings).Count | Should -Be 0
+            $result | Should-BeFalsy
+            @($warnings).Count | Should-Be 0
         }
     }
 }

--- a/Tests/Unit/SystemAdministration/Upgrade-PlatformPackage.Tests.ps1
+++ b/Tests/Unit/SystemAdministration/Upgrade-PlatformPackage.Tests.ps1
@@ -20,27 +20,27 @@ Describe 'Upgrade-PlatformPackage' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Upgrade-PlatformPackage -PackageManager brew -UninstallPrevious -CommandRunner $runner -Confirm:$false } |
-                Should -Throw -ExpectedMessage "*Parameter -UninstallPrevious*package manager 'brew'*only supported by winget*"
+                Should-Throw -ExceptionMessage "*Parameter -UninstallPrevious*package manager 'brew'*only supported by winget*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
 
         It 'rejects interactive mode outside winget' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Upgrade-PlatformPackage -PackageManager apt -Interactive -CommandRunner $runner -Confirm:$false } |
-                Should -Throw -ExpectedMessage "*Parameter -Interactive*package manager 'apt'*only supported by winget*"
+                Should-Throw -ExceptionMessage "*Parameter -Interactive*package manager 'apt'*only supported by winget*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
 
         It 'rejects NoSudo for package managers that do not use sudo' {
             $runner = & $script:NewPackageCommandRunner @{}
 
             { Upgrade-PlatformPackage -PackageManager winget -NoSudo -CommandRunner $runner -Confirm:$false } |
-                Should -Throw -ExpectedMessage "*Parameter -NoSudo*package manager 'winget'*only supported by apt and apk*"
+                Should-Throw -ExceptionMessage "*Parameter -NoSudo*package manager 'winget'*only supported by apt and apk*"
 
-            $script:Invocations.Count | Should -Be 0
+            $script:Invocations.Count | Should-Be 0
         }
     }
 
@@ -71,18 +71,18 @@ Describe 'Upgrade-PlatformPackage' {
 
             $result = @(Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $formula = $result | Where-Object { $_.Name -eq 'git' }
-            $formula.PackageManager | Should -Be 'brew'
-            $formula.Type | Should -Be 'Formula'
-            $formula.InstalledVersion | Should -Be '2.43.0'
-            $formula.LatestVersion | Should -Be '2.44.0'
-            (@($formula.UpgradeArguments) -join '|') | Should -Be 'upgrade|git'
+            $formula.PackageManager | Should-Be 'brew'
+            $formula.Type | Should-Be 'Formula'
+            $formula.InstalledVersion | Should-Be '2.43.0'
+            $formula.LatestVersion | Should-Be '2.44.0'
+            (@($formula.UpgradeArguments) -join '|') | Should-Be 'upgrade|git'
 
             $cask = $result | Where-Object { $_.Name -eq 'visual-studio-code' }
-            $cask.Type | Should -Be 'Cask'
-            (@($cask.UpgradeArguments) -join '|') | Should -Be 'upgrade|--cask|visual-studio-code'
+            $cask.Type | Should-Be 'Cask'
+            (@($cask.UpgradeArguments) -join '|') | Should-Be 'upgrade|--cask|visual-studio-code'
         }
 
         It 'keeps AsObject as an alias for NonInteractive discovery' {
@@ -103,10 +103,10 @@ Describe 'Upgrade-PlatformPackage' {
 
             $result = @(Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -AsObject -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
-            (@($result[0].UpgradeArguments) -join '|') | Should -Be 'upgrade|git'
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should -Be 0
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
+            (@($result[0].UpgradeArguments) -join '|') | Should-Be 'upgrade|git'
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should-Be 0
         }
 
         It 'captures Homebrew refresh output and streams upgrade command output when upgrading all packages' {
@@ -130,15 +130,15 @@ Describe 'Upgrade-PlatformPackage' {
 
             $result = Upgrade-PlatformPackage -PackageManager brew -All -CommandRunner $runner -Confirm:$false
 
-            $result.Upgraded | Should -Be 1
-            $result.Failed | Should -Be 0
-            $result.NotSelected | Should -Be 0
+            $result.Upgraded | Should-Be 1
+            $result.Failed | Should-Be 0
+            $result.NotSelected | Should-Be 0
 
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew update --quiet' }).StreamOutput | Should -BeFalse
-            ($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).StreamOutput | Should -BeTrue
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew update --quiet' }).StreamOutput | Should-BeFalsy
+            ($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).StreamOutput | Should-BeTruthy
 
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew update output' } -Times 0 -Exactly
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew upgrade git output' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew update output' } -Times 0 -Exactly
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'brew upgrade git output' } -Times 1
         }
 
         It 'captures Homebrew refresh process output before the picker and streams upgrade process output' {
@@ -229,20 +229,20 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
                 }
             }
 
-            $childExitCode | Should -Be 0
+            $childExitCode | Should-Be 0
             $outputText = $childOutput -join "`n"
-            $outputText | Should -Match 'Refreshing Homebrew package metadata'
-            $outputText | Should -Match 'Upgrade-PlatformPackage - Homebrew'
-            $outputText | Should -Not -Match ([Regex]::Escape('brew update stdout'))
-            $outputText | Should -Not -Match ([Regex]::Escape('brew update stderr'))
-            $outputText | Should -Match ([Regex]::Escape('brew upgrade stdout'))
-            $outputText | Should -Match ([Regex]::Escape('brew upgrade stderr'))
-            $outputText | Should -Match 'RESULT Upgraded=1 Failed=0 NotSelected=0'
+            $outputText | Should-MatchString 'Refreshing Homebrew package metadata'
+            $outputText | Should-MatchString 'Upgrade-PlatformPackage - Homebrew'
+            $outputText | Should-NotMatchString ([Regex]::Escape('brew update stdout'))
+            $outputText | Should-NotMatchString ([Regex]::Escape('brew update stderr'))
+            $outputText | Should-MatchString ([Regex]::Escape('brew upgrade stdout'))
+            $outputText | Should-MatchString ([Regex]::Escape('brew upgrade stderr'))
+            $outputText | Should-MatchString 'RESULT Upgraded=1 Failed=0 NotSelected=0'
 
             $brewInvocations = @(Get-Content -LiteralPath $brewLogPath)
-            $brewInvocations | Should -Contain 'update --quiet'
-            $brewInvocations | Should -Contain 'outdated --json=v2 --greedy'
-            $brewInvocations | Should -Contain 'upgrade git'
+            $brewInvocations | Should-ContainCollection 'update --quiet'
+            $brewInvocations | Should-ContainCollection 'outdated --json=v2 --greedy'
+            $brewInvocations | Should-ContainCollection 'upgrade git'
         }
 
         It 'captures post-upgrade instructions in the result object' {
@@ -269,11 +269,11 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -All -CommandRunner $runner -Confirm:$false
 
-            $result.Upgraded | Should -Be 1
-            $result.Results[0].CapturedOutput | Should -Contain 'Upgrading python...'
-            $result.Results[0].InformationalOutput | Should -Contain '==> Caveats'
-            $result.InformationalResults.Count | Should -Be 1
-            $result.InformationalResults[0].Lines | Should -Contain 'Add /opt/homebrew/opt/python/libexec/bin to PATH'
+            $result.Upgraded | Should-Be 1
+            $result.Results[0].CapturedOutput | Should-ContainCollection 'Upgrading python...'
+            $result.Results[0].InformationalOutput | Should-ContainCollection '==> Caveats'
+            $result.InformationalResults.Count | Should-Be 1
+            $result.InformationalResults[0].Lines | Should-ContainCollection 'Add /opt/homebrew/opt/python/libexec/bin to PATH'
         }
 
         It 'reports streamed command failures with command context when captured output is unavailable' {
@@ -296,16 +296,16 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -All -CommandRunner $runner -Confirm:$false -WarningAction SilentlyContinue
 
-            $result.Failed | Should -Be 1
-            $result.Skipped | Should -Be 0
-            $result.NotSelected | Should -Be 0
-            $result.Results[0].Message | Should -Match 'brew upgrade git failed with exit code 42'
-            $result.Results[0].Message | Should -Match 'streamed directly to the console'
-            $result.Results[0].InformationalOutput | Should -HaveCount 1
-            $result.Results[0].InformationalOutput[0] | Should -BeExactly $result.Results[0].Message
-            $result.InformationalResults | Should -HaveCount 1
-            $result.InformationalResults[0].Lines | Should -HaveCount 1
-            $result.InformationalResults[0].Lines[0] | Should -BeExactly $result.Results[0].Message
+            $result.Failed | Should-Be 1
+            $result.Skipped | Should-Be 0
+            $result.NotSelected | Should-Be 0
+            $result.Results[0].Message | Should-MatchString 'brew upgrade git failed with exit code 42'
+            $result.Results[0].Message | Should-MatchString 'streamed directly to the console'
+            $result.Results[0].InformationalOutput | Should-BeCollection -Count 1
+            $result.Results[0].InformationalOutput[0] | Should-BeString $result.Results[0].Message -CaseSensitive
+            $result.InformationalResults | Should-BeCollection -Count 1
+            $result.InformationalResults[0].Lines | Should-BeCollection -Count 1
+            $result.InformationalResults[0].Lines[0] | Should-BeString $result.Results[0].Message -CaseSensitive
         }
 
         It 'does not read stale LASTEXITCODE for unstructured command runner output' {
@@ -362,9 +362,9 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
                 $result = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -All -CommandRunner $runner -Confirm:$false
 
-                $result.Upgraded | Should -Be 1
-                $result.Failed | Should -Be 0
-                $result.Results[0].ExitCode | Should -Be 0
+                $result.Upgraded | Should-Be 1
+                $result.Failed | Should-Be 0
+                $result.Results[0].ExitCode | Should-Be 0
             }
             finally
             {
@@ -391,12 +391,12 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = @(Upgrade-PlatformPackage -PackageManager apt -SkipRefresh -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'openssl'
-            $result[0].PackageManager | Should -Be 'apt'
-            $result[0].InstalledVersion | Should -Be '3.0.2-0ubuntu1.14'
-            $result[0].LatestVersion | Should -Be '3.0.2-0ubuntu1.15'
-            (@($result[0].UpgradeArguments) -join '|') | Should -Be 'install|--only-upgrade|-y|openssl'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'openssl'
+            $result[0].PackageManager | Should-Be 'apt'
+            $result[0].InstalledVersion | Should-Be '3.0.2-0ubuntu1.14'
+            $result[0].LatestVersion | Should-Be '3.0.2-0ubuntu1.15'
+            (@($result[0].UpgradeArguments) -join '|') | Should-Be 'install|--only-upgrade|-y|openssl'
         }
 
         It 'parses apk version output and keeps hyphenated package names' {
@@ -409,16 +409,16 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = @(Upgrade-PlatformPackage -PackageManager apk -SkipRefresh -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $busybox = $result | Where-Object { $_.Name -eq 'busybox' }
-            $busybox.InstalledVersion | Should -Be '1.36.1-r19'
-            $busybox.LatestVersion | Should -Be '1.36.1-r20'
-            (@($busybox.UpgradeArguments) -join '|') | Should -Be 'add|--upgrade|busybox'
+            $busybox.InstalledVersion | Should-Be '1.36.1-r19'
+            $busybox.LatestVersion | Should-Be '1.36.1-r20'
+            (@($busybox.UpgradeArguments) -join '|') | Should-Be 'add|--upgrade|busybox'
 
             $requests = $result | Where-Object { $_.Name -eq 'py3-requests' }
-            $requests.InstalledVersion | Should -Be '2.31.0-r0'
-            $requests.LatestVersion | Should -Be '2.32.0-r0'
+            $requests.InstalledVersion | Should-Be '2.31.0-r0'
+            $requests.LatestVersion | Should-Be '2.32.0-r0'
         }
     }
 
@@ -447,11 +447,11 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.NotSelected | Should -Be 1
-            $result.Upgraded | Should -Be 0
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should -Be 0
-            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should -Be 4
+            $result.Selected | Should-Be 0
+            $result.NotSelected | Should-Be 1
+            $result.Upgraded | Should-Be 0
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should-Be 0
+            @($script:HostOutput | Where-Object { [String]::IsNullOrEmpty([String]$_) }).Count | Should-Be 4
         }
 
         It 'shows keyboard help from the upgrade picker' {
@@ -483,13 +483,13 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $result.Upgraded | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter upgrade  V details  A toggle all  F: [all]" } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Upgrade-PlatformPackage Help' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'upgrade selected packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
+            $result.Selected | Should-Be 0
+            $result.Upgraded | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "Keys: Space select  Enter upgrade  V details  A toggle all  F: [all]" } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq "1-1 of 1 visible  $([char]0x00B7)  1 total  $([char]0x00B7)  0 selected" -and $ForegroundColor -eq 'White' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Upgrade-PlatformPackage Help' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Enter: ' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'upgrade selected packages' -and $ForegroundColor -eq 'DarkGray' } -Times 1
         }
 
         It 'renders only the current viewport for long upgrade lists' {
@@ -513,10 +513,10 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $null = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -PickerPageSize 2 -Confirm:$false
 
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-01*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-02*' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-03*' } -Times 0 -Exactly
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like '*pkg-04*' } -Times 0 -Exactly
         }
 
         It 'filters picker results by package name when F is pressed' {
@@ -547,11 +547,11 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Upgraded | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade curl' }).Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
+            $result.Upgraded | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade curl' }).Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: g' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[g\]' } -Times 1
         }
 
         It 'treats lowercase q as filter text instead of cancel' {
@@ -582,11 +582,11 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Upgraded | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade jq' }).Count | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
+            $result.Upgraded | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade jq' }).Count | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Current filter: q' } -Times 1
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'F: \[q\]' } -Times 1
         }
 
         It 'upgrades only the visible package when filtering duplicate winget ids by source' {
@@ -636,11 +636,11 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -FilterSource msstore -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Selected | Should -Be 1
-            $result.Upgraded | Should -Be 1
-            @($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements' }).Count | Should -Be 0
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source msstore --accept-package-agreements --accept-source-agreements' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
+            $result.Selected | Should-Be 1
+            $result.Upgraded | Should-Be 1
+            @($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements' }).Count | Should-Be 0
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source msstore --accept-package-agreements --accept-source-agreements' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'S: \[msstore\]' } -Times 1
         }
 
         It 'toggles interactive mode for the current winget picker row' {
@@ -673,11 +673,11 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -Confirm:$false
 
-            $result.Upgraded | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --interactive' }).StreamOutput | Should -BeTrue
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'U remove old version\s+I interactive installer' } -Times 3
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+RmOld\s+UI\s+' } -Times 3
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^> \[x\] \[ \]\s+\[I\]' } -Times 1
+            $result.Upgraded | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --interactive' }).StreamOutput | Should-BeTruthy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match 'U remove old version\s+I interactive installer' } -Times 3
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^\s+Sel\s+RmOld\s+UI\s+' } -Times 3
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -match '^> \[x\] \[ \]\s+\[I\]' } -Times 1
         }
 
         It 'does not suppress terminal echo when a custom key reader drives winget details' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -716,9 +716,9 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -TerminalEchoController $terminalEchoController -Confirm:$false
 
-            $result.Selected | Should -Be 0
-            $echoActions.Count | Should -Be 0
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
+            $result.Selected | Should-Be 0
+            $echoActions.Count | Should-Be 0
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -eq 'Description: Distributed version control system' } -Times 1
         }
 
         It 'restores terminal echo when winget details throw in the console key reader flow' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
@@ -776,9 +776,9 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             {
                 Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -CommandRunner $runner -KeyReader $keyReader -TreatKeyReaderAsConsoleKeyReader -TerminalEchoController $terminalEchoController -Confirm:$false
-            } | Should -Throw -ExpectedMessage '*winget details failed*'
+            } | Should-Throw -ExceptionMessage '*winget details failed*'
 
-            ($echoActions -join '|') | Should -Be 'Disable|Restore:saved-stty-state'
+            ($echoActions -join '|') | Should-Be 'Disable|Restore:saved-stty-state'
         }
 
         It 'keeps winget picker table rows within the current console width' {
@@ -850,13 +850,13 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
                 }
             )
 
-            $tableLines.Count | Should -BeGreaterThan 1
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should -Match '\bInst\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should -Match '\bAvail\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should -Match '\bTyp\b'
-            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should -Match '\bSrc\b'
-            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\] \[[ U]\]\s+\[[ I]\]\s+' } | Select-Object -First 1) | Should -Match 'homebrew/core'
-            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should -BeLessOrEqual $limit
+            $tableLines.Count | Should-BeGreaterThan 1
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should-MatchString '\bInst\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should-MatchString '\bAvail\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should-MatchString '\bTyp\b'
+            ($tableLines | Where-Object { $_ -match '^\s+Sel\s+RmOld\s+UI\s+' } | Select-Object -First 1) | Should-MatchString '\bSrc\b'
+            ($tableLines | Where-Object { $_ -match '^[> ] \[[ x]\] \[[ U]\]\s+\[[ I]\]\s+' } | Select-Object -First 1) | Should-MatchString 'homebrew/core'
+            (($tableLines | ForEach-Object { $_.Length } | Measure-Object -Maximum).Maximum) | Should-BeLessThanOrEqual $limit
         }
     }
 
@@ -884,9 +884,9 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = @(Upgrade-PlatformPackage -PackageManager winget -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget source update' }).StreamOutput | Should -BeFalse
-            Should -Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Updating all sources*' -or $Object -like 'Updating source:*' } -Times 0 -Exactly
+            $result.Count | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget source update' }).StreamOutput | Should-BeFalsy
+            Should-Invoke -CommandName Write-Host -ParameterFilter { $Object -like 'Updating all sources*' -or $Object -like 'Updating source:*' } -Times 0 -Exactly
         }
 
         It 'falls back to table parsing when JSON output is unavailable' {
@@ -903,13 +903,13 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = @(Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -NonInteractive -CommandRunner $runner)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
 
             $powershell = $result | Where-Object { $_.Name -eq 'PowerShell' }
-            $powershell.Id | Should -Be 'Microsoft.PowerShell'
-            $powershell.InstalledVersion | Should -Be '7.4.1'
-            $powershell.LatestVersion | Should -Be '7.4.2'
-            (@($powershell.UpgradeArguments) -join '|') | Should -Be 'upgrade|--id|Microsoft.PowerShell|--exact|--source|winget|--accept-package-agreements|--accept-source-agreements'
+            $powershell.Id | Should-Be 'Microsoft.PowerShell'
+            $powershell.InstalledVersion | Should-Be '7.4.1'
+            $powershell.LatestVersion | Should-Be '7.4.2'
+            (@($powershell.UpgradeArguments) -join '|') | Should-Be 'upgrade|--id|Microsoft.PowerShell|--exact|--source|winget|--accept-package-agreements|--accept-source-agreements'
         }
 
         It 'passes the package source to winget upgrade commands' {
@@ -937,8 +937,8 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -All -CommandRunner $runner -Confirm:$false
 
-            $result.Upgraded | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source msstore --accept-package-agreements --accept-source-agreements' }).StreamOutput | Should -BeTrue
+            $result.Upgraded | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source msstore --accept-package-agreements --accept-source-agreements' }).StreamOutput | Should-BeTruthy
         }
 
         It 'passes interactive mode to winget upgrades' {
@@ -964,8 +964,8 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -All -Interactive -CommandRunner $runner -Confirm:$false
 
-            $result.Upgraded | Should -Be 1
-            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --interactive' }).StreamOutput | Should -BeTrue
+            $result.Upgraded | Should-Be 1
+            ($script:Invocations | Where-Object { $_.Key -eq 'winget upgrade --id Git.Git --exact --source winget --accept-package-agreements --accept-source-agreements --interactive' }).StreamOutput | Should-BeTruthy
         }
 
         It 'decodes winget uninstall command failures when streamed output is unavailable' {
@@ -993,14 +993,14 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = Upgrade-PlatformPackage -PackageManager winget -SkipRefresh -All -CommandRunner $runner -Confirm:$false -WarningAction SilentlyContinue
 
-            $result.Upgraded | Should -Be 0
-            $result.Failed | Should -Be 1
-            $result.Results[0].ExitCode | Should -Be -1978335184
-            $result.Results[0].Message | Should -Match '0x8A150030'
-            $result.Results[0].Message | Should -Match 'APPINSTALLER_CLI_ERROR_EXEC_UNINSTALL_COMMAND_FAILED'
-            $result.Results[0].Message | Should -Match 'Running uninstall command failed'
-            $result.Results[0].Message | Should -Match 'winget uninstall --id JohnMacFarlane\.Pandoc --exact --source winget'
-            $result.Results[0].Message | Should -Match 'winget install --id JohnMacFarlane\.Pandoc --exact --source winget'
+            $result.Upgraded | Should-Be 0
+            $result.Failed | Should-Be 1
+            $result.Results[0].ExitCode | Should-Be -1978335184
+            $result.Results[0].Message | Should-MatchString '0x8A150030'
+            $result.Results[0].Message | Should-MatchString 'APPINSTALLER_CLI_ERROR_EXEC_UNINSTALL_COMMAND_FAILED'
+            $result.Results[0].Message | Should-MatchString 'Running uninstall command failed'
+            $result.Results[0].Message | Should-MatchString 'winget uninstall --id JohnMacFarlane\.Pandoc --exact --source winget'
+            $result.Results[0].Message | Should-MatchString 'winget install --id JohnMacFarlane\.Pandoc --exact --source winget'
         }
     }
 
@@ -1033,8 +1033,8 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
 
             $result = @(Upgrade-PlatformPackage -PackageManager brew -SkipRefresh -NonInteractive -IncludePackage 'git*' -ExcludePackage 'git-lfs' -CommandRunner $runner)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'git'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'git'
         }
 
         It 'honors -WhatIf for refresh and upgrade commands' {
@@ -1056,13 +1056,13 @@ $result = Upgrade-PlatformPackage -PackageManager brew -CommandPathOverrides @{ 
             $result = Upgrade-PlatformPackage -PackageManager brew -All -WhatIf -CommandRunner $runner
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Selected | Should -Be 1
-            $result.NotSelected | Should -Be 0
-            $result.Upgraded | Should -Be 0
-            $result.Skipped | Should -Be 1
+            $result.Selected | Should-Be 1
+            $result.NotSelected | Should-Be 0
+            $result.Upgraded | Should-Be 0
+            $result.Skipped | Should-Be 1
 
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew update --quiet' }).Count | Should -Be 0
-            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should -Be 0
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew update --quiet' }).Count | Should-Be 0
+            @($script:Invocations | Where-Object { $_.Key -eq 'brew upgrade git' }).Count | Should-Be 0
         }
     }
 }

--- a/Tests/Unit/Utilities/Convert-LineEnding.Tests.ps1
+++ b/Tests/Unit/Utilities/Convert-LineEnding.Tests.ps1
@@ -43,19 +43,19 @@ Describe 'Convert-LineEnding' {
         It 'Should have optional Path parameter' {
             $command = Get-Command Convert-LineEnding
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Mandatory | Should -Not -Contain $true
+            $pathParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should have optional LineEnding parameter with default value' {
             $command = Get-Command Convert-LineEnding
             $lineEndingParam = $command.Parameters['LineEnding']
-            $lineEndingParam.Attributes.Mandatory | Should -Not -Contain $true
+            $lineEndingParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should validate LineEnding values' {
             $testFile = Join-Path -Path $script:TestDir -ChildPath 'validation-test.txt'
             'test' | Out-File -FilePath $testFile -NoNewline
-            { Convert-LineEnding -Path $testFile -LineEnding 'Invalid' -ErrorAction Stop } | Should -Throw
+            { Convert-LineEnding -Path $testFile -LineEnding 'Invalid' -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should accept valid LineEnding values' {
@@ -96,8 +96,8 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'LF'
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be "Line 1`nLine 2`nLine 3"
-            $result | Should -Not -Match "`r"
+            $result | Should-Be "Line 1`nLine 2`nLine 3"
+            $result | Should-NotMatchString "`r"
         }
 
         It 'Should correctly handle CRLF split across stream read boundary' {
@@ -110,10 +110,10 @@ Describe 'Convert-LineEnding' {
             $conversionResult = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -PassThru
             $result = [System.IO.File]::ReadAllText($script:TestFile, [System.Text.UTF8Encoding]::new($false))
 
-            $result | Should -Be ($prefix + "`n" + 'B')
-            $result | Should -Not -Match "`n`nB$"
-            $conversionResult.OriginalCRLF | Should -Be 1
-            $conversionResult.NewLF | Should -Be 1
+            $result | Should-Be ($prefix + "`n" + 'B')
+            $result | Should-NotMatchString "`n`nB$"
+            $conversionResult.OriginalCRLF | Should-Be 1
+            $conversionResult.NewLF | Should-Be 1
         }
 
         It 'Should convert LF to CRLF' {
@@ -124,8 +124,8 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'CRLF'
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be "Line 1`r`nLine 2`r`nLine 3"
-            ($result -split "`r`n").Count | Should -Be 3
+            $result | Should-Be "Line 1`r`nLine 2`r`nLine 3"
+            ($result -split "`r`n").Count | Should-Be 3
         }
 
         It 'Should handle mixed line endings' {
@@ -136,8 +136,8 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'LF'
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be "Line 1`nLine 2`nLine 3`nLine 4"
-            $result | Should -Not -Match "`r"
+            $result | Should-Be "Line 1`nLine 2`nLine 3`nLine 4"
+            $result | Should-NotMatchString "`r"
         }
 
         It 'Should handle empty files' {
@@ -148,7 +148,7 @@ Describe 'Convert-LineEnding' {
 
             # File should remain empty (or have only BOM if encoding requires it)
             $fileSize = (Get-Item $script:TestFile).Length
-            $fileSize | Should -BeLessOrEqual 3  # Allow for potential BOM
+            $fileSize | Should-BeLessThanOrEqual 3  # Allow for potential BOM
         }
 
         It 'Should handle files without line endings' {
@@ -158,7 +158,7 @@ Describe 'Convert-LineEnding' {
             { Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' } | Should -Not -Throw
 
             $result = Get-Content -Path $script:TestFile -Raw
-            $result | Should -Be 'Single line without newline'
+            $result | Should-Be 'Single line without newline'
         }
     }
 
@@ -181,7 +181,7 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'LF'
 
             $result = [System.IO.File]::ReadAllText($script:TestFile, [System.Text.Encoding]::UTF8)
-            $result | Should -Be "Test with UTF-8: café, naïve, résumé`n"
+            $result | Should-Be "Test with UTF-8: café, naïve, résumé`n"
         }
 
         It 'Should preserve UTF-8 with BOM' {
@@ -193,9 +193,9 @@ Describe 'Convert-LineEnding' {
 
             # Verify BOM is still present
             $bytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $bytes[0] | Should -Be 0xEF
-            $bytes[1] | Should -Be 0xBB
-            $bytes[2] | Should -Be 0xBF
+            $bytes[0] | Should-Be 0xEF
+            $bytes[1] | Should-Be 0xBB
+            $bytes[2] | Should-Be 0xBF
         }
 
         It 'Should preserve UTF-8 without BOM' {
@@ -205,17 +205,17 @@ Describe 'Convert-LineEnding' {
 
             # Verify original file has no BOM
             $originalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $originalBytes[0] | Should -Not -Be 0xEF
+            $originalBytes[0] | Should-NotBe 0xEF
 
             Convert-LineEnding -Path $script:TestFile -LineEnding 'CRLF'
 
             # Verify BOM is still NOT present after conversion
             $convertedBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $convertedBytes[0] | Should -Not -Be 0xEF
+            $convertedBytes[0] | Should-NotBe 0xEF
 
             # Verify content is correct
             $result = [System.IO.File]::ReadAllText($script:TestFile, $utf8NoBom)
-            $result | Should -Be "Test UTF-8 without BOM: café, naïve`r`n"
+            $result | Should-Be "Test UTF-8 without BOM: café, naïve`r`n"
         }
 
         It 'Should preserve ASCII encoding' {
@@ -225,7 +225,7 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'LF'
 
             $result = [System.IO.File]::ReadAllText($script:TestFile, [System.Text.Encoding]::ASCII)
-            $result | Should -Be "Simple ASCII text`n"
+            $result | Should-Be "Simple ASCII text`n"
         }
     }
 
@@ -246,14 +246,14 @@ Describe 'Convert-LineEnding' {
             $encodingParam = $command.Parameters['Encoding']
             $validEncodings = $encodingParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } | Select-Object -ExpandProperty ValidValues
 
-            $validEncodings | Should -Contain 'UTF8'
-            $validEncodings | Should -Contain 'UTF8BOM'
-            $validEncodings | Should -Contain 'UTF16LE'
-            $validEncodings | Should -Contain 'UTF16BE'
-            $validEncodings | Should -Contain 'UTF32'
-            $validEncodings | Should -Contain 'UTF32BE'
-            $validEncodings | Should -Contain 'ASCII'
-            $validEncodings | Should -Contain 'ANSI'
+            $validEncodings | Should-ContainCollection 'UTF8'
+            $validEncodings | Should-ContainCollection 'UTF8BOM'
+            $validEncodings | Should-ContainCollection 'UTF16LE'
+            $validEncodings | Should-ContainCollection 'UTF16BE'
+            $validEncodings | Should-ContainCollection 'UTF32'
+            $validEncodings | Should-ContainCollection 'UTF32BE'
+            $validEncodings | Should-ContainCollection 'ASCII'
+            $validEncodings | Should-ContainCollection 'ANSI'
         }
 
         It 'Should convert UTF8 to UTF8BOM' {
@@ -263,20 +263,20 @@ Describe 'Convert-LineEnding' {
 
             # Verify original has no BOM and CRLF
             $originalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $originalBytes[0] | Should -Not -Be 0xEF
+            $originalBytes[0] | Should-NotBe 0xEF
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8BOM' -PassThru
 
             # Verify conversion occurred
-            $result.SourceEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.TargetEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.EncodingChanged | Should -Be $true
+            $result.SourceEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.TargetEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.EncodingChanged | Should-Be $true
 
             # Verify BOM was added
             $convertedBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $convertedBytes[0] | Should -Be 0xEF
-            $convertedBytes[1] | Should -Be 0xBB
-            $convertedBytes[2] | Should -Be 0xBF
+            $convertedBytes[0] | Should-Be 0xEF
+            $convertedBytes[1] | Should-Be 0xBB
+            $convertedBytes[2] | Should-Be 0xBF
         }
 
         It 'Should convert UTF8BOM to UTF8' {
@@ -286,18 +286,18 @@ Describe 'Convert-LineEnding' {
 
             # Verify original has BOM and CRLF
             $originalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $originalBytes[0] | Should -Be 0xEF
+            $originalBytes[0] | Should-Be 0xEF
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8' -PassThru
 
             # Verify conversion occurred
-            $result.SourceEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.TargetEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.EncodingChanged | Should -Be $true
+            $result.SourceEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.TargetEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.EncodingChanged | Should-Be $true
 
             # Verify BOM was removed
             $convertedBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $convertedBytes[0] | Should -Not -Be 0xEF
+            $convertedBytes[0] | Should-NotBe 0xEF
         }
 
         It 'Should convert UTF8 to UTF16LE' {
@@ -308,18 +308,18 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF16LE' -PassThru
 
             # Verify conversion occurred
-            $result.SourceEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.TargetEncoding | Should -Be 'Unicode'
-            $result.EncodingChanged | Should -Be $true
+            $result.SourceEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.TargetEncoding | Should-Be 'Unicode'
+            $result.EncodingChanged | Should-Be $true
 
             # Verify UTF16LE BOM
             $convertedBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $convertedBytes[0] | Should -Be 0xFF
-            $convertedBytes[1] | Should -Be 0xFE
+            $convertedBytes[0] | Should-Be 0xFF
+            $convertedBytes[1] | Should-Be 0xFE
 
             # Verify content can be read correctly
             $readContent = [System.IO.File]::ReadAllText($script:TestFile, [System.Text.Encoding]::Unicode)
-            $readContent | Should -Be "Test UTF16: café`n"
+            $readContent | Should-Be "Test UTF16: café`n"
         }
 
         It 'Should convert UTF8 to ASCII (with special character replacement)' {
@@ -330,13 +330,13 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'ASCII' -PassThru
 
             # Verify conversion occurred
-            $result.SourceEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.TargetEncoding | Should -Be 'US-ASCII'
-            $result.EncodingChanged | Should -Be $true
+            $result.SourceEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.TargetEncoding | Should-Be 'US-ASCII'
+            $result.EncodingChanged | Should-Be $true
 
             # Verify content
             $readContent = [System.IO.File]::ReadAllText($script:TestFile, [System.Text.Encoding]::ASCII)
-            $readContent | Should -Be "Test ASCII: hello world`n"
+            $readContent | Should-Be "Test ASCII: hello world`n"
         }
 
         It 'Should not convert when target encoding matches source encoding' {
@@ -347,11 +347,11 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8' -PassThru
 
             # Verify line ending conversion occurred but no encoding conversion
-            $result.SourceEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.TargetEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.EncodingChanged | Should -Be $false
-            $result.OriginalCRLF | Should -Be 1
-            $result.NewLF | Should -Be 1
+            $result.SourceEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.TargetEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.EncodingChanged | Should-Be $false
+            $result.OriginalCRLF | Should-Be 1
+            $result.NewLF | Should-Be 1
         }
 
         It 'Should convert only encoding when line endings are already correct (legacy behavior)' {
@@ -361,18 +361,18 @@ Describe 'Convert-LineEnding' {
 
             # Verify original has no BOM
             $originalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $originalBytes[0] | Should -Not -Be 0xEF
+            $originalBytes[0] | Should-NotBe 0xEF
 
             # This should convert encoding even though line endings are already correct
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8BOM' -PassThru
 
             # Should NOT be skipped and should convert encoding
-            $result.Skipped | Should -Be $false
-            $result.EncodingChanged | Should -Be $true
+            $result.Skipped | Should-Be $false
+            $result.EncodingChanged | Should-Be $true
 
             # Verify BOM was added
             $finalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $finalBytes[0] | Should -Be 0xEF
+            $finalBytes[0] | Should-Be 0xEF
         }
 
         It 'Should convert only encoding when line endings are already correct' {
@@ -382,27 +382,27 @@ Describe 'Convert-LineEnding' {
 
             # Verify original has no BOM
             $originalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $originalBytes[0] | Should -Not -Be 0xEF
+            $originalBytes[0] | Should-NotBe 0xEF
 
             # This should convert encoding but not line endings since they're already correct
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8BOM' -PassThru
 
             # Should NOT be skipped and should convert encoding
-            $result.Skipped | Should -Be $false
-            $result.EncodingChanged | Should -Be $true
-            $result.SourceEncoding | Should -Be 'Unicode (UTF-8)'
-            $result.TargetEncoding | Should -Be 'Unicode (UTF-8)'
+            $result.Skipped | Should-Be $false
+            $result.EncodingChanged | Should-Be $true
+            $result.SourceEncoding | Should-Be 'Unicode (UTF-8)'
+            $result.TargetEncoding | Should-Be 'Unicode (UTF-8)'
 
             # Verify BOM was added
             $finalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $finalBytes[0] | Should -Be 0xEF
-            $finalBytes[1] | Should -Be 0xBB
-            $finalBytes[2] | Should -Be 0xBF
+            $finalBytes[0] | Should-Be 0xEF
+            $finalBytes[1] | Should-Be 0xBB
+            $finalBytes[2] | Should-Be 0xBF
 
             # Verify content is still correct
             $finalContent = [System.IO.File]::ReadAllText($script:TestFile)
-            $finalContent | Should -Be "Test content`n"
-            $finalContent | Should -Not -Match "`r"
+            $finalContent | Should-Be "Test content`n"
+            $finalContent | Should-NotMatchString "`r"
         }
 
         It 'Should convert only line endings when encoding is already correct' {
@@ -412,29 +412,29 @@ Describe 'Convert-LineEnding' {
 
             # Verify original has BOM and CRLF
             $originalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $originalBytes[0] | Should -Be 0xEF
+            $originalBytes[0] | Should-Be 0xEF
             $originalContent = [System.IO.File]::ReadAllText($script:TestFile)
-            $originalContent | Should -Match "`r`n"
+            $originalContent | Should-MatchString "`r`n"
 
             # This should convert line endings but not encoding since it's already correct
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8BOM' -PassThru
 
             # Should NOT be skipped and should convert line endings but not encoding
-            $result.Skipped | Should -Be $false
-            $result.EncodingChanged | Should -Be $false
-            $result.OriginalCRLF | Should -Be 1
-            $result.NewLF | Should -Be 1
+            $result.Skipped | Should-Be $false
+            $result.EncodingChanged | Should-Be $false
+            $result.OriginalCRLF | Should-Be 1
+            $result.NewLF | Should-Be 1
 
             # Verify BOM is still present
             $finalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $finalBytes[0] | Should -Be 0xEF
-            $finalBytes[1] | Should -Be 0xBB
-            $finalBytes[2] | Should -Be 0xBF
+            $finalBytes[0] | Should-Be 0xEF
+            $finalBytes[1] | Should-Be 0xBB
+            $finalBytes[2] | Should-Be 0xBF
 
             # Verify line endings were converted
             $finalContent = [System.IO.File]::ReadAllText($script:TestFile)
-            $finalContent | Should -Be "Test content`n"
-            $finalContent | Should -Not -Match "`r"
+            $finalContent | Should-Be "Test content`n"
+            $finalContent | Should-NotMatchString "`r"
         }
 
         It 'Should skip file entirely when both line endings and encoding are already correct' {
@@ -444,23 +444,23 @@ Describe 'Convert-LineEnding' {
 
             # Verify original has BOM and LF
             $originalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $originalBytes[0] | Should -Be 0xEF
+            $originalBytes[0] | Should-Be 0xEF
 
             # This should skip the file entirely since both line endings and encoding are correct
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8BOM' -PassThru
 
             # Should return a skipped result
-            $result.Skipped | Should -Be $true
-            $result.EncodingChanged | Should -Be $false
+            $result.Skipped | Should-Be $true
+            $result.EncodingChanged | Should-Be $false
 
             # Verify file is unchanged
             $finalBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $finalBytes[0] | Should -Be 0xEF
-            $finalBytes[1] | Should -Be 0xBB
-            $finalBytes[2] | Should -Be 0xBF
+            $finalBytes[0] | Should-Be 0xEF
+            $finalBytes[1] | Should-Be 0xBB
+            $finalBytes[2] | Should-Be 0xBF
 
             $finalContent = [System.IO.File]::ReadAllText($script:TestFile)
-            $finalContent | Should -Be "Test content`n"
+            $finalContent | Should-Be "Test content`n"
         }
 
         It 'Should work with cross-platform encoding names' -Skip:($PSVersionTable.PSVersion.Major -lt 6 -and $IsWindows -eq $false) {
@@ -485,22 +485,22 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF32' -PassThru
 
             # Verify conversion occurred
-            $result.EncodingChanged | Should -BeTrue
-            $result.Converted | Should -BeTrue
-            $result.SourceEncoding | Should -Match 'UTF-8'
-            $result.TargetEncoding | Should -Match 'UTF-32'
+            $result.EncodingChanged | Should-BeTruthy
+            $result.Converted | Should-BeTruthy
+            $result.SourceEncoding | Should-MatchString 'UTF-8'
+            $result.TargetEncoding | Should-MatchString 'UTF-32'
 
             # Verify UTF-32 LE BOM is present (FF FE 00 00)
             $bytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $bytes[0] | Should -Be 0xFF
-            $bytes[1] | Should -Be 0xFE
-            $bytes[2] | Should -Be 0x00
-            $bytes[3] | Should -Be 0x00
+            $bytes[0] | Should-Be 0xFF
+            $bytes[1] | Should-Be 0xFE
+            $bytes[2] | Should-Be 0x00
+            $bytes[3] | Should-Be 0x00
 
             # Verify content with UTF-32 LE encoding
             $utf32LE = [System.Text.Encoding]::UTF32
             $resultContent = [System.IO.File]::ReadAllText($script:TestFile, $utf32LE)
-            $resultContent | Should -Be "Unicode test: 🚀 café`n"
+            $resultContent | Should-Be "Unicode test: 🚀 café`n"
         }
 
         It 'Should convert UTF8 to UTF32BE' {
@@ -511,22 +511,22 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF32BE' -PassThru
 
             # Verify conversion occurred
-            $result.EncodingChanged | Should -BeTrue
-            $result.Converted | Should -BeTrue
-            $result.SourceEncoding | Should -Match 'UTF-8'
-            $result.TargetEncoding | Should -Match 'UTF-32'
+            $result.EncodingChanged | Should-BeTruthy
+            $result.Converted | Should-BeTruthy
+            $result.SourceEncoding | Should-MatchString 'UTF-8'
+            $result.TargetEncoding | Should-MatchString 'UTF-32'
 
             # Verify UTF-32 BE BOM is present (00 00 FE FF)
             $bytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $bytes[0] | Should -Be 0x00
-            $bytes[1] | Should -Be 0x00
-            $bytes[2] | Should -Be 0xFE
-            $bytes[3] | Should -Be 0xFF
+            $bytes[0] | Should-Be 0x00
+            $bytes[1] | Should-Be 0x00
+            $bytes[2] | Should-Be 0xFE
+            $bytes[3] | Should-Be 0xFF
 
             # Verify content with UTF-32 BE encoding
             $utf32BE = [System.Text.Encoding]::GetEncoding('utf-32BE')
             $resultContent = [System.IO.File]::ReadAllText($script:TestFile, $utf32BE)
-            $resultContent | Should -Be "Unicode test: 🚀 café`n"
+            $resultContent | Should-Be "Unicode test: 🚀 café`n"
         }
 
         It 'Should convert UTF8 to ANSI' {
@@ -537,14 +537,14 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'ANSI' -PassThru
 
             # Verify conversion occurred
-            $result.EncodingChanged | Should -BeTrue
-            $result.Converted | Should -BeTrue
-            $result.SourceEncoding | Should -Match 'UTF-8'
+            $result.EncodingChanged | Should-BeTruthy
+            $result.Converted | Should-BeTruthy
+            $result.SourceEncoding | Should-MatchString 'UTF-8'
 
             # Verify content with system default encoding
             $ansiEncoding = [System.Text.Encoding]::Default
             $resultContent = [System.IO.File]::ReadAllText($script:TestFile, $ansiEncoding)
-            $resultContent | Should -Be "ASCII content only`n"
+            $resultContent | Should-Be "ASCII content only`n"
         }
 
         It 'Should detect UTF-32 LE BOM correctly' {
@@ -555,25 +555,25 @@ Describe 'Convert-LineEnding' {
 
             # Verify BOM is present
             $bytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $bytes[0] | Should -Be 0xFF
-            $bytes[1] | Should -Be 0xFE
-            $bytes[2] | Should -Be 0x00
-            $bytes[3] | Should -Be 0x00
+            $bytes[0] | Should-Be 0xFF
+            $bytes[1] | Should-Be 0xFE
+            $bytes[2] | Should-Be 0x00
+            $bytes[3] | Should-Be 0x00
 
             # Convert to CRLF (no encoding change, so should preserve UTF-32 LE)
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'CRLF' -PassThru
 
             # Should not change encoding since we're not specifying -Encoding
-            $result.EncodingChanged | Should -BeFalse
-            $result.Converted | Should -BeTrue
-            $result.TargetEncoding | Should -Match 'UTF-32'
+            $result.EncodingChanged | Should-BeFalsy
+            $result.Converted | Should-BeTruthy
+            $result.TargetEncoding | Should-MatchString 'UTF-32'
 
             # Verify UTF-32 LE BOM is still present
             $newBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $newBytes[0] | Should -Be 0xFF
-            $newBytes[1] | Should -Be 0xFE
-            $newBytes[2] | Should -Be 0x00
-            $newBytes[3] | Should -Be 0x00
+            $newBytes[0] | Should-Be 0xFF
+            $newBytes[1] | Should-Be 0xFE
+            $newBytes[2] | Should-Be 0x00
+            $newBytes[3] | Should-Be 0x00
         }
 
         It 'Should detect UTF-32 BE BOM correctly' {
@@ -584,25 +584,25 @@ Describe 'Convert-LineEnding' {
 
             # Verify BOM is present
             $bytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $bytes[0] | Should -Be 0x00
-            $bytes[1] | Should -Be 0x00
-            $bytes[2] | Should -Be 0xFE
-            $bytes[3] | Should -Be 0xFF
+            $bytes[0] | Should-Be 0x00
+            $bytes[1] | Should-Be 0x00
+            $bytes[2] | Should-Be 0xFE
+            $bytes[3] | Should-Be 0xFF
 
             # Convert to CRLF (no encoding change, so should preserve UTF-32 BE)
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'CRLF' -PassThru
 
             # Should not change encoding since we're not specifying -Encoding
-            $result.EncodingChanged | Should -BeFalse
-            $result.Converted | Should -BeTrue
-            $result.TargetEncoding | Should -Match 'UTF-32'
+            $result.EncodingChanged | Should-BeFalsy
+            $result.Converted | Should-BeTruthy
+            $result.TargetEncoding | Should-MatchString 'UTF-32'
 
             # Verify UTF-32 BE BOM is still present
             $newBytes = [System.IO.File]::ReadAllBytes($script:TestFile)
-            $newBytes[0] | Should -Be 0x00
-            $newBytes[1] | Should -Be 0x00
-            $newBytes[2] | Should -Be 0xFE
-            $newBytes[3] | Should -Be 0xFF
+            $newBytes[0] | Should-Be 0x00
+            $newBytes[1] | Should-Be 0x00
+            $newBytes[2] | Should-Be 0xFE
+            $newBytes[3] | Should-Be 0xFF
         }
 
         It 'Should distinguish UTF-32 LE from UTF-16 LE BOM' {
@@ -619,12 +619,12 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'CRLF' -PassThru
 
             # Should preserve as UTF-32, not mistakenly convert to UTF-16
-            $result.TargetEncoding | Should -Match 'UTF-32'
-            $result.TargetEncoding | Should -Not -Match 'UTF-16'
+            $result.TargetEncoding | Should-MatchString 'UTF-32'
+            $result.TargetEncoding | Should-NotMatchString 'UTF-16'
 
             # Content should be readable with UTF-32 LE encoding
             $resultContent = [System.IO.File]::ReadAllText($script:TestFile, $utf32LE)
-            $resultContent | Should -Be "BOM order test`r`n"
+            $resultContent | Should-Be "BOM order test`r`n"
         }
     }
 
@@ -657,10 +657,10 @@ Describe 'Convert-LineEnding' {
 
             # Files should remain unchanged
             $imageContent = Get-Content -Path $script:ImageFile -Raw
-            $imageContent | Should -Be 'fake content'
+            $imageContent | Should-Be 'fake content'
 
             $exeContent = Get-Content -Path $script:ExecutableFile -Raw
-            $exeContent | Should -Be 'fake content'
+            $exeContent | Should-Be 'fake content'
         }
 
         It 'Should detect additional binary extensions (WASM)' {
@@ -669,7 +669,7 @@ Describe 'Convert-LineEnding' {
             { Convert-LineEnding -Path $script:WasmFile -LineEnding 'LF' } | Should -Not -Throw
 
             $wasmContent = Get-Content -Path $script:WasmFile -Raw
-            $wasmContent | Should -Match "`r"
+            $wasmContent | Should-MatchString "`r"
         }
 
         It 'Should detect binary files by content (null bytes)' {
@@ -746,10 +746,10 @@ Describe 'Convert-LineEnding' {
 
             # Check that text files were converted
             $result1 = Get-Content -Path (Join-Path -Path $script:TestDir -ChildPath 'test1.txt') -Raw
-            $result1 | Should -Not -Match "`r"
+            $result1 | Should-NotMatchString "`r"
 
             $result2 = Get-Content -Path (Join-Path -Path $script:TestDir -ChildPath 'test1.ps1') -Raw
-            $result2 | Should -Not -Match "`r"
+            $result2 | Should-NotMatchString "`r"
         }
 
         It 'Should process recursively when Recurse is specified' {
@@ -757,7 +757,7 @@ Describe 'Convert-LineEnding' {
 
             # Check that file in subdirectory was also converted
             $result = Get-Content -Path (Join-Path -Path $script:SubDir -ChildPath 'test2.txt') -Raw
-            $result | Should -Not -Match "`r"
+            $result | Should-NotMatchString "`r"
         }
 
         It 'Should not process recursively when Recurse is not specified' {
@@ -765,7 +765,7 @@ Describe 'Convert-LineEnding' {
 
             # File in subdirectory should not be processed (still has CRLF)
             $result = Get-Content -Path (Join-Path -Path $script:SubDir -ChildPath 'test2.txt') -Raw
-            $result | Should -Match "`r"
+            $result | Should-MatchString "`r"
         }
 
         It 'Should respect Include patterns' {
@@ -773,11 +773,11 @@ Describe 'Convert-LineEnding' {
 
             # Only .ps1 file should be converted
             $ps1Result = Get-Content -Path (Join-Path -Path $script:TestDir -ChildPath 'test1.ps1') -Raw
-            $ps1Result | Should -Not -Match "`r"
+            $ps1Result | Should-NotMatchString "`r"
 
             # .txt file should not be converted
             $txtResult = Get-Content -Path (Join-Path -Path $script:TestDir -ChildPath 'test1.txt') -Raw
-            $txtResult | Should -Match "`r"
+            $txtResult | Should-MatchString "`r"
         }
 
         It 'Should respect Exclude patterns' {
@@ -785,26 +785,26 @@ Describe 'Convert-LineEnding' {
 
             # .ps1 file should be converted
             $ps1Result = Get-Content -Path (Join-Path -Path $script:TestDir -ChildPath 'test1.ps1') -Raw
-            $ps1Result | Should -Not -Match "`r"
+            $ps1Result | Should-NotMatchString "`r"
 
             # .txt file should not be converted (excluded)
             $txtResult = Get-Content -Path (Join-Path -Path $script:TestDir -ChildPath 'test1.txt') -Raw
-            $txtResult | Should -Match "`r"
+            $txtResult | Should-MatchString "`r"
         }
 
         It 'Should include .env.* files by default' {
             Convert-LineEnding -Path $script:TestDir -LineEnding 'LF'
 
             $envResult = Get-Content -Path (Join-Path -Path $script:TestDir -ChildPath '.env.local') -Raw
-            $envResult | Should -Not -Match "`r"
-            $envResult | Should -Be "KEY=value`n"
+            $envResult | Should-NotMatchString "`r"
+            $envResult | Should-Be "KEY=value`n"
         }
 
         It 'Should exclude .idea directory by default' {
             Convert-LineEnding -Path $script:TestDir -LineEnding 'LF' -Recurse
 
             $ideaResult = Get-Content -Path (Join-Path -Path $script:IdeaDir -ChildPath 'workspace.xml') -Raw
-            $ideaResult | Should -Match "`r"
+            $ideaResult | Should-MatchString "`r"
         }
     }
 
@@ -827,8 +827,8 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -WhatIf
 
             $currentContent = Get-Content -Path $script:TestFile -Raw
-            $currentContent | Should -Be $originalContent
-            $currentContent | Should -Match "`r"  # Should still have CRLF
+            $currentContent | Should-Be $originalContent
+            $currentContent | Should-MatchString "`r"  # Should still have CRLF
         }
 
         It 'Should show what would be processed when WhatIf is specified' {
@@ -837,7 +837,7 @@ Describe 'Convert-LineEnding' {
 
             # Verify file was not actually modified (this is the key test)
             $content = Get-Content -Path $script:TestFile -Raw
-            $content | Should -Match "`r"  # Should still have CRLF
+            $content | Should-MatchString "`r"  # Should still have CRLF
         }
     }
 
@@ -858,8 +858,8 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.FilePath | Should -Be $script:TestFile
-            $result.Success | Should -Be $true
+            $result.FilePath | Should-Be $script:TestFile
+            $result.Success | Should-Be $true
             $result.SourceEncoding | Should -Not -BeNullOrEmpty
             $result.TargetEncoding | Should -Not -BeNullOrEmpty
         }
@@ -868,8 +868,8 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'CRLF' -PassThru
 
             # Should have counts of original and new line endings
-            ($result.OriginalLF + $result.OriginalCRLF) | Should -BeGreaterThan 0
-            ($result.NewLF + $result.NewCRLF) | Should -BeGreaterThan 0
+            ($result.OriginalLF + $result.OriginalCRLF) | Should-BeGreaterThan 0
+            ($result.NewLF + $result.NewCRLF) | Should-BeGreaterThan 0
         }
 
         It 'Should not return anything when PassThru is not specified' {
@@ -886,7 +886,7 @@ Describe 'Convert-LineEnding' {
             $errorMessages = @()
             Convert-LineEnding -Path $nonExistentFile -LineEnding 'LF' -ErrorVariable errorMessages -ErrorAction SilentlyContinue
             $errorMessages | Should -Not -BeNullOrEmpty
-            $errorMessages[0] | Should -Match 'Path not found'
+            ($errorMessages[0] | Out-String) | Should-MatchString 'Path not found'
         }
 
         It 'Should handle read-only files when Force is not specified' {
@@ -898,8 +898,8 @@ Describe 'Convert-LineEnding' {
                 Set-ItemProperty -Path $script:ReadOnlyFile -Name IsReadOnly -Value $true
 
                 $result = Convert-LineEnding -Path $script:ReadOnlyFile -LineEnding 'LF' -PassThru -ErrorAction SilentlyContinue
-                $result.Success | Should -Be $false
-                $result.Error | Should -Match 'read-only'
+                $result.Success | Should-Be $false
+                $result.Error | Should-MatchString 'read-only'
             }
             finally
             {
@@ -921,11 +921,11 @@ Describe 'Convert-LineEnding' {
                 Set-ItemProperty -Path $script:ReadOnlyFile -Name IsReadOnly -Value $true
 
                 $result = Convert-LineEnding -Path $script:ReadOnlyFile -LineEnding 'LF' -Force -PassThru
-                $result.Success | Should -Be $true
+                $result.Success | Should-Be $true
 
                 # Verify conversion worked
                 $content = Get-Content -Path $script:ReadOnlyFile -Raw
-                $content | Should -Not -Match "`r"
+                $content | Should-NotMatchString "`r"
             }
             finally
             {
@@ -967,7 +967,7 @@ Describe 'Convert-LineEnding' {
             foreach ($file in $script:PipelineFiles)
             {
                 $content = Get-Content -Path $file -Raw
-                $content | Should -Not -Match "`r"
+                $content | Should-NotMatchString "`r"
             }
         }
 
@@ -978,7 +978,7 @@ Describe 'Convert-LineEnding' {
             foreach ($file in $script:PipelineFiles)
             {
                 $content = Get-Content -Path $file -Raw
-                $content | Should -Not -Match "`r"
+                $content | Should-NotMatchString "`r"
             }
         }
     }
@@ -997,8 +997,8 @@ Describe 'Convert-LineEnding' {
 
         It 'Should have EnsureEndingNewline parameter' {
             $command = Get-Command Convert-LineEnding
-            $command.Parameters.Keys | Should -Contain 'EnsureEndingNewline'
-            $command.Parameters['EnsureEndingNewline'].ParameterType | Should -Be ([Switch])
+            $command.Parameters.Keys | Should-ContainCollection 'EnsureEndingNewline'
+            $command.Parameters['EnsureEndingNewline'].ParameterType | Should-Be ([Switch])
         }
 
         It 'Should add ending newline to file without one' {
@@ -1010,8 +1010,8 @@ Describe 'Convert-LineEnding' {
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
             $expectedContent = 'Line 1' + [char]10 + 'Line 2 without newline' + [char]10
-            $result | Should -Be $expectedContent
-            $result | Should -Match ([char]10 + '$')
+            $result | Should-Be $expectedContent
+            $result | Should-MatchString ([char]10 + '$')
         }
 
         It 'Should not modify file that already ends with newline' {
@@ -1025,8 +1025,8 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be "Line 1`nLine 2`n"
-            $result | Should -Match "`n$"
+            $result | Should-Be "Line 1`nLine 2`n"
+            $result | Should-MatchString "`n$"
         }
 
         It 'Should add CRLF ending when LineEnding is CRLF' {
@@ -1036,8 +1036,8 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'CRLF' -EnsureEndingNewline
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be "Test content`r`n"
-            $result | Should -Match "`r`n$"
+            $result | Should-Be "Test content`r`n"
+            $result | Should-MatchString "`r`n$"
         }
 
         It 'Should add LF ending when LineEnding is LF' {
@@ -1047,9 +1047,9 @@ Describe 'Convert-LineEnding' {
             Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be "Test content`n"
-            $result | Should -Match "`n$"
-            $result | Should -Not -Match "`r"
+            $result | Should-Be "Test content`n"
+            $result | Should-MatchString "`n$"
+            $result | Should-NotMatchString "`r"
         }
 
         It 'Should handle empty files correctly' {
@@ -1060,7 +1060,7 @@ Describe 'Convert-LineEnding' {
 
             # Empty files should get a newline added when EnsureEndingNewline is specified
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be ([char]10)
+            $result | Should-Be ([char]10)
         }
 
         It 'Should work with PassThru parameter' {
@@ -1069,9 +1069,9 @@ Describe 'Convert-LineEnding' {
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline -PassThru
 
-            $result.EndingNewlineAdded | Should -Be $true
-            $result.Success | Should -Be $true
-            $result.NewLF | Should -Be 1
+            $result.EndingNewlineAdded | Should-Be $true
+            $result.Success | Should-Be $true
+            $result.NewLF | Should-Be 1
         }
 
         It 'Should report EndingNewlineAdded as false when newline already exists' {
@@ -1081,8 +1081,8 @@ Describe 'Convert-LineEnding' {
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline -PassThru
 
-            $result.EndingNewlineAdded | Should -Be $false
-            $result.Success | Should -Be $true
+            $result.EndingNewlineAdded | Should-Be $false
+            $result.Success | Should-Be $true
         }
 
         It 'Should work with WhatIf parameter' {
@@ -1093,7 +1093,7 @@ Describe 'Convert-LineEnding' {
             { Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline -WhatIf } | Should -Not -Throw
 
             $result = [System.IO.File]::ReadAllText($script:TestFile)
-            $result | Should -Be 'Test content'  # Should be unchanged
+            $result | Should-Be 'Test content'  # Should be unchanged
         }
 
         It 'Should work when only ending newline is needed (no line ending conversion)' {
@@ -1103,12 +1103,12 @@ Describe 'Convert-LineEnding' {
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline -PassThru
 
-            $result.EndingNewlineAdded | Should -Be $true
-            $result.Success | Should -Be $true
-            $result.NewLF | Should -Be 2  # 1 original + 1 added
+            $result.EndingNewlineAdded | Should-Be $true
+            $result.Success | Should-Be $true
+            $result.NewLF | Should-Be 2  # 1 original + 1 added
 
             $content = [System.IO.File]::ReadAllText($script:TestFile)
-            $content | Should -Be "Line 1`nLine 2 no ending`n"
+            $content | Should-Be "Line 1`nLine 2 no ending`n"
         }
 
         It 'Should work when only ending newline is needed (no encoding conversion)' {
@@ -1119,12 +1119,12 @@ Describe 'Convert-LineEnding' {
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -Encoding 'UTF8' -EnsureEndingNewline -PassThru
 
-            $result.EndingNewlineAdded | Should -Be $true
-            $result.EncodingChanged | Should -Be $false
-            $result.Success | Should -Be $true
+            $result.EndingNewlineAdded | Should-Be $true
+            $result.EncodingChanged | Should-Be $false
+            $result.Success | Should-Be $true
 
             $content = [System.IO.File]::ReadAllText($script:TestFile)
-            $content | Should -Be "Test content`n"
+            $content | Should-Be "Test content`n"
         }
 
         It 'Should work with complex content including line endings within text' {
@@ -1134,11 +1134,11 @@ Describe 'Convert-LineEnding' {
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline -PassThru
 
-            $result.EndingNewlineAdded | Should -Be $true
-            $result.Success | Should -Be $true
+            $result.EndingNewlineAdded | Should-Be $true
+            $result.Success | Should-Be $true
 
             $finalContent = [System.IO.File]::ReadAllText($script:TestFile)
-            $finalContent | Should -Be "Line 1`nLine 2`nLine 3 without ending`n"
+            $finalContent | Should-Be "Line 1`nLine 2`nLine 3 without ending`n"
         }
 
         It 'Should handle files with only whitespace content' {
@@ -1148,12 +1148,12 @@ Describe 'Convert-LineEnding' {
 
             $result = Convert-LineEnding -Path $script:TestFile -LineEnding 'LF' -EnsureEndingNewline -PassThru
 
-            $result.EndingNewlineAdded | Should -Be $true
-            $result.Success | Should -Be $true
+            $result.EndingNewlineAdded | Should-Be $true
+            $result.Success | Should-Be $true
 
             $finalContent = [System.IO.File]::ReadAllText($script:TestFile)
             $expectedContent = $whitespaceContent + [char]10
-            $finalContent | Should -Be $expectedContent
+            $finalContent | Should-Be $expectedContent
         }
     }
 
@@ -1189,17 +1189,17 @@ Describe 'Convert-LineEnding' {
             if ($script:IsWindowsPlatform)
             {
                 # On Windows, Auto should resolve to CRLF, so no conversion needed
-                $result.LineEnding | Should -Be 'CRLF'
+                $result.LineEnding | Should-Be 'CRLF'
                 $finalContent = [System.IO.File]::ReadAllText($script:TestFile)
-                $finalContent | Should -Match "`r`n"
+                $finalContent | Should-MatchString "`r`n"
             }
             else
             {
                 # On Unix/Linux/macOS, Auto should resolve to LF, so conversion needed
-                $result.LineEnding | Should -Be 'LF'
-                $result.Converted | Should -Be $true
+                $result.LineEnding | Should-Be 'LF'
+                $result.Converted | Should-Be $true
                 $finalContent = [System.IO.File]::ReadAllText($script:TestFile)
-                $finalContent | Should -Not -Match "`r"
+                $finalContent | Should-NotMatchString "`r"
             }
         }
 
@@ -1212,7 +1212,7 @@ Describe 'Convert-LineEnding' {
             $result = Convert-LineEnding -Path $script:TestFile -PassThru
 
             # Should have processed the file (not skipped)
-            $result.Skipped | Should -Be $false
+            $result.Skipped | Should-Be $false
 
             # Platform detection logic
             if ($PSVersionTable.PSVersion.Major -lt 6)
@@ -1226,11 +1226,11 @@ Describe 'Convert-LineEnding' {
 
             if ($script:IsWindowsPlatform)
             {
-                $result.LineEnding | Should -Be 'CRLF'
+                $result.LineEnding | Should-Be 'CRLF'
             }
             else
             {
-                $result.LineEnding | Should -Be 'LF'
+                $result.LineEnding | Should-Be 'LF'
             }
         }
 
@@ -1281,11 +1281,11 @@ Describe 'Convert-LineEnding' {
             $fileInfoAfter = Get-Item $script:TestFile
             $writeDiff = ($fileInfoAfter.LastWriteTime - $pastTime).TotalSeconds
 
-            $writeDiff | Should -BeGreaterThan 1 -Because 'Last write time should be updated by default (no -PreserveTimestamps)'
+            $writeDiff | Should-BeGreaterThan 1 -Because 'Last write time should be updated by default (no -PreserveTimestamps)'
 
             # Verify content was actually converted
             $newContent = Get-Content -Path $script:TestFile -Raw
-            $newContent | Should -Be "line1`nline2`nline3`n"
+            $newContent | Should-Be "line1`nline2`nline3`n"
         }
 
         It 'Should preserve timestamps when PreserveTimestamps switch is specified' {
@@ -1309,8 +1309,8 @@ Describe 'Convert-LineEnding' {
 
             # Use platform-appropriate tolerance: Windows NTFS can have different precision than APFS/ext4
             $tolerance = if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) { 2 } else { 0.1 }
-            $creationDiff | Should -BeLessThan $tolerance -Because 'Creation time should be preserved (filesystem precision varies by platform)'
-            $writeDiff | Should -BeLessThan $tolerance -Because 'Last write time should be preserved (filesystem precision varies by platform)'
+            $creationDiff | Should-BeLessThan $tolerance -Because 'Creation time should be preserved (filesystem precision varies by platform)'
+            $writeDiff | Should-BeLessThan $tolerance -Because 'Last write time should be preserved (filesystem precision varies by platform)'
         }
 
         It 'Should update timestamps when PreserveTimestamps is not specified' {
@@ -1332,11 +1332,11 @@ Describe 'Convert-LineEnding' {
             $fileInfoAfter = Get-Item $script:TestFile
             # Note: Creation time may not change on all filesystems when modifying files
             # Only LastWriteTime is guaranteed to be updated when PreserveTimestamps is not specified
-            $fileInfoAfter.LastWriteTime | Should -BeGreaterThan $pastTime
+            $fileInfoAfter.LastWriteTime | Should-BeGreaterThan $pastTime
 
             # Allow some tolerance for timing differences (within 30 seconds)
             $timeDifference = ($fileInfoAfter.LastWriteTime - $convertTime).TotalSeconds
-            [Math]::Abs($timeDifference) | Should -BeLessThan 30
+            [Math]::Abs($timeDifference) | Should-BeLessThan 30
         }
 
         It 'Should preserve timestamps for skipped files regardless of PreserveTimestamps setting' {
@@ -1360,8 +1360,8 @@ Describe 'Convert-LineEnding' {
 
             # Use platform-appropriate tolerance: Windows NTFS can have different precision than APFS/ext4
             $tolerance = if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) { 2 } else { 0.1 }
-            $creationDiff | Should -BeLessThan $tolerance -Because 'Creation time should be preserved for skipped files'
-            $writeDiff | Should -BeLessThan $tolerance -Because 'Last write time should be preserved for skipped files'
+            $creationDiff | Should-BeLessThan $tolerance -Because 'Creation time should be preserved for skipped files'
+            $writeDiff | Should-BeLessThan $tolerance -Because 'Last write time should be preserved for skipped files'
         }
 
         It 'Should preserve timestamps when converting encoding' {
@@ -1385,8 +1385,8 @@ Describe 'Convert-LineEnding' {
 
             # Use platform-appropriate tolerance: Windows NTFS can have different precision than APFS/ext4
             $tolerance = if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) { 2 } else { 0.1 }
-            $creationDiff | Should -BeLessThan $tolerance -Because 'Creation time should be preserved during encoding conversion'
-            $writeDiff | Should -BeLessThan $tolerance -Because 'Last write time should be preserved during encoding conversion'
+            $creationDiff | Should-BeLessThan $tolerance -Because 'Creation time should be preserved during encoding conversion'
+            $writeDiff | Should-BeLessThan $tolerance -Because 'Last write time should be preserved during encoding conversion'
 
             # Verify encoding was actually converted
             $bytes = [System.IO.File]::ReadAllBytes($script:TestFile)
@@ -1410,8 +1410,8 @@ Describe 'Convert-LineEnding' {
 
             # Verify PassThru result
             $result | Should -Not -BeNullOrEmpty
-            $result.Success | Should -Be $true
-            $result.Converted | Should -Be $true
+            $result.Success | Should-Be $true
+            $result.Converted | Should-Be $true
 
             # Verify timestamps are preserved (allow for filesystem precision differences)
             $fileInfoAfter = Get-Item $script:TestFile
@@ -1420,8 +1420,8 @@ Describe 'Convert-LineEnding' {
 
             # Use platform-appropriate tolerance: Windows NTFS can have different precision than APFS/ext4
             $tolerance = if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) { 2 } else { 0.1 }
-            $creationDiff | Should -BeLessThan $tolerance -Because 'Creation time should be preserved with PassThru'
-            $writeDiff | Should -BeLessThan $tolerance -Because 'Last write time should be preserved with PassThru'
+            $creationDiff | Should-BeLessThan $tolerance -Because 'Creation time should be preserved with PassThru'
+            $writeDiff | Should-BeLessThan $tolerance -Because 'Last write time should be preserved with PassThru'
         }
 
         It 'Should handle timestamp preservation failure gracefully' {
@@ -1441,7 +1441,7 @@ Describe 'Convert-LineEnding' {
 
                 # Verify content was converted
                 $newContent = Get-Content -Path $script:TestFile -Raw
-                $newContent | Should -Be "line1`nline2`nline3`n"
+                $newContent | Should-Be "line1`nline2`nline3`n"
             }
             finally
             {

--- a/Tests/Unit/Utilities/ConvertFrom-Base64.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertFrom-Base64.Tests.ps1
@@ -10,64 +10,64 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
     Context 'String Output' {
         It 'Should decode a simple Base64 string' {
             $result = ConvertFrom-Base64 -InputObject 'SGVsbG8gV29ybGQ='
-            $result | Should -Be 'Hello World'
+            $result | Should-Be 'Hello World'
         }
 
         It 'Should decode Base64 from pipeline' {
             $result = 'UGlwZWxpbmUgVGVzdA==' | ConvertFrom-Base64
-            $result | Should -Be 'Pipeline Test'
+            $result | Should-Be 'Pipeline Test'
         }
 
         It 'Should decode Base64 with special characters' {
             $encoded = ConvertTo-Base64 -InputObject 'Hello! @#$%^&*()_+-=[]{}|;:",.<>?'
             $result = ConvertFrom-Base64 -InputObject $encoded
-            $result | Should -Be 'Hello! @#$%^&*()_+-=[]{}|;:",.<>?'
+            $result | Should-Be 'Hello! @#$%^&*()_+-=[]{}|;:",.<>?'
         }
 
         It 'Should decode Base64 with unicode characters' {
             $encoded = ConvertTo-Base64 -InputObject 'Hello 世界 🌍'
             $result = ConvertFrom-Base64 -InputObject $encoded
-            $result | Should -Be 'Hello 世界 🌍'
+            $result | Should-Be 'Hello 世界 🌍'
         }
 
         It 'Should decode multiline Base64' {
             $original = "Line 1`nLine 2`nLine 3"
             $encoded = ConvertTo-Base64 -InputObject $original
             $result = ConvertFrom-Base64 -InputObject $encoded
-            $result | Should -Be $original
+            $result | Should-Be $original
         }
 
         It 'Should handle multiple pipeline inputs' {
             $result = 'Rmlyc3Q=', 'U2Vjb25k' | ConvertFrom-Base64
-            $result | Should -Match 'First'
-            $result | Should -Match 'Second'
+            $result | Should-MatchString 'First'
+            $result | Should-MatchString 'Second'
         }
 
         It 'Should handle minimal valid Base64 input' {
             # Single character Base64 (A = 0x00)
             $result = ConvertFrom-Base64 -InputObject 'AA=='
-            $result | Should -Be ([char]0x00)
+            $result | Should-Be ([char]0x00)
         }
     }
 
     Context 'URL-Safe Decoding' {
         It 'Should decode URL-safe Base64 without padding' {
             $result = ConvertFrom-Base64 -InputObject 'SGVsbG8gV29ybGQ' -UrlSafe
-            $result | Should -Be 'Hello World'
+            $result | Should-Be 'Hello World'
         }
 
         It 'Should decode URL-safe Base64 with - instead of +' {
             # Standard: 'subject?query' encodes to contain + or /
             $urlSafeEncoded = ConvertTo-Base64 -InputObject 'subject?query' -UrlSafe
             $result = ConvertFrom-Base64 -InputObject $urlSafeEncoded -UrlSafe
-            $result | Should -Be 'subject?query'
+            $result | Should-Be 'subject?query'
         }
 
         It 'Should decode URL-safe Base64 with _ instead of /' {
             $original = [char]0xFF + [char]0xFE
             $urlSafeEncoded = ConvertTo-Base64 -InputObject $original -UrlSafe
             $result = ConvertFrom-Base64 -InputObject $urlSafeEncoded -UrlSafe
-            $result | Should -Be $original
+            $result | Should-Be $original
         }
 
         It 'Should add padding when decoding URL-safe Base64' {
@@ -81,7 +81,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             foreach ($case in $testCases)
             {
                 $result = ConvertFrom-Base64 -InputObject $case.Input -UrlSafe
-                $result | Should -Be $case.Expected
+                $result | Should-Be $case.Expected
             }
         }
     }
@@ -96,7 +96,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $content = Get-Content -Path $outputFile -Raw
-            $content.TrimEnd() | Should -Be 'Test file content'
+            $content.TrimEnd() | Should-Be 'Test file content'
         }
 
         It 'Should decode binary Base64 to file' {
@@ -106,7 +106,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $decodedBytes = [System.IO.File]::ReadAllBytes($outputFile)
-            $decodedBytes | Should -Be $originalBytes
+            $decodedBytes | Should-Be $originalBytes
         }
 
         It 'Should create output directory if it does not exist' {
@@ -115,7 +115,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
 
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $nestedPath
 
-            Test-Path $nestedPath | Should -Be $true
+            Test-Path $nestedPath | Should-Be $true
         }
 
         It 'Should handle output paths with spaces' {
@@ -125,7 +125,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $pathWithSpaces
 
             $content = Get-Content -Path $pathWithSpaces -Raw
-            $content.TrimEnd() | Should -Be 'Content'
+            $content.TrimEnd() | Should-Be 'Content'
         }
 
         It 'Should resolve relative output paths' {
@@ -135,7 +135,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
                 $encoded = 'UmVsYXRpdmUgcGF0aCB0ZXN0'
                 ConvertFrom-Base64 -InputObject $encoded -OutputPath './relative-output.txt'
 
-                Test-Path './relative-output.txt' | Should -Be $true
+                Test-Path './relative-output.txt' | Should-Be $true
             }
             finally
             {
@@ -150,7 +150,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $content = Get-Content -Path $outputFile -Raw
-            $content.TrimEnd() | Should -Be 'New content'
+            $content.TrimEnd() | Should-Be 'New content'
         }
     }
 
@@ -158,30 +158,30 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
         It 'Should require InputObject parameter' {
             # When ValueFromPipeline is enabled, calling without params waits for pipeline
             # Instead test that an empty/null value throws
-            { ConvertFrom-Base64 -InputObject '' -ErrorAction Stop } | Should -Throw
+            { ConvertFrom-Base64 -InputObject '' -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should not accept null or empty InputObject' {
-            { ConvertFrom-Base64 -InputObject $null -ErrorAction Stop } | Should -Throw
-            { ConvertFrom-Base64 -InputObject '' -ErrorAction Stop } | Should -Throw
+            { ConvertFrom-Base64 -InputObject $null -ErrorAction Stop } | Should-Throw
+            { ConvertFrom-Base64 -InputObject '' -ErrorAction Stop } | Should-Throw
         }
     }
 
     Context 'Error Handling' {
         It 'Should throw error for invalid Base64 string' {
             { ConvertFrom-Base64 -InputObject 'Invalid!@#$' -ErrorAction Stop } |
-            Should -Throw
+            Should-Throw
         }
 
         It 'Should throw error for malformed Base64' {
             # Test with string that has invalid length (not multiple of 4 after padding)
             { ConvertFrom-Base64 -InputObject 'A' -ErrorAction Stop } |
-            Should -Throw
+            Should-Throw
         }
 
         It 'Should handle decoding errors gracefully' {
             { ConvertFrom-Base64 -InputObject '!!!Invalid!!!' -ErrorAction Stop } |
-            Should -Throw
+            Should-Throw
         }
     }
 
@@ -190,21 +190,21 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             $original = 'Hello World'
             $encoded = ConvertTo-Base64 -InputObject $original
             $decoded = ConvertFrom-Base64 -InputObject $encoded
-            $decoded | Should -Be $original
+            $decoded | Should-Be $original
         }
 
         It 'Should round-trip with URL-safe encoding' {
             $original = 'Hello World'
             $encoded = ConvertTo-Base64 -InputObject $original -UrlSafe
             $decoded = ConvertFrom-Base64 -InputObject $encoded -UrlSafe
-            $decoded | Should -Be $original
+            $decoded | Should-Be $original
         }
 
         It 'Should round-trip complex text' {
             $original = 'Line 1' + [Environment]::NewLine + 'Line 2' + [Environment]::NewLine + 'Special: !@#$%^&*()'
             $encoded = ConvertTo-Base64 -InputObject $original
             $decoded = ConvertFrom-Base64 -InputObject $encoded
-            $decoded | Should -Be $original
+            $decoded | Should-Be $original
         }
 
         It 'Should round-trip file content' {
@@ -218,7 +218,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $decodedContent = Get-Content -Path $outputFile -Raw
-            $decodedContent.TrimEnd() | Should -Be $originalContent
+            $decodedContent.TrimEnd() | Should-Be $originalContent
         }
     }
 }

--- a/Tests/Unit/Utilities/ConvertFrom-Base64.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertFrom-Base64.Tests.ps1
@@ -106,7 +106,7 @@ Describe 'ConvertFrom-Base64' -Tag 'Unit' {
             ConvertFrom-Base64 -InputObject $encoded -OutputPath $outputFile
 
             $decodedBytes = [System.IO.File]::ReadAllBytes($outputFile)
-            $decodedBytes | Should-Be $originalBytes
+            [Convert]::ToBase64String($decodedBytes) | Should-Be ([Convert]::ToBase64String($originalBytes))
         }
 
         It 'Should create output directory if it does not exist' {

--- a/Tests/Unit/Utilities/ConvertTo-Base64.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-Base64.Tests.ps1
@@ -9,12 +9,12 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
     Context 'String Input' {
         It 'Should encode a simple string' {
             $result = ConvertTo-Base64 -InputObject 'Hello World'
-            $result | Should -Be 'SGVsbG8gV29ybGQ='
+            $result | Should-Be 'SGVsbG8gV29ybGQ='
         }
 
         It 'Should encode an empty string' {
             $result = ConvertTo-Base64 -InputObject ''
-            $result | Should -Be ''
+            $result | Should-Be ''
         }
 
         It 'Should encode a string with special characters' {
@@ -23,7 +23,7 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
 
             # Verify it can be decoded back
             $decoded = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($result))
-            $decoded | Should -Be 'Hello! @#$%^&*()_+-=[]{}|;:",.<>?'
+            $decoded | Should-Be 'Hello! @#$%^&*()_+-=[]{}|;:",.<>?'
         }
 
         It 'Should encode a string with unicode characters' {
@@ -32,7 +32,7 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
 
             # Verify it can be decoded back
             $decoded = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($result))
-            $decoded | Should -Be 'Hello 世界 🌍'
+            $decoded | Should-Be 'Hello 世界 🌍'
         }
 
         It 'Should encode multiline text' {
@@ -42,18 +42,18 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
 
             # Verify it can be decoded back
             $decoded = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($result))
-            $decoded | Should -Be $inputText
+            $decoded | Should-Be $inputText
         }
 
         It 'Should accept input from pipeline' {
             $result = 'Pipeline Test' | ConvertTo-Base64
-            $result | Should -Be 'UGlwZWxpbmUgVGVzdA=='
+            $result | Should-Be 'UGlwZWxpbmUgVGVzdA=='
         }
 
         It 'Should handle multiple pipeline inputs' {
             $result = 'First', 'Second' | ConvertTo-Base64
-            $result | Should -Match 'Rmlyc3Q='
-            $result | Should -Match 'U2Vjb25k'
+            $result | Should-MatchString 'Rmlyc3Q='
+            $result | Should-MatchString 'U2Vjb25k'
         }
     }
 
@@ -61,29 +61,29 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
         It 'Should encode with URL-safe characters' {
             # Input that produces + and / in standard Base64
             $result = ConvertTo-Base64 -InputObject 'subject?query' -UrlSafe
-            $result | Should -Not -Match '\+'
-            $result | Should -Not -Match '/'
-            $result | Should -Not -Match '='
+            $result | Should-NotMatchString '\+'
+            $result | Should-NotMatchString '/'
+            $result | Should-NotMatchString '='
         }
 
         It 'Should remove padding when using URL-safe encoding' {
             $result = ConvertTo-Base64 -InputObject 'Hello World' -UrlSafe
-            $result | Should -Be 'SGVsbG8gV29ybGQ'
-            $result | Should -Not -Match '='
+            $result | Should-Be 'SGVsbG8gV29ybGQ'
+            $result | Should-NotMatchString '='
         }
 
         It 'Should replace + with - in URL-safe mode' {
             # Create input that generates + in standard Base64
             $inputText = [char]0xFB + [char]0xFF
             $result = ConvertTo-Base64 -InputObject $inputText -UrlSafe
-            $result | Should -Not -Match '\+'
+            $result | Should-NotMatchString '\+'
         }
 
         It 'Should replace / with _ in URL-safe mode' {
             # Create input that generates / in standard Base64
             $inputText = [char]0xFF + [char]0xFE
             $result = ConvertTo-Base64 -InputObject $inputText -UrlSafe
-            $result | Should -Not -Match '/'
+            $result | Should-NotMatchString '/'
         }
     }
 
@@ -95,7 +95,7 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
         It 'Should encode file content' {
             'Test file content' | Set-Content -Path $testFile -NoNewline
             $result = ConvertTo-Base64 -Path $testFile
-            $result | Should -Be 'VGVzdCBmaWxlIGNvbnRlbnQ='
+            $result | Should-Be 'VGVzdCBmaWxlIGNvbnRlbnQ='
         }
 
         It 'Should encode binary file content' {
@@ -103,24 +103,24 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
             [System.IO.File]::WriteAllBytes($testFile, $bytes)
 
             $result = ConvertTo-Base64 -Path $testFile
-            $result | Should -Be 'AQIDBAU='
+            $result | Should-Be 'AQIDBAU='
         }
 
         It 'Should encode empty file' {
             '' | Set-Content -Path $testFile -NoNewline
             $result = ConvertTo-Base64 -Path $testFile
-            $result | Should -Be ''
+            $result | Should-Be ''
         }
 
         It 'Should throw error for non-existent file' {
             { ConvertTo-Base64 -Path (Join-Path -Path $TestDrive -ChildPath 'nonexistent.txt') } |
-            Should -Throw -ErrorId 'ParameterArgumentValidationError*'
+            Should-Throw -FullyQualifiedErrorId 'ParameterArgumentValidationError*'
         }
 
         It 'Should encode file with URL-safe encoding' {
             'subject?query' | Set-Content -Path $testFile -NoNewline
             $result = ConvertTo-Base64 -Path $testFile -UrlSafe
-            $result | Should -Not -Match '='
+            $result | Should-NotMatchString '='
         }
 
         It 'Should handle file paths with spaces' {
@@ -128,7 +128,7 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
             'Content' | Set-Content -Path $fileWithSpaces -NoNewline
 
             $result = ConvertTo-Base64 -Path $fileWithSpaces
-            $result | Should -Be 'Q29udGVudA=='
+            $result | Should-Be 'Q29udGVudA=='
         }
 
         It 'Should resolve relative paths' {
@@ -150,7 +150,7 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
         It 'Should require either InputObject or Path' {
             # When called without parameters, it waits for pipeline input
             # We can't easily test this synchronously
-            $true | Should -Be $true
+            $true | Should-Be $true
         }
 
         It 'Should not allow both String and File parameter sets' {
@@ -160,7 +160,7 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
             'Test' | Set-Content -Path $testFile -NoNewline
 
             $result = ConvertTo-Base64 -Path $testFile
-            $result | Should -Be 'VGVzdA=='
+            $result | Should-Be 'VGVzdA=='
         }
     }
 
@@ -168,7 +168,7 @@ Describe 'ConvertTo-Base64' -Tag 'Unit' {
         It 'Should provide clear error messages' {
             # Test that error messages are helpful
             { ConvertTo-Base64 -Path '/nonexistent/file.txt' -ErrorAction Stop } |
-            Should -Throw
+            Should-Throw
         }
     }
 }

--- a/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-Markdown.Tests.ps1
@@ -94,7 +94,7 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             Mock -CommandName Get-Command -ParameterFilter { $Name -eq 'pandoc' } -MockWith { $null }
 
             { ConvertTo-Markdown -InputObject 'https://example.com' } |
-            Should -Throw 'Pandoc is not installed or not available in PATH. Please install Pandoc and try again.'
+            Should-Throw 'Pandoc is not installed or not available in PATH. Please install Pandoc and try again.'
         }
     }
 
@@ -103,8 +103,8 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             $aliasCommand = Get-Command -Name 'url2markdown' -ErrorAction SilentlyContinue
 
             $aliasCommand | Should -Not -BeNullOrEmpty
-            $aliasCommand.CommandType | Should -Be 'Alias'
-            $aliasCommand.Definition | Should -Be 'ConvertTo-Markdown'
+            $aliasCommand.CommandType | Should-Be 'Alias'
+            $aliasCommand.Definition | Should-Be 'ConvertTo-Markdown'
         }
     }
 
@@ -126,14 +126,14 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             $expectedPath = Join-Path -Path $script:TestDir -ChildPath 'sample.md'
 
             $result | Should -BeNullOrEmpty
-            Test-Path -LiteralPath $expectedPath | Should -BeTrue
-            Get-Content -LiteralPath $expectedPath -Raw | Should -Match '^# Converted Markdown'
+            Test-Path -LiteralPath $expectedPath | Should-BeTruthy
+            Get-Content -LiteralPath $expectedPath -Raw | Should-MatchString '^# Converted Markdown'
             $runCall = $script:PandocShimInvocations[0]
-            $runCall | Should -Contain '--to'
-            $runCall | Should -Contain 'gfm'
-            $runCall | Should -Contain '-o'
-            $runCall | Should -Contain $expectedPath
-            $runCall | Should -Contain ([System.IO.Path]::GetFullPath($inputFile))
+            $runCall | Should-ContainCollection '--to'
+            $runCall | Should-ContainCollection 'gfm'
+            $runCall | Should-ContainCollection '-o'
+            $runCall | Should-ContainCollection $expectedPath
+            $runCall | Should-ContainCollection ([System.IO.Path]::GetFullPath($inputFile))
         }
 
         It 'Converts an HTTPS URL and writes to an auto-generated file path' {
@@ -141,11 +141,11 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             $expectedPath = Join-Path -Path $script:TestDir -ChildPath 'example-com-docs-page.md'
 
             $result | Should -BeNullOrEmpty
-            Test-Path -LiteralPath $expectedPath | Should -BeTrue
+            Test-Path -LiteralPath $expectedPath | Should-BeTruthy
             $runCall = $script:PandocShimInvocations[0]
-            $runCall | Should -Contain '-o'
-            $runCall | Should -Contain $expectedPath
-            $runCall | Should -Contain 'https://example.com/docs/page.html'
+            $runCall | Should-ContainCollection '-o'
+            $runCall | Should-ContainCollection $expectedPath
+            $runCall | Should-ContainCollection 'https://example.com/docs/page.html'
         }
 
         It 'Auto-saves URL input using URI path segments when -OutputPath is omitted' {
@@ -153,22 +153,22 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             $expectedPath = Join-Path -Path $script:TestDir -ChildPath 'example-com-docs-page.md'
 
             $result | Should -BeNullOrEmpty
-            Test-Path -LiteralPath $expectedPath | Should -BeTrue
-            Get-Content -LiteralPath $expectedPath -Raw | Should -Match '^# Converted Markdown'
+            Test-Path -LiteralPath $expectedPath | Should-BeTruthy
+            Get-Content -LiteralPath $expectedPath -Raw | Should-MatchString '^# Converted Markdown'
         }
 
         It 'Auto-saves base URL input as domain-derived markdown filename' {
             ConvertTo-Markdown -InputObject 'https://example.com' | Out-Null
             $expectedPath = Join-Path -Path $script:TestDir -ChildPath 'example-com.md'
 
-            Test-Path -LiteralPath $expectedPath | Should -BeTrue
+            Test-Path -LiteralPath $expectedPath | Should-BeTruthy
         }
 
         It 'Throws when a local file path does not exist' {
             $missingPath = Join-Path -Path $script:TestDir -ChildPath 'missing.html'
 
             { ConvertTo-Markdown -InputObject $missingPath } |
-            Should -Throw "*Input path does not exist or is not a file: $missingPath*"
+            Should-Throw "*Input path does not exist or is not a file: $missingPath*"
         }
 
         It 'Accepts pipeline input' {
@@ -176,8 +176,8 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             ConvertTo-Markdown
 
             $results | Should -BeNullOrEmpty
-            Test-Path -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'example-com-one.md') | Should -BeTrue
-            Test-Path -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'example-com-two.md') | Should -BeTrue
+            Test-Path -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'example-com-one.md') | Should-BeTruthy
+            Test-Path -LiteralPath (Join-Path -Path $script:TestDir -ChildPath 'example-com-two.md') | Should-BeTruthy
         }
     }
 
@@ -198,12 +198,12 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             ConvertTo-Markdown -InputObject $inputFile -From html -To markdown -PandocArgs @('--wrap=none', '--strip-comments') | Out-Null
 
             $runCall = $script:PandocShimInvocations[0]
-            $runCall | Should -Contain '--from'
-            $runCall | Should -Contain 'html'
-            $runCall | Should -Contain '--to'
-            $runCall | Should -Contain 'markdown'
-            $runCall | Should -Contain '--wrap=none'
-            $runCall | Should -Contain '--strip-comments'
+            $runCall | Should-ContainCollection '--from'
+            $runCall | Should-ContainCollection 'html'
+            $runCall | Should-ContainCollection '--to'
+            $runCall | Should-ContainCollection 'markdown'
+            $runCall | Should-ContainCollection '--wrap=none'
+            $runCall | Should-ContainCollection '--strip-comments'
         }
 
         It 'Accepts Pandoc markdown output variants and extension modifiers for -To' {
@@ -216,8 +216,8 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             ConvertTo-Markdown -InputObject $inputFile -To 'gfm+task_lists+pipe_tables-smart' | Out-Null
 
             $runCall = $script:PandocShimInvocations[-1]
-            $runCall | Should -Contain '--to'
-            $runCall | Should -Contain 'gfm+task_lists+pipe_tables-smart'
+            $runCall | Should-ContainCollection '--to'
+            $runCall | Should-ContainCollection 'gfm+task_lists+pipe_tables-smart'
         }
 
         It 'Rejects non-markdown or malformed values for -To' {
@@ -225,13 +225,13 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             '<h1>Hello</h1>' | Set-Content -LiteralPath $inputFile -NoNewline
 
             { ConvertTo-Markdown -InputObject $inputFile -To html } |
-            Should -Throw "*Cannot validate argument on parameter 'To'*"
+            Should-Throw "*Cannot validate argument on parameter 'To'*"
 
             { ConvertTo-Markdown -InputObject $inputFile -To 'gfm++task_lists' } |
-            Should -Throw "*Cannot validate argument on parameter 'To'*"
+            Should-Throw "*Cannot validate argument on parameter 'To'*"
 
             { ConvertTo-Markdown -InputObject $inputFile -To 'gfm+1invalid' } |
-            Should -Throw "*Cannot validate argument on parameter 'To'*"
+            Should-Throw "*Cannot validate argument on parameter 'To'*"
         }
 
         It 'Writes to -OutputPath and returns path with -PassThru' {
@@ -242,25 +242,25 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             $result = ConvertTo-Markdown -InputObject $inputFile -OutputPath $outputPath -PassThru
 
             $resolvedOutputPath = [System.IO.Path]::GetFullPath($outputPath)
-            $result | Should -Be $resolvedOutputPath
+            $result | Should-Be $resolvedOutputPath
 
             $runCall = $script:PandocShimInvocations[0]
-            $runCall | Should -Contain '-o'
-            $runCall | Should -Contain $resolvedOutputPath
-            Test-Path -LiteralPath $resolvedOutputPath | Should -BeTrue
+            $runCall | Should-ContainCollection '-o'
+            $runCall | Should-ContainCollection $resolvedOutputPath
+            Test-Path -LiteralPath $resolvedOutputPath | Should-BeTruthy
         }
 
         It 'Returns auto-generated output path with -PassThru when -OutputPath is omitted' {
             $result = ConvertTo-Markdown -InputObject 'https://example.com/notes' -PassThru
             $expectedPath = Join-Path -Path $script:TestDir -ChildPath 'example-com-notes.md'
 
-            $result | Should -Be $expectedPath
-            Test-Path -LiteralPath $expectedPath | Should -BeTrue
+            $result | Should-Be $expectedPath
+            Test-Path -LiteralPath $expectedPath | Should-BeTruthy
         }
 
         It 'Rejects multiple input values when -OutputPath is specified' {
             { @('https://example.com/one', 'https://example.com/two') | ConvertTo-Markdown -OutputPath (Join-Path -Path $script:TestDir -ChildPath 'out.md') } |
-            Should -Throw '*only one InputObject value is supported*'
+            Should-Throw '*only one InputObject value is supported*'
         }
 
         It 'Accepts valid values for -Encoding' {
@@ -270,15 +270,15 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
             Select-Object -ExpandProperty ValidValues
 
-            $validEncodings | Should -Contain 'Auto'
-            $validEncodings | Should -Contain 'UTF8'
-            $validEncodings | Should -Contain 'UTF8BOM'
-            $validEncodings | Should -Contain 'UTF16LE'
-            $validEncodings | Should -Contain 'UTF16BE'
-            $validEncodings | Should -Contain 'UTF32'
-            $validEncodings | Should -Contain 'UTF32BE'
-            $validEncodings | Should -Contain 'ASCII'
-            $validEncodings | Should -Contain 'ANSI'
+            $validEncodings | Should-ContainCollection 'Auto'
+            $validEncodings | Should-ContainCollection 'UTF8'
+            $validEncodings | Should-ContainCollection 'UTF8BOM'
+            $validEncodings | Should-ContainCollection 'UTF16LE'
+            $validEncodings | Should-ContainCollection 'UTF16BE'
+            $validEncodings | Should-ContainCollection 'UTF32'
+            $validEncodings | Should-ContainCollection 'UTF32BE'
+            $validEncodings | Should-ContainCollection 'ASCII'
+            $validEncodings | Should-ContainCollection 'ANSI'
         }
 
         It 'Preserves Pandoc output encoding when -Encoding Auto' {
@@ -289,9 +289,9 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             ConvertTo-Markdown -InputObject $inputFile -OutputPath $outputPath -Encoding Auto | Out-Null
 
             $bytes = [System.IO.File]::ReadAllBytes($outputPath)
-            $bytes[0] | Should -Not -Be 0xEF
-            $bytes[0] | Should -Not -Be 0xFF
-            $bytes[0] | Should -Not -Be 0xFE
+            $bytes[0] | Should-NotBe 0xEF
+            $bytes[0] | Should-NotBe 0xFF
+            $bytes[0] | Should-NotBe 0xFE
         }
 
         It 'Converts output file encoding when -Encoding is specified' {
@@ -302,9 +302,9 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             ConvertTo-Markdown -InputObject $inputFile -OutputPath $outputPath -Encoding UTF8BOM | Out-Null
 
             $bytes = [System.IO.File]::ReadAllBytes($outputPath)
-            $bytes[0] | Should -Be 0xEF
-            $bytes[1] | Should -Be 0xBB
-            $bytes[2] | Should -Be 0xBF
+            $bytes[0] | Should-Be 0xEF
+            $bytes[1] | Should-Be 0xBB
+            $bytes[2] | Should-Be 0xBF
         }
     }
 
@@ -322,7 +322,7 @@ Describe 'ConvertTo-Markdown' -Tag 'Unit' {
             $script:PandocShimExitCode = 9
 
             { ConvertTo-Markdown -InputObject 'https://example.com/fail' } |
-            Should -Throw '*exit code 9*'
+            Should-Throw '*exit code 9*'
         }
     }
 }

--- a/Tests/Unit/Utilities/ConvertTo-MarkdownObject.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-MarkdownObject.Tests.ps1
@@ -17,8 +17,8 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject
 
-            $result | Should -Match ([Regex]::Escape('- `Name`: `Jon`'))
-            $result | Should -Match ([Regex]::Escape('- `Age`: `42`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Name`: `Jon`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Age`: `42`'))
         }
 
         It 'Converts a nested PSCustomObject and arrays' {
@@ -33,12 +33,12 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject
 
-            $result | Should -Match ([Regex]::Escape('- `Name`: `Tooling`'))
-            $result | Should -Match ([Regex]::Escape('- `Tags`'))
-            $result | Should -Match ([Regex]::Escape('- `[0]`: `powershell`'))
-            $result | Should -Match ([Regex]::Escape('- `Meta`'))
-            $result | Should -Match ([Regex]::Escape('- `Enabled`: `true`'))
-            $result | Should -Match ([Regex]::Escape('- `RetryCount`: `3`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Name`: `Tooling`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Tags`'))
+            $result | Should-MatchString ([Regex]::Escape('- `[0]`: `powershell`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Meta`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Enabled`: `true`'))
+            $result | Should-MatchString ([Regex]::Escape('- `RetryCount`: `3`'))
         }
     }
 
@@ -48,7 +48,7 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $json
 
-            $result | Should -Match ([Regex]::Escape('- `{"name":"Jon","age":42}`'))
+            $result | Should-MatchString ([Regex]::Escape('- `{"name":"Jon","age":42}`'))
         }
 
         It 'Parses JSON strings when -ParseJsonStrings is used' {
@@ -56,10 +56,10 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $json -ParseJsonStrings
 
-            $result | Should -Match ([Regex]::Escape('- `name`: `Jon`'))
-            $result | Should -Match ([Regex]::Escape('- `roles`'))
-            $result | Should -Match ([Regex]::Escape('- `[0]`: `admin`'))
-            $result | Should -Match ([Regex]::Escape('- `[1]`: `ops`'))
+            $result | Should-MatchString ([Regex]::Escape('- `name`: `Jon`'))
+            $result | Should-MatchString ([Regex]::Escape('- `roles`'))
+            $result | Should-MatchString ([Regex]::Escape('- `[0]`: `admin`'))
+            $result | Should-MatchString ([Regex]::Escape('- `[1]`: `ops`'))
         }
     }
 
@@ -75,8 +75,8 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject -Depth 2
 
-            $result | Should -Match ([Regex]::Escape('- `Level1`'))
-            $result | Should -Match ([Regex]::Escape('- `Level2`: `(max depth reached)`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Level1`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Level2`: `(max depth reached)`'))
         }
 
         It 'Handles null, empty arrays, and empty objects' {
@@ -88,11 +88,11 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject
 
-            $result | Should -Match ([Regex]::Escape('- `EmptyArray`'))
-            $result | Should -Match ([Regex]::Escape('- *(empty array)*'))
-            $result | Should -Match ([Regex]::Escape('- `EmptyObject`'))
-            $result | Should -Match ([Regex]::Escape('- *(empty object)*'))
-            $result | Should -Match ([Regex]::Escape('- `Nothing`: `null`'))
+            $result | Should-MatchString ([Regex]::Escape('- `EmptyArray`'))
+            $result | Should-MatchString ([Regex]::Escape('- *(empty array)*'))
+            $result | Should-MatchString ([Regex]::Escape('- `EmptyObject`'))
+            $result | Should-MatchString ([Regex]::Escape('- *(empty object)*'))
+            $result | Should-MatchString ([Regex]::Escape('- `Nothing`: `null`'))
         }
     }
 
@@ -105,10 +105,10 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject -AsTable
 
-            $result | Should -Match ([Regex]::Escape('| Name | Role |'))
-            $result | Should -Match ([Regex]::Escape('| --- | --- |'))
-            $result | Should -Match ([Regex]::Escape('| Jon | Admin |'))
-            $result | Should -Match ([Regex]::Escape('| Ava | Author |'))
+            $result | Should-MatchString ([Regex]::Escape('| Name | Role |'))
+            $result | Should-MatchString ([Regex]::Escape('| --- | --- |'))
+            $result | Should-MatchString ([Regex]::Escape('| Jon | Admin |'))
+            $result | Should-MatchString ([Regex]::Escape('| Ava | Author |'))
         }
 
         It 'Renders a scalar hashtable as a Property/Value table with -AsTable' {
@@ -119,9 +119,9 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject -AsTable
 
-            $result | Should -Match ([Regex]::Escape('| Property | Value |'))
-            $result | Should -Match ([Regex]::Escape('| Name | Jon |'))
-            $result | Should -Match ([Regex]::Escape('| Age | 42 |'))
+            $result | Should-MatchString ([Regex]::Escape('| Property | Value |'))
+            $result | Should-MatchString ([Regex]::Escape('| Name | Jon |'))
+            $result | Should-MatchString ([Regex]::Escape('| Age | 42 |'))
         }
 
         It 'Renders nested compatible collections as tables with -AsTable' {
@@ -134,9 +134,9 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject -AsTable
 
-            $result | Should -Match ([Regex]::Escape('- `Users`'))
-            $result | Should -Match ([Regex]::Escape('| Name | Role |'))
-            $result | Should -Match ([Regex]::Escape('| Jon | Admin |'))
+            $result | Should-MatchString ([Regex]::Escape('- `Users`'))
+            $result | Should-MatchString ([Regex]::Escape('| Name | Role |'))
+            $result | Should-MatchString ([Regex]::Escape('| Jon | Admin |'))
         }
 
         It 'Falls back to list rendering when rows contain non-scalar values' {
@@ -157,11 +157,11 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
 
             $result = ConvertTo-MarkdownObject -InputObject $inputObject -AsTable
 
-            $result | Should -Not -Match ([Regex]::Escape('| Name | Meta |'))
-            $result | Should -Match ([Regex]::Escape('- `[0]`'))
-            $result | Should -Match ([Regex]::Escape('- `[1]`'))
-            $result | Should -Match ([Regex]::Escape('- `Meta`'))
-            $result | Should -Match ([Regex]::Escape('| Enabled |'))
+            $result | Should-NotMatchString ([Regex]::Escape('| Name | Meta |'))
+            $result | Should-MatchString ([Regex]::Escape('- `[0]`'))
+            $result | Should-MatchString ([Regex]::Escape('- `[1]`'))
+            $result | Should-MatchString ([Regex]::Escape('- `Meta`'))
+            $result | Should-MatchString ([Regex]::Escape('| Enabled |'))
         }
     }
 
@@ -172,9 +172,9 @@ Describe 'ConvertTo-MarkdownObject' -Tag 'Unit' {
                 [ordered]@{ Second = 2 }
             ) | ConvertTo-MarkdownObject
 
-            @($results).Count | Should -Be 2
-            $results[0] | Should -Match ([Regex]::Escape('- `First`: `1`'))
-            $results[1] | Should -Match ([Regex]::Escape('- `Second`: `2`'))
+            @($results).Count | Should-Be 2
+            $results[0] | Should-MatchString ([Regex]::Escape('- `First`: `1`'))
+            $results[1] | Should-MatchString ([Regex]::Escape('- `Second`: `2`'))
         }
     }
 }

--- a/Tests/Unit/Utilities/ConvertTo-TimeZone.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-TimeZone.Tests.ps1
@@ -12,39 +12,39 @@ Describe 'ConvertTo-TimeZone' -Tag 'Unit', 'Utilities' {
         It 'Converts US Eastern time to India time using informal aliases' {
             $result = ConvertTo-TimeZone '2026-07-04 12:00' -FromTimeZone Eastern -ToTimeZone India
 
-            $result.TimeZone | Should -Be 'India'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-07-04 21:30:00 +05:30'
-            $result.SourceDateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-07-04 12:00:00 -04:00'
-            $result.SourceTimeZone | Should -Be 'Eastern'
-            $result.Abbreviation | Should -Be 'IST'
+            $result.TimeZone | Should-Be 'India'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-07-04 21:30:00 +05:30'
+            $result.SourceDateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-07-04 12:00:00 -04:00'
+            $result.SourceTimeZone | Should-Be 'Eastern'
+            $result.Abbreviation | Should-Be 'IST'
         }
 
         It 'Accepts IANA time-zone ids on supported platforms' {
             $result = ConvertTo-TimeZone '2026-01-15 12:00' -FromTimeZone America/New_York -ToTimeZone Asia/Kolkata
 
-            $result.TimeZone | Should -Be 'India'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 22:30:00 +05:30'
+            $result.TimeZone | Should-Be 'India'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 22:30:00 +05:30'
         }
 
         It 'Accepts Windows time-zone ids' {
             $result = ConvertTo-TimeZone '2026-01-15 12:00' -FromTimeZone 'Eastern Standard Time' -ToTimeZone 'India Standard Time'
 
-            $result.TimeZone | Should -Be 'India'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 22:30:00 +05:30'
+            $result.TimeZone | Should-Be 'India'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 22:30:00 +05:30'
         }
 
         It 'Accepts normalized informal names' {
             $result = ConvertTo-TimeZone '2026-01-15T12:00:00Z' -ToTimeZone 'india_time'
 
-            $result.TimeZone | Should -Be 'India'
-            $result.UtcOffsetString | Should -Be 'UTC+05:30'
+            $result.TimeZone | Should-Be 'India'
+            $result.UtcOffsetString | Should-Be 'UTC+05:30'
         }
 
         It 'Accepts a strongly typed TimeZoneInfo object' {
             $result = ConvertTo-TimeZone '2026-01-15T12:00:00Z' -ToTimeZone ([System.TimeZoneInfo]::Utc)
 
-            $result.TimeZoneId | Should -Be ([System.TimeZoneInfo]::Utc.Id)
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 12:00:00 +00:00'
+            $result.TimeZoneId | Should-Be ([System.TimeZoneInfo]::Utc.Id)
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 12:00:00 +00:00'
         }
     }
 
@@ -52,38 +52,38 @@ Describe 'ConvertTo-TimeZone' -Tag 'Unit', 'Utilities' {
         It 'Uses FromTimeZone for a timezone-less string' {
             $result = ConvertTo-TimeZone '2026-01-15 18:00' -FromTimeZone India -ToTimeZone Eastern
 
-            $result.SourceKind | Should -Be 'TimeZoneAssumed'
-            $result.SourceOffset | Should -Be 'UTC+05:30'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 07:30:00 -05:00'
+            $result.SourceKind | Should-Be 'TimeZoneAssumed'
+            $result.SourceOffset | Should-Be 'UTC+05:30'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 07:30:00 -05:00'
         }
 
         It 'Reports UtcAssumed when UTC is the source of a timezone-less string' {
             $result = ConvertTo-TimeZone '2026-01-15 18:00' -FromTimeZone UTC -ToTimeZone Eastern
 
-            $result.SourceKind | Should -Be 'UtcAssumed'
-            $result.SourceOffset | Should -Be 'UTC+00:00'
+            $result.SourceKind | Should-Be 'UtcAssumed'
+            $result.SourceOffset | Should-Be 'UTC+00:00'
         }
 
         It 'Preserves offset-aware input instead of applying FromTimeZone' {
             $result = ConvertTo-TimeZone '2026-01-15T12:00:00-08:00' -FromTimeZone India -ToTimeZone Eastern
 
-            $result.SourceKind | Should -Be 'OffsetSpecified'
+            $result.SourceKind | Should-Be 'OffsetSpecified'
             $result.SourceTimeZone | Should -BeNullOrEmpty
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 15:00:00 -05:00'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 15:00:00 -05:00'
         }
 
         It 'Preserves DateTime values whose Kind is UTC' {
             $inputObject = [DateTime]::SpecifyKind([DateTime]'2026-01-15 12:00', [DateTimeKind]::Utc)
             $result = ConvertTo-TimeZone $inputObject -FromTimeZone India -ToTimeZone Eastern
 
-            $result.SourceKind | Should -Be 'Utc'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 07:00:00 -05:00'
+            $result.SourceKind | Should-Be 'Utc'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 07:00:00 -05:00'
         }
 
         It 'Rejects a nonexistent source clock time during spring-forward' {
             {
                 ConvertTo-TimeZone '2026-03-08 02:30' -FromTimeZone Eastern -ToTimeZone UTC
-            } | Should -Throw '*does not exist*'
+            } | Should-Throw '*does not exist*'
         }
     }
 
@@ -93,54 +93,54 @@ Describe 'ConvertTo-TimeZone' -Tag 'Unit', 'Utilities' {
             $result = ConvertTo-TimeZone -ToTimeZone UTC
             $after = [DateTimeOffset]::UtcNow
 
-            $result.SourceKind | Should -Be 'Utc'
-            $result.SourceDateTime.UtcDateTime | Should -BeGreaterThan $before.UtcDateTime.AddSeconds(-1)
-            $result.SourceDateTime.UtcDateTime | Should -BeLessThan $after.UtcDateTime.AddSeconds(1)
+            $result.SourceKind | Should-Be 'Utc'
+            $result.SourceDateTime.UtcDateTime | Should-BeGreaterThan $before.UtcDateTime.AddSeconds(-1)
+            $result.SourceDateTime.UtcDateTime | Should-BeLessThan $after.UtcDateTime.AddSeconds(1)
         }
 
         It 'Returns targets in requested order' {
             $results = @(ConvertTo-TimeZone '2026-01-15T12:00:00Z' -ToTimeZone India, Eastern, Japan)
 
-            $results.Count | Should -Be 3
-            (($results | Select-Object -ExpandProperty TimeZone) -join ',') | Should -Be 'India,Eastern,Japan'
+            $results.Count | Should-Be 3
+            (($results | Select-Object -ExpandProperty TimeZone) -join ',') | Should-Be 'India,Eastern,Japan'
         }
 
         It 'Converts each pipeline input' {
             $results = @('2026-01-15T12:00:00Z', '2026-01-15T13:00:00Z') |
                 ConvertTo-TimeZone -ToTimeZone India
 
-            $results.Count | Should -Be 2
-            $results[0].DateTime24 | Should -Be '17:30:00'
-            $results[1].DateTime24 | Should -Be '18:30:00'
+            $results.Count | Should-Be 2
+            $results[0].DateTime24 | Should-Be '17:30:00'
+            $results[1].DateTime24 | Should-Be '18:30:00'
         }
 
         It 'Returns source and destination metadata' {
             $result = ConvertTo-TimeZone '2026-07-04 12:00' -FromTimeZone Eastern -ToTimeZone India
             $propertyNames = @($result.PSObject.Properties.Name)
 
-            $propertyNames | Should -Contain 'TimeZoneId'
-            $propertyNames | Should -Contain 'UtcOffset'
-            $propertyNames | Should -Contain 'IsDaylightSavingTime'
-            $propertyNames | Should -Contain 'SourceTimeZoneId'
-            $propertyNames | Should -Contain 'SourceOffset'
+            $propertyNames | Should-ContainCollection 'TimeZoneId'
+            $propertyNames | Should-ContainCollection 'UtcOffset'
+            $propertyNames | Should-ContainCollection 'IsDaylightSavingTime'
+            $propertyNames | Should-ContainCollection 'SourceTimeZoneId'
+            $propertyNames | Should-ContainCollection 'SourceOffset'
         }
     }
 
     Context 'Error handling' {
         It 'Throws for an invalid date string' {
-            { ConvertTo-TimeZone 'not-a-date' -ToTimeZone UTC } | Should -Throw
+            { ConvertTo-TimeZone 'not-a-date' -ToTimeZone UTC } | Should-Throw
         }
 
         It 'Throws for an unknown source time zone' {
-            { ConvertTo-TimeZone '2026-01-15 12:00' -FromTimeZone Mars -ToTimeZone UTC } | Should -Throw '*Unknown time zone*'
+            { ConvertTo-TimeZone '2026-01-15 12:00' -FromTimeZone Mars -ToTimeZone UTC } | Should-Throw '*Unknown time zone*'
         }
 
         It 'Throws for an unknown destination time zone' {
-            { ConvertTo-TimeZone '2026-01-15T12:00:00Z' -ToTimeZone Mars } | Should -Throw '*Unknown time zone*'
+            { ConvertTo-TimeZone '2026-01-15T12:00:00Z' -ToTimeZone Mars } | Should-Throw '*Unknown time zone*'
         }
 
         It 'Throws for an unsupported input type' {
-            { ConvertTo-TimeZone 42 -ToTimeZone UTC } | Should -Throw '*String, DateTime, or DateTimeOffset*'
+            { ConvertTo-TimeZone 42 -ToTimeZone UTC } | Should-Throw '*String, DateTime, or DateTimeOffset*'
         }
     }
 }

--- a/Tests/Unit/Utilities/ConvertTo-USDateTime.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-USDateTime.Tests.ps1
@@ -14,11 +14,11 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
             $result = ConvertTo-USDateTime -TimeZone Eastern
             $after = [DateTimeOffset]::UtcNow
 
-            $result.SourceKind | Should -Be 'Utc'
-            $result.SourceOffset | Should -Be 'UTC+00:00'
-            $result.SourceDateTime.Offset | Should -Be ([TimeSpan]::Zero)
-            $result.SourceDateTime.UtcDateTime | Should -BeGreaterThan $before.UtcDateTime.AddSeconds(-1)
-            $result.SourceDateTime.UtcDateTime | Should -BeLessThan $after.UtcDateTime.AddSeconds(1)
+            $result.SourceKind | Should-Be 'Utc'
+            $result.SourceOffset | Should-Be 'UTC+00:00'
+            $result.SourceDateTime.Offset | Should-Be ([TimeSpan]::Zero)
+            $result.SourceDateTime.UtcDateTime | Should-BeGreaterThan $before.UtcDateTime.AddSeconds(-1)
+            $result.SourceDateTime.UtcDateTime | Should-BeLessThan $after.UtcDateTime.AddSeconds(1)
         }
     }
 
@@ -26,8 +26,8 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
         It 'Returns the default US timezone set for UTC input' {
             $results = @(ConvertTo-USDateTime -InputObject '2026-07-04T12:00:00Z')
 
-            $results.Count | Should -Be 11
-            (($results | Select-Object -ExpandProperty TimeZone) -join ',') | Should -Be 'Atlantic,Eastern,Central,Mountain,Arizona,Pacific,Alaska,Aleutian,Hawaii,Samoa,Chamorro'
+            $results.Count | Should-Be 11
+            (($results | Select-Object -ExpandProperty TimeZone) -join ',') | Should-Be 'Atlantic,Eastern,Central,Mountain,Arizona,Pacific,Alaska,Aleutian,Hawaii,Samoa,Chamorro'
 
             $atlantic = $results | Where-Object TimeZone -EQ 'Atlantic'
             $eastern = $results | Where-Object TimeZone -EQ 'Eastern'
@@ -37,40 +37,40 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
             $samoa = $results | Where-Object TimeZone -EQ 'Samoa'
             $chamorro = $results | Where-Object TimeZone -EQ 'Chamorro'
 
-            $atlantic.UtcOffsetString | Should -Be 'UTC-04:00'
-            $atlantic.IsDaylightSavingTime | Should -BeFalse
-            $atlantic.ObservesDaylightSavingTime | Should -BeFalse
-            $atlantic.Abbreviation | Should -Be 'AST'
+            $atlantic.UtcOffsetString | Should-Be 'UTC-04:00'
+            $atlantic.IsDaylightSavingTime | Should-BeFalsy
+            $atlantic.ObservesDaylightSavingTime | Should-BeFalsy
+            $atlantic.Abbreviation | Should-Be 'AST'
 
-            $eastern.UtcOffsetString | Should -Be 'UTC-04:00'
-            $eastern.IsDaylightSavingTime | Should -BeTrue
-            $eastern.Abbreviation | Should -Be 'EDT'
+            $eastern.UtcOffsetString | Should-Be 'UTC-04:00'
+            $eastern.IsDaylightSavingTime | Should-BeTruthy
+            $eastern.Abbreviation | Should-Be 'EDT'
             $eastern.TimeZoneName | Should -Not -BeNullOrEmpty
 
-            $arizona.UtcOffsetString | Should -Be 'UTC-07:00'
-            $arizona.IsDaylightSavingTime | Should -BeFalse
-            $arizona.ObservesDaylightSavingTime | Should -BeFalse
-            $arizona.Abbreviation | Should -Be 'MST'
+            $arizona.UtcOffsetString | Should-Be 'UTC-07:00'
+            $arizona.IsDaylightSavingTime | Should-BeFalsy
+            $arizona.ObservesDaylightSavingTime | Should-BeFalsy
+            $arizona.Abbreviation | Should-Be 'MST'
 
-            $aleutian.UtcOffsetString | Should -Be 'UTC-09:00'
-            $aleutian.IsDaylightSavingTime | Should -BeTrue
-            $aleutian.ObservesDaylightSavingTime | Should -BeTrue
-            $aleutian.Abbreviation | Should -Be 'HADT'
+            $aleutian.UtcOffsetString | Should-Be 'UTC-09:00'
+            $aleutian.IsDaylightSavingTime | Should-BeTruthy
+            $aleutian.ObservesDaylightSavingTime | Should-BeTruthy
+            $aleutian.Abbreviation | Should-Be 'HADT'
 
-            $hawaii.UtcOffsetString | Should -Be 'UTC-10:00'
-            $hawaii.IsDaylightSavingTime | Should -BeFalse
-            $hawaii.ObservesDaylightSavingTime | Should -BeFalse
-            $hawaii.Abbreviation | Should -Be 'HST'
+            $hawaii.UtcOffsetString | Should-Be 'UTC-10:00'
+            $hawaii.IsDaylightSavingTime | Should-BeFalsy
+            $hawaii.ObservesDaylightSavingTime | Should-BeFalsy
+            $hawaii.Abbreviation | Should-Be 'HST'
 
-            $samoa.UtcOffsetString | Should -Be 'UTC-11:00'
-            $samoa.IsDaylightSavingTime | Should -BeFalse
-            $samoa.ObservesDaylightSavingTime | Should -BeFalse
-            $samoa.Abbreviation | Should -Be 'SST'
+            $samoa.UtcOffsetString | Should-Be 'UTC-11:00'
+            $samoa.IsDaylightSavingTime | Should-BeFalsy
+            $samoa.ObservesDaylightSavingTime | Should-BeFalsy
+            $samoa.Abbreviation | Should-Be 'SST'
 
-            $chamorro.UtcOffsetString | Should -Be 'UTC+10:00'
-            $chamorro.IsDaylightSavingTime | Should -BeFalse
-            $chamorro.ObservesDaylightSavingTime | Should -BeFalse
-            $chamorro.Abbreviation | Should -Be 'ChST'
+            $chamorro.UtcOffsetString | Should-Be 'UTC+10:00'
+            $chamorro.IsDaylightSavingTime | Should-BeFalsy
+            $chamorro.ObservesDaylightSavingTime | Should-BeFalsy
+            $chamorro.Abbreviation | Should-Be 'ChST'
         }
     }
 
@@ -78,18 +78,18 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
         It 'Returns only requested timezones and resolves aliases' {
             $results = @(ConvertTo-USDateTime -InputObject '2026-01-15T15:00:00Z' -TimeZone ET, Pacific)
 
-            $results.Count | Should -Be 2
-            (($results | Select-Object -ExpandProperty TimeZone) -join ',') | Should -Be 'Eastern,Pacific'
+            $results.Count | Should-Be 2
+            (($results | Select-Object -ExpandProperty TimeZone) -join ',') | Should-Be 'Eastern,Pacific'
 
-            ($results | Where-Object TimeZone -EQ 'Eastern').UtcOffsetString | Should -Be 'UTC-05:00'
-            ($results | Where-Object TimeZone -EQ 'Pacific').UtcOffsetString | Should -Be 'UTC-08:00'
+            ($results | Where-Object TimeZone -EQ 'Eastern').UtcOffsetString | Should-Be 'UTC-05:00'
+            ($results | Where-Object TimeZone -EQ 'Pacific').UtcOffsetString | Should-Be 'UTC-08:00'
         }
 
         It 'Returns properties in the expected display order' {
             $result = ConvertTo-USDateTime -InputObject '2026-04-23T17:14:53Z' -TimeZone Eastern
             $propertyNames = @($result.PSObject.Properties.Name)
 
-            $propertyNames | Should -Be @(
+            $propertyNames | Should-BeCollection @(
                 'TimeZone',
                 'DateTime',
                 'DateTime24',
@@ -113,9 +113,9 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
         It 'Treats timezone-less strings as UTC when AssumeInputKind Utc is used' {
             $result = ConvertTo-USDateTime -InputObject '2026-01-15 15:00:00' -AssumeInputKind Utc -TimeZone Eastern
 
-            $result.SourceKind | Should -Be 'UtcAssumed'
-            $result.SourceOffset | Should -Be 'UTC+00:00'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 10:00:00 -05:00'
+            $result.SourceKind | Should-Be 'UtcAssumed'
+            $result.SourceOffset | Should-Be 'UTC+00:00'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 10:00:00 -05:00'
         }
 
         It 'Preserves DateTime values marked as UTC' {
@@ -123,8 +123,8 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
 
             $result = ConvertTo-USDateTime -InputObject $inputObject -TimeZone Eastern
 
-            $result.SourceKind | Should -Be 'Utc'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 10:00:00 -05:00'
+            $result.SourceKind | Should-Be 'Utc'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 10:00:00 -05:00'
         }
 
         It 'Accepts DateTimeOffset input with a non-UTC offset' {
@@ -132,9 +132,9 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
 
             $result = ConvertTo-USDateTime -InputObject $inputObject -TimeZone Eastern
 
-            $result.SourceKind | Should -Be 'OffsetSpecified'
-            $result.SourceOffset | Should -Be 'UTC-08:00'
-            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 18:00:00 -05:00'
+            $result.SourceKind | Should-Be 'OffsetSpecified'
+            $result.SourceOffset | Should-Be 'UTC-08:00'
+            $result.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 18:00:00 -05:00'
         }
 
         It 'Recognizes DateTime values marked as local time' {
@@ -142,8 +142,8 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
 
             $result = ConvertTo-USDateTime -InputObject $inputObject -TimeZone Eastern
 
-            $result.SourceKind | Should -Be 'Local'
-            $result.SourceOffset | Should -Match '^UTC[+-]\d{2}:\d{2}$'
+            $result.SourceKind | Should-Be 'Local'
+            $result.SourceOffset | Should-MatchString '^UTC[+-]\d{2}:\d{2}$'
             $result.TimeZoneName | Should -Not -BeNullOrEmpty
         }
     }
@@ -153,45 +153,45 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
             $before = ConvertTo-USDateTime -InputObject '2026-03-08T06:59:59Z' -TimeZone Eastern
             $after = ConvertTo-USDateTime -InputObject '2026-03-08T07:00:00Z' -TimeZone Eastern
 
-            $before.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-03-08 01:59:59 -05:00'
-            $before.UtcOffsetString | Should -Be 'UTC-05:00'
-            $before.IsDaylightSavingTime | Should -BeFalse
-            $before.Abbreviation | Should -Be 'EST'
+            $before.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-03-08 01:59:59 -05:00'
+            $before.UtcOffsetString | Should-Be 'UTC-05:00'
+            $before.IsDaylightSavingTime | Should-BeFalsy
+            $before.Abbreviation | Should-Be 'EST'
 
-            $after.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-03-08 03:00:00 -04:00'
-            $after.UtcOffsetString | Should -Be 'UTC-04:00'
-            $after.IsDaylightSavingTime | Should -BeTrue
-            $after.Abbreviation | Should -Be 'EDT'
+            $after.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-03-08 03:00:00 -04:00'
+            $after.UtcOffsetString | Should-Be 'UTC-04:00'
+            $after.IsDaylightSavingTime | Should-BeTruthy
+            $after.Abbreviation | Should-Be 'EDT'
         }
 
         It 'Keeps offset-aware timestamps that land in the spring-forward gap on the correct Eastern side' {
             $invalidStandardSide = ConvertTo-USDateTime -InputObject '2026-03-08T02:30:00-05:00' -TimeZone Eastern
             $invalidDaylightSide = ConvertTo-USDateTime -InputObject '2026-03-08T02:30:00-04:00' -TimeZone Eastern
 
-            $invalidStandardSide.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-03-08 03:30:00 -04:00'
-            $invalidStandardSide.UtcOffsetString | Should -Be 'UTC-04:00'
-            $invalidStandardSide.IsDaylightSavingTime | Should -BeTrue
-            $invalidStandardSide.Abbreviation | Should -Be 'EDT'
+            $invalidStandardSide.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-03-08 03:30:00 -04:00'
+            $invalidStandardSide.UtcOffsetString | Should-Be 'UTC-04:00'
+            $invalidStandardSide.IsDaylightSavingTime | Should-BeTruthy
+            $invalidStandardSide.Abbreviation | Should-Be 'EDT'
 
-            $invalidDaylightSide.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-03-08 01:30:00 -05:00'
-            $invalidDaylightSide.UtcOffsetString | Should -Be 'UTC-05:00'
-            $invalidDaylightSide.IsDaylightSavingTime | Should -BeFalse
-            $invalidDaylightSide.Abbreviation | Should -Be 'EST'
+            $invalidDaylightSide.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-03-08 01:30:00 -05:00'
+            $invalidDaylightSide.UtcOffsetString | Should-Be 'UTC-05:00'
+            $invalidDaylightSide.IsDaylightSavingTime | Should-BeFalsy
+            $invalidDaylightSide.Abbreviation | Should-Be 'EST'
         }
 
         It 'Disambiguates the repeated Eastern fall-back hour by converted offset' {
             $daylightOccurrence = ConvertTo-USDateTime -InputObject '2026-11-01T05:30:00Z' -TimeZone Eastern
             $standardOccurrence = ConvertTo-USDateTime -InputObject '2026-11-01T06:30:00Z' -TimeZone Eastern
 
-            $daylightOccurrence.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-11-01 01:30:00 -04:00'
-            $daylightOccurrence.UtcOffsetString | Should -Be 'UTC-04:00'
-            $daylightOccurrence.IsDaylightSavingTime | Should -BeTrue
-            $daylightOccurrence.Abbreviation | Should -Be 'EDT'
+            $daylightOccurrence.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-11-01 01:30:00 -04:00'
+            $daylightOccurrence.UtcOffsetString | Should-Be 'UTC-04:00'
+            $daylightOccurrence.IsDaylightSavingTime | Should-BeTruthy
+            $daylightOccurrence.Abbreviation | Should-Be 'EDT'
 
-            $standardOccurrence.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-11-01 01:30:00 -05:00'
-            $standardOccurrence.UtcOffsetString | Should -Be 'UTC-05:00'
-            $standardOccurrence.IsDaylightSavingTime | Should -BeFalse
-            $standardOccurrence.Abbreviation | Should -Be 'EST'
+            $standardOccurrence.DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-11-01 01:30:00 -05:00'
+            $standardOccurrence.UtcOffsetString | Should-Be 'UTC-05:00'
+            $standardOccurrence.IsDaylightSavingTime | Should-BeFalsy
+            $standardOccurrence.Abbreviation | Should-Be 'EST'
         }
     }
 
@@ -202,21 +202,21 @@ Describe 'ConvertTo-USDateTime' -Tag 'Unit' {
                 '2026-01-15T13:00:00Z'
             ) | ConvertTo-USDateTime -TimeZone Hawaii
 
-            @($results).Count | Should -Be 2
-            $results[0].TimeZone | Should -Be 'Hawaii'
-            $results[1].TimeZone | Should -Be 'Hawaii'
-            $results[0].DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 02:00:00 -10:00'
-            $results[1].DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should -Be '2026-01-15 03:00:00 -10:00'
+            @($results).Count | Should-Be 2
+            $results[0].TimeZone | Should-Be 'Hawaii'
+            $results[1].TimeZone | Should-Be 'Hawaii'
+            $results[0].DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 02:00:00 -10:00'
+            $results[1].DateTime.ToString('yyyy-MM-dd HH:mm:ss zzz') | Should-Be '2026-01-15 03:00:00 -10:00'
         }
     }
 
     Context 'Error handling' {
         It 'Throws for invalid date strings' {
-            { ConvertTo-USDateTime -InputObject 'not-a-date' } | Should -Throw
+            { ConvertTo-USDateTime -InputObject 'not-a-date' } | Should-Throw
         }
 
         It 'Throws for unsupported timezone names' {
-            { ConvertTo-USDateTime -InputObject '2026-01-15T15:00:00Z' -TimeZone Mars } | Should -Throw
+            { ConvertTo-USDateTime -InputObject '2026-01-15T15:00:00Z' -TimeZone Mars } | Should-Throw
         }
     }
 }

--- a/Tests/Unit/Utilities/ConvertTo-UrlSlug.Tests.ps1
+++ b/Tests/Unit/Utilities/ConvertTo-UrlSlug.Tests.ps1
@@ -19,37 +19,37 @@ Describe 'ConvertTo-UrlSlug' -Tag 'Unit', 'Utilities' {
     Context 'String mode' {
         It 'Should convert text to a lowercase slug' {
             $result = ConvertTo-UrlSlug -InputObject 'Hello, World!'
-            $result | Should -Be 'hello-world'
+            $result | Should-Be 'hello-world'
         }
 
         It 'Should strip diacritics by default' {
             $slugInput = ('Cr{0}me br{1}l{2}e & caf{2}' -f [char]0x00E8, [char]0x00FB, [char]0x00E9)
             $result = ConvertTo-UrlSlug -InputObject $slugInput
-            $result | Should -Be 'creme-brulee-cafe'
+            $result | Should-Be 'creme-brulee-cafe'
         }
 
         It 'Should decode URL-encoded input' {
             $result = ConvertTo-UrlSlug -InputObject 'My%20Encoded%20Title'
-            $result | Should -Be 'my-encoded-title'
+            $result | Should-Be 'my-encoded-title'
         }
 
         It 'Should allow a custom separator' {
             $result = ConvertTo-UrlSlug -InputObject 'Hello World' -Separator '_'
-            $result | Should -Be 'hello_world'
+            $result | Should-Be 'hello_world'
         }
 
         It 'Should preserve unicode characters when KeepUnicode is specified' {
             $slugInput = ('{0}{1} 2026' -f [char]0x6771, [char]0x4EAC)
             $expected = ('{0}{1}-2026' -f [char]0x6771, [char]0x4EAC)
             $result = ConvertTo-UrlSlug -InputObject $slugInput -KeepUnicode
-            $result | Should -Be $expected
+            $result | Should-Be $expected
         }
 
         It 'Should accept multiple pipeline values' {
             $result = 'First Post', 'Second Post' | ConvertTo-UrlSlug
-            $result.Count | Should -Be 2
-            $result[0] | Should -Be 'first-post'
-            $result[1] | Should -Be 'second-post'
+            $result.Count | Should-Be 2
+            $result[0] | Should-Be 'first-post'
+            $result[1] | Should-Be 'second-post'
         }
     }
 
@@ -72,7 +72,7 @@ Describe 'ConvertTo-UrlSlug' -Tag 'Unit', 'Utilities' {
 
             ConvertTo-UrlSlug -LiteralPath $filePath
 
-            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'my-draft-file.txt') | Should -Be $true
+            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'my-draft-file.txt') | Should-Be $true
         }
 
         It 'Should rename a directory' {
@@ -81,7 +81,7 @@ Describe 'ConvertTo-UrlSlug' -Tag 'Unit', 'Utilities' {
 
             ConvertTo-UrlSlug -LiteralPath $directoryPath
 
-            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'release-notes-2026') | Should -Be $true
+            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'release-notes-2026') | Should-Be $true
         }
 
         It 'Should resolve name collisions with numeric suffixes' {
@@ -93,7 +93,7 @@ Describe 'ConvertTo-UrlSlug' -Tag 'Unit', 'Utilities' {
 
             ConvertTo-UrlSlug -LiteralPath $renamePath
 
-            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'my-file-2.txt') | Should -Be $true
+            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'my-file-2.txt') | Should-Be $true
         }
 
         It 'Should support WhatIf and not rename when specified' {
@@ -102,8 +102,8 @@ Describe 'ConvertTo-UrlSlug' -Tag 'Unit', 'Utilities' {
 
             ConvertTo-UrlSlug -LiteralPath $filePath -WhatIf
 
-            Test-Path -LiteralPath $filePath | Should -Be $true
-            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'what-if-name.txt') | Should -Be $false
+            Test-Path -LiteralPath $filePath | Should-Be $true
+            Test-Path -LiteralPath (Join-Path -Path $script:testRoot -ChildPath 'what-if-name.txt') | Should-Be $false
         }
 
         It 'Should return renamed item when PassThru is specified' {
@@ -113,7 +113,7 @@ Describe 'ConvertTo-UrlSlug' -Tag 'Unit', 'Utilities' {
             $result = ConvertTo-UrlSlug -LiteralPath $filePath -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Name | Should -Be 'pass-thru-me.txt'
+            $result.Name | Should-Be 'pass-thru-me.txt'
         }
 
         It 'Should rename from Get-ChildItem pipeline when PassThru is specified' {
@@ -123,7 +123,7 @@ Describe 'ConvertTo-UrlSlug' -Tag 'Unit', 'Utilities' {
             $result = Get-ChildItem -LiteralPath $script:testRoot -File | ConvertTo-UrlSlug -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Name | Should -Contain 'pipeline-rename.txt'
+            $result.Name | Should-ContainCollection 'pipeline-rename.txt'
         }
     }
 }

--- a/Tests/Unit/Utilities/Copy-Directory.Tests.ps1
+++ b/Tests/Unit/Utilities/Copy-Directory.Tests.ps1
@@ -33,25 +33,25 @@ Describe 'Copy-Directory' {
         It 'Should have mandatory Source parameter' {
             $command = Get-Command Copy-Directory
             $sourceParam = $command.Parameters['Source']
-            $sourceParam.Attributes.Mandatory | Should -Contain $true
+            $sourceParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should have mandatory Destination parameter' {
             $command = Get-Command Copy-Directory
             $destParam = $command.Parameters['Destination']
-            $destParam.Attributes.Mandatory | Should -Contain $true
+            $destParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should have optional ExcludeDirectories parameter' {
             $command = Get-Command Copy-Directory
             $excludeParam = $command.Parameters['ExcludeDirectories']
-            $excludeParam.Attributes.Mandatory | Should -Not -Contain $true
+            $excludeParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should have optional ExcludeFiles parameter' {
             $command = Get-Command Copy-Directory
             $excludeParam = $command.Parameters['ExcludeFiles']
-            $excludeParam.Attributes.Mandatory | Should -Not -Contain $true
+            $excludeParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should have UpdateMode parameter with correct default' {
@@ -64,31 +64,31 @@ Describe 'Copy-Directory' {
             $command = Get-Command Copy-Directory
             $updateModeParam = $command.Parameters['UpdateMode']
             $validateSet = $updateModeParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
-            $validateSet.ValidValues | Should -Contain 'Skip'
-            $validateSet.ValidValues | Should -Contain 'Overwrite'
-            $validateSet.ValidValues | Should -Contain 'IfNewer'
-            $validateSet.ValidValues | Should -Contain 'Prompt'
-            $validateSet.ValidValues.Count | Should -Be 4
+            $validateSet.ValidValues | Should-ContainCollection 'Skip'
+            $validateSet.ValidValues | Should-ContainCollection 'Overwrite'
+            $validateSet.ValidValues | Should-ContainCollection 'IfNewer'
+            $validateSet.ValidValues | Should-ContainCollection 'Prompt'
+            $validateSet.ValidValues.Count | Should-Be 4
         }
 
         It 'Should support ShouldProcess (WhatIf/Confirm)' {
             $command = Get-Command Copy-Directory
-            $command.Parameters.ContainsKey('WhatIf') | Should -Be $true
-            $command.Parameters.ContainsKey('Confirm') | Should -Be $true
+            $command.Parameters.ContainsKey('WhatIf') | Should-Be $true
+            $command.Parameters.ContainsKey('Confirm') | Should-Be $true
         }
 
         It 'Should expose optional Recurse switch' {
             $command = Get-Command Copy-Directory
             $recurseParam = $command.Parameters['Recurse']
             $recurseParam | Should -Not -BeNullOrEmpty
-            $recurseParam.Attributes.Mandatory | Should -Not -Contain $true
+            $recurseParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should have optional ThrottleLimit parameter' {
             $command = Get-Command Copy-Directory
             $throttleParam = $command.Parameters['ThrottleLimit']
             $throttleParam | Should -Not -BeNullOrEmpty
-            $throttleParam.Attributes.Mandatory | Should -Not -Contain $true
+            $throttleParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should have ThrottleLimit parameter with ValidateRange(1,32)' {
@@ -96,14 +96,14 @@ Describe 'Copy-Directory' {
             $throttleParam = $command.Parameters['ThrottleLimit']
             $validateRange = $throttleParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
             $validateRange | Should -Not -BeNullOrEmpty
-            $validateRange.MinRange | Should -Be 1
-            $validateRange.MaxRange | Should -Be 32
+            $validateRange.MinRange | Should-Be 1
+            $validateRange.MaxRange | Should-Be 32
         }
 
         It 'Should have ThrottleLimit parameter type Int32' {
             $command = Get-Command Copy-Directory
             $throttleParam = $command.Parameters['ThrottleLimit']
-            $throttleParam.ParameterType | Should -Be ([Int32])
+            $throttleParam.ParameterType | Should-Be ([Int32])
         }
     }
 
@@ -115,7 +115,7 @@ Describe 'Copy-Directory' {
             'content' | Set-Content -Path "$testSource\test.txt"
 
             { Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 1 } | Should -Not -Throw
-            Test-Path "$testDest\test.txt" | Should -BeTrue
+            Test-Path "$testDest\test.txt" | Should-BeTruthy
         }
 
         It 'Should accept ThrottleLimit of 8' {
@@ -125,7 +125,7 @@ Describe 'Copy-Directory' {
             'content' | Set-Content -Path "$testSource\test.txt"
 
             { Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 8 } | Should -Not -Throw
-            Test-Path "$testDest\test.txt" | Should -BeTrue
+            Test-Path "$testDest\test.txt" | Should-BeTruthy
         }
 
         It 'Should accept ThrottleLimit of 32 (maximum)' {
@@ -135,7 +135,7 @@ Describe 'Copy-Directory' {
             'content' | Set-Content -Path "$testSource\test.txt"
 
             { Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 32 } | Should -Not -Throw
-            Test-Path "$testDest\test.txt" | Should -BeTrue
+            Test-Path "$testDest\test.txt" | Should-BeTruthy
         }
 
         It 'Should reject ThrottleLimit of 0' {
@@ -143,7 +143,7 @@ Describe 'Copy-Directory' {
             $testDest = Join-Path -Path $TestDrive -ChildPath 'throttle0_dest'
             New-Item -ItemType Directory -Path $testSource -Force | Out-Null
 
-            { Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 0 } | Should -Throw
+            { Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 0 } | Should-Throw
         }
 
         It 'Should reject ThrottleLimit greater than 32' {
@@ -151,7 +151,7 @@ Describe 'Copy-Directory' {
             $testDest = Join-Path -Path $TestDrive -ChildPath 'throttle33_dest'
             New-Item -ItemType Directory -Path $testSource -Force | Out-Null
 
-            { Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 33 } | Should -Throw
+            { Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 33 } | Should-Throw
         }
 
         It 'Should disable parallel processing when UpdateMode is Prompt' {
@@ -176,10 +176,10 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ThrottleLimit 4
 
-            $result.TotalFiles | Should -Be 10
+            $result.TotalFiles | Should-Be 10
             1..10 | ForEach-Object {
-                Test-Path "$testDest\file$_.txt" | Should -BeTrue
-                (Get-Content -Path "$testDest\file$_.txt") | Should -Be "content $_"
+                Test-Path "$testDest\file$_.txt" | Should-BeTruthy
+                (Get-Content -Path "$testDest\file$_.txt") | Should-Be "content $_"
             }
         }
 
@@ -200,9 +200,9 @@ Describe 'Copy-Directory' {
             $resultSeq = Copy-Directory -Source $testSourceSeq -Destination $testDestSeq -ThrottleLimit 1
             $resultPar = Copy-Directory -Source $testSourcePar -Destination $testDestPar -ThrottleLimit 4
 
-            $resultSeq.TotalFiles | Should -Be $resultPar.TotalFiles
-            $resultSeq.FilesSkipped | Should -Be $resultPar.FilesSkipped
-            $resultSeq.FilesOverwritten | Should -Be $resultPar.FilesOverwritten
+            $resultSeq.TotalFiles | Should-Be $resultPar.TotalFiles
+            $resultSeq.FilesSkipped | Should-Be $resultPar.FilesSkipped
+            $resultSeq.FilesOverwritten | Should-Be $resultPar.FilesOverwritten
         }
     }
 
@@ -218,9 +218,9 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip
 
-            Test-Path (Join-Path -Path $testDest -ChildPath 'root.txt') | Should -BeTrue
-            Test-Path (Join-Path -Path $testDest -ChildPath 'subdir/nested.txt') | Should -BeFalse
-            $result.TotalDirectories | Should -Be 0
+            Test-Path (Join-Path -Path $testDest -ChildPath 'root.txt') | Should-BeTruthy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'subdir/nested.txt') | Should-BeFalsy
+            $result.TotalDirectories | Should-Be 0
         }
     }
 
@@ -237,8 +237,8 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -Recurse
 
-            $result.FilesSkipped | Should -Be 1
-            (Get-Content -Path "$testDest\test.txt") | Should -Be 'old content'
+            $result.FilesSkipped | Should-Be 1
+            (Get-Content -Path "$testDest\test.txt") | Should-Be 'old content'
         }
         It 'Should return PSCustomObject with expected properties' {
             $testSource = Join-Path -Path $TestDrive -ChildPath 'source'
@@ -248,12 +248,12 @@ Describe 'Copy-Directory' {
             $result = Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip -Recurse
 
             $result | Should -Not -BeNullOrEmpty
-            $result.PSObject.Properties.Name | Should -Contain 'TotalFiles'
-            $result.PSObject.Properties.Name | Should -Contain 'TotalDirectories'
-            $result.PSObject.Properties.Name | Should -Contain 'ExcludedDirectories'
-            $result.PSObject.Properties.Name | Should -Contain 'FilesSkipped'
-            $result.PSObject.Properties.Name | Should -Contain 'FilesOverwritten'
-            $result.PSObject.Properties.Name | Should -Contain 'Duration'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'TotalFiles'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'TotalDirectories'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ExcludedDirectories'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FilesSkipped'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FilesOverwritten'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Duration'
         }
 
         It 'Should have correct property types' {
@@ -263,12 +263,12 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip -Recurse
 
-            $result.TotalFiles | Should -BeOfType [Int32]
-            $result.TotalDirectories | Should -BeOfType [Int32]
-            $result.ExcludedDirectories | Should -BeOfType [Int32]
-            $result.FilesSkipped | Should -BeOfType [Int32]
-            $result.FilesOverwritten | Should -BeOfType [Int32]
-            $result.Duration | Should -BeOfType [TimeSpan]
+            $result.TotalFiles | Should-HaveType ([Int32])
+            $result.TotalDirectories | Should-HaveType ([Int32])
+            $result.ExcludedDirectories | Should-HaveType ([Int32])
+            $result.FilesSkipped | Should-HaveType ([Int32])
+            $result.FilesOverwritten | Should-HaveType ([Int32])
+            $result.Duration | Should-HaveType ([TimeSpan])
         }
 
         It 'Should have zero values for empty source directory' {
@@ -278,11 +278,11 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip -Recurse
 
-            $result.TotalFiles | Should -Be 0
-            $result.TotalDirectories | Should -Be 0
-            $result.ExcludedDirectories | Should -Be 0
-            $result.FilesSkipped | Should -Be 0
-            $result.FilesOverwritten | Should -Be 0
+            $result.TotalFiles | Should-Be 0
+            $result.TotalDirectories | Should-Be 0
+            $result.ExcludedDirectories | Should-Be 0
+            $result.FilesSkipped | Should-Be 0
+            $result.FilesOverwritten | Should-Be 0
         }
     }
 
@@ -295,7 +295,7 @@ Describe 'Copy-Directory' {
 
             { Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip -Recurse } | Should -Not -Throw
 
-            Test-Path $testDest | Should -Be $true
+            Test-Path $testDest | Should-Be $true
         }
 
         It 'Should handle relative paths' {
@@ -308,7 +308,7 @@ Describe 'Copy-Directory' {
 
                 { Copy-Directory -Source './relative_source' -Destination './relative_dest' -UpdateMode Skip -Recurse } | Should -Not -Throw
 
-                Test-Path 'relative_dest' | Should -Be $true
+                Test-Path 'relative_dest' | Should-Be $true
             }
             finally
             {
@@ -320,7 +320,7 @@ Describe 'Copy-Directory' {
             $nonExistentSource = Join-Path -Path $TestDrive -ChildPath 'non_existent'
             $testDest = Join-Path -Path $TestDrive -ChildPath 'dest'
 
-            { Copy-Directory -Source $nonExistentSource -Destination $testDest -UpdateMode Skip -Recurse } | Should -Throw
+            { Copy-Directory -Source $nonExistentSource -Destination $testDest -UpdateMode Skip -Recurse } | Should-Throw
         }
 
         It 'Should throw when source and destination are the same directory' {
@@ -330,7 +330,7 @@ Describe 'Copy-Directory' {
 
             {
                 Copy-Directory -Source $testPath -Destination $testPath -UpdateMode Skip -Recurse
-            } | Should -Throw -ExpectedMessage '*same directory*'
+            } | Should-Throw -ExceptionMessage '*same directory*'
         }
 
         It 'Should throw when recursive destination is inside source' {
@@ -341,7 +341,7 @@ Describe 'Copy-Directory' {
 
             {
                 Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip -Recurse
-            } | Should -Throw -ExpectedMessage '*inside the source directory*'
+            } | Should-Throw -ExceptionMessage '*inside the source directory*'
         }
 
         It 'Should throw when destination path exists as a file' {
@@ -353,7 +353,7 @@ Describe 'Copy-Directory' {
 
             {
                 Copy-Directory -Source $testSource -Destination $testDestFile -UpdateMode Skip
-            } | Should -Throw -ExpectedMessage '*exists as a file*'
+            } | Should-Throw -ExceptionMessage '*exists as a file*'
         }
 
         It 'Should allow non-recursive copy when destination is inside source' {
@@ -367,8 +367,8 @@ Describe 'Copy-Directory' {
                 Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip
             } | Should -Not -Throw
 
-            Test-Path (Join-Path -Path $testDest -ChildPath 'root.txt') | Should -BeTrue
-            Test-Path (Join-Path -Path $testDest -ChildPath 'subdir/nested.txt') | Should -BeFalse
+            Test-Path (Join-Path -Path $testDest -ChildPath 'root.txt') | Should-BeTruthy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'subdir/nested.txt') | Should-BeFalsy
         }
     }
 
@@ -384,9 +384,9 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeDirectories '.git' -UpdateMode Skip -Recurse
 
-            $result.ExcludedDirectories | Should -Be 1
-            Test-Path "$testDest\.git" | Should -Be $false
-            Test-Path "$testDest\include" | Should -Be $true
+            $result.ExcludedDirectories | Should-Be 1
+            Test-Path "$testDest\.git" | Should-Be $false
+            Test-Path "$testDest\include" | Should-Be $true
         }
 
         It 'Should exclude multiple directories' {
@@ -401,11 +401,11 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeDirectories '.git', 'node_modules', 'bin' -UpdateMode Skip -Recurse
 
-            $result.ExcludedDirectories | Should -Be 3
-            Test-Path "$testDest\.git" | Should -Be $false
-            Test-Path "$testDest\node_modules" | Should -Be $false
-            Test-Path "$testDest\bin" | Should -Be $false
-            Test-Path "$testDest\src" | Should -Be $true
+            $result.ExcludedDirectories | Should-Be 3
+            Test-Path "$testDest\.git" | Should-Be $false
+            Test-Path "$testDest\node_modules" | Should-Be $false
+            Test-Path "$testDest\bin" | Should-Be $false
+            Test-Path "$testDest\src" | Should-Be $true
         }
 
         It 'Should perform case-insensitive directory exclusion' {
@@ -417,8 +417,8 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeDirectories '.git' -UpdateMode Skip -Recurse
 
-            $result.ExcludedDirectories | Should -Be 1
-            Test-Path "$testDest\.GIT" | Should -Be $false
+            $result.ExcludedDirectories | Should-Be 1
+            Test-Path "$testDest\.GIT" | Should-Be $false
         }
 
         It 'Should support wildcard directory exclusions' {
@@ -434,10 +434,10 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeDirectories 'cache-*' -UpdateMode Skip -Recurse
 
-            $result.ExcludedDirectories | Should -Be 2
-            Test-Path "$testDest\cache-api" | Should -Be $false
-            Test-Path "$testDest\cache-ui" | Should -Be $false
-            Test-Path "$testDest\src\main.txt" | Should -Be $true
+            $result.ExcludedDirectories | Should-Be 2
+            Test-Path "$testDest\cache-api" | Should-Be $false
+            Test-Path "$testDest\cache-ui" | Should-Be $false
+            Test-Path "$testDest\src\main.txt" | Should-Be $true
         }
 
         It 'Should exclude specified files' {
@@ -453,11 +453,11 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeFiles 'secret.txt' -UpdateMode Skip -Recurse
 
-            $result.TotalFiles | Should -Be 2
-            Test-Path (Join-Path -Path $testDest -ChildPath 'keep.txt') | Should -BeTrue
-            Test-Path (Join-Path -Path $testDest -ChildPath 'secret.txt') | Should -BeFalse
-            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/keep.md') | Should -BeTrue
-            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/secret.txt') | Should -BeFalse
+            $result.TotalFiles | Should-Be 2
+            Test-Path (Join-Path -Path $testDest -ChildPath 'keep.txt') | Should-BeTruthy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'secret.txt') | Should-BeFalsy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/keep.md') | Should-BeTruthy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/secret.txt') | Should-BeFalsy
         }
 
         It 'Should support wildcard file exclusions' {
@@ -473,11 +473,11 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeFiles '*.log' -UpdateMode Skip -Recurse
 
-            $result.TotalFiles | Should -Be 2
-            Test-Path (Join-Path -Path $testDest -ChildPath 'keep.txt') | Should -BeTrue
-            Test-Path (Join-Path -Path $testDest -ChildPath 'debug.log') | Should -BeFalse
-            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/trace.log') | Should -BeFalse
-            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/data.json') | Should -BeTrue
+            $result.TotalFiles | Should-Be 2
+            Test-Path (Join-Path -Path $testDest -ChildPath 'keep.txt') | Should-BeTruthy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'debug.log') | Should-BeFalsy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/trace.log') | Should-BeFalsy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'nested/data.json') | Should-BeTruthy
         }
 
         It 'Should perform case-insensitive file exclusion' {
@@ -490,9 +490,9 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeFiles 'readme.md' -UpdateMode Skip -Recurse
 
-            $result.TotalFiles | Should -Be 1
-            Test-Path (Join-Path -Path $testDest -ChildPath 'README.MD') | Should -BeFalse
-            Test-Path (Join-Path -Path $testDest -ChildPath 'notes.txt') | Should -BeTrue
+            $result.TotalFiles | Should-Be 1
+            Test-Path (Join-Path -Path $testDest -ChildPath 'README.MD') | Should-BeFalsy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'notes.txt') | Should-BeTruthy
         }
 
         It 'Should exclude files and directories when using native tools' {
@@ -514,10 +514,10 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -ExcludeDirectories '.git' -ExcludeFiles '*.log' -UpdateMode Skip -Recurse -UseNativeTools
 
-            $result.TotalFiles | Should -Be 1
-            Test-Path (Join-Path -Path $testDest -ChildPath 'keep.txt') | Should -BeTrue
-            Test-Path (Join-Path -Path $testDest -ChildPath 'debug.log') | Should -BeFalse
-            Test-Path (Join-Path -Path $testDest -ChildPath '.git') | Should -BeFalse
+            $result.TotalFiles | Should-Be 1
+            Test-Path (Join-Path -Path $testDest -ChildPath 'keep.txt') | Should-BeTruthy
+            Test-Path (Join-Path -Path $testDest -ChildPath 'debug.log') | Should-BeFalsy
+            Test-Path (Join-Path -Path $testDest -ChildPath '.git') | Should-BeFalsy
         }
 
         It 'Should accept Skip mode explicitly' {
@@ -532,8 +532,8 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Skip -Recurse
 
-            $result.FilesSkipped | Should -Be 1
-            (Get-Content -Path "$testDest\test.txt") | Should -Be 'old content'
+            $result.FilesSkipped | Should-Be 1
+            (Get-Content -Path "$testDest\test.txt") | Should-Be 'old content'
         }
 
         It 'Should accept Overwrite mode' {
@@ -548,8 +548,8 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Overwrite -Recurse
 
-            $result.FilesOverwritten | Should -Be 1
-            (Get-Content -Path "$testDest\test.txt") | Should -Be 'new content'
+            $result.FilesOverwritten | Should-Be 1
+            (Get-Content -Path "$testDest\test.txt") | Should-Be 'new content'
         }
 
         It 'Should accept IfNewer mode' {
@@ -565,8 +565,8 @@ Describe 'Copy-Directory' {
 
             $result = Copy-Directory -Source $testSource -Destination $testDest -UpdateMode IfNewer -Recurse
 
-            $result.FilesOverwritten | Should -Be 1
-            (Get-Content -Path "$testDest\test.txt") | Should -Be 'new content'
+            $result.FilesOverwritten | Should-Be 1
+            (Get-Content -Path "$testDest\test.txt") | Should-Be 'new content'
         }
 
         It 'Should accept Prompt mode' {
@@ -583,7 +583,7 @@ Describe 'Copy-Directory' {
             Copy-Directory -Source $testSource -Destination $testDest -UpdateMode Prompt -WhatIf -Recurse | Out-Null
 
             # With -WhatIf, no actual copy happens
-            (Get-Content -Path "$testDest\test.txt") | Should -Be 'old content'
+            (Get-Content -Path "$testDest\test.txt") | Should-Be 'old content'
         }
     }
 }

--- a/Tests/Unit/Utilities/Extract-Archive.Tests.ps1
+++ b/Tests/Unit/Utilities/Extract-Archive.Tests.ps1
@@ -24,24 +24,24 @@ Describe 'Extract-Archive' {
         It 'Should accept optional Path parameter with pipeline support' {
             $command = Get-Command Extract-Archive
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Mandatory | Should -Not -Contain $true
-            $pathParam.Attributes.ValueFromPipeline | Should -Contain $true
+            $pathParam.Attributes.Mandatory | Should-NotContainCollection $true
+            $pathParam.Attributes.ValueFromPipeline | Should-ContainCollection $true
         }
 
         It 'Should expose Include, Exclude, DestinationRoot, and merging parameters' {
             $command = Get-Command Extract-Archive
-            $command.Parameters.ContainsKey('Include') | Should -Be $true
-            $command.Parameters.ContainsKey('Exclude') | Should -Be $true
-            $command.Parameters.ContainsKey('DestinationRoot') | Should -Be $true
-            $command.Parameters.ContainsKey('ExtractNested') | Should -Be $true
-            $command.Parameters.ContainsKey('DeleteArchive') | Should -Be $true
-            $command.Parameters.ContainsKey('MergeMultipartAcrossDirectories') | Should -Be $true
+            $command.Parameters.ContainsKey('Include') | Should-Be $true
+            $command.Parameters.ContainsKey('Exclude') | Should-Be $true
+            $command.Parameters.ContainsKey('DestinationRoot') | Should-Be $true
+            $command.Parameters.ContainsKey('ExtractNested') | Should-Be $true
+            $command.Parameters.ContainsKey('DeleteArchive') | Should-Be $true
+            $command.Parameters.ContainsKey('MergeMultipartAcrossDirectories') | Should-Be $true
         }
 
         It 'Should support ShouldProcess (WhatIf/Confirm)' {
             $command = Get-Command Extract-Archive
-            $command.Parameters.ContainsKey('WhatIf') | Should -Be $true
-            $command.Parameters.ContainsKey('Confirm') | Should -Be $true
+            $command.Parameters.ContainsKey('WhatIf') | Should-Be $true
+            $command.Parameters.ContainsKey('Confirm') | Should-Be $true
         }
 
         It 'Should declare OutputType' {
@@ -63,9 +63,9 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root
 
             $destination = Join-Path -Path $root -ChildPath 'archive'
-            Test-Path $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'hello world'
-            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should -Be 'Extracted'
+            Test-Path $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'hello world'
+            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should-Be 'Extracted'
         }
 
         It 'Extracts archives recursively when -Recurse is specified' {
@@ -81,9 +81,9 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root -Recurse
 
             $destination = Join-Path -Path $nested -ChildPath 'nested'
-            Test-Path $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'data.txt')) | Should -Be 'nested content'
-            $result.Extracted | Should -BeGreaterThan 0
+            Test-Path $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'data.txt')) | Should-Be 'nested content'
+            $result.Extracted | Should-BeGreaterThan 0
         }
     }
 
@@ -106,8 +106,8 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root
 
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'modified'
-            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should -Be 'SkippedExisting'
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'modified'
+            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should-Be 'SkippedExisting'
         }
 
         It 'Overwrites destination when Force is provided' {
@@ -127,8 +127,8 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root -Force
 
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'fresh'
-            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should -Be 'Extracted'
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'fresh'
+            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should-Be 'Extracted'
         }
 
         It 'Respects WhatIf when Force would overwrite destination' {
@@ -148,8 +148,8 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root -Force -WhatIf
 
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'stale'
-            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should -Be 'SkippedWhatIf'
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'stale'
+            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should-Be 'SkippedWhatIf'
         }
     }
 
@@ -165,11 +165,11 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root -DeleteArchive
 
-            Test-Path -LiteralPath $zipPath | Should -Be $false
+            Test-Path -LiteralPath $zipPath | Should-Be $false
             $destination = Join-Path -Path $root -ChildPath 'archive'
-            Test-Path -LiteralPath $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'content'
-            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should -Be 'Extracted'
+            Test-Path -LiteralPath $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'content'
+            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should-Be 'Extracted'
         }
 
         It 'Keeps archive when extraction is skipped due to existing destination' {
@@ -185,8 +185,8 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root -DeleteArchive
 
-            Test-Path -LiteralPath $zipPath | Should -Be $true
-            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should -Be 'SkippedExisting'
+            Test-Path -LiteralPath $zipPath | Should-Be $true
+            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should-Be 'SkippedExisting'
         }
 
         It 'Deletes archives discovered recursively' {
@@ -201,11 +201,11 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root -Recurse -DeleteArchive
 
-            Test-Path -LiteralPath $zipPath | Should -Be $false
+            Test-Path -LiteralPath $zipPath | Should-Be $false
             $destination = Join-Path -Path $nested -ChildPath 'archive'
-            Test-Path -LiteralPath $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'recursive'
-            $result.Extracted | Should -BeGreaterThan 0
+            Test-Path -LiteralPath $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'recursive'
+            $result.Extracted | Should-BeGreaterThan 0
         }
 
         It 'Deletes nested archives when ExtractNested is specified' {
@@ -233,12 +233,12 @@ Describe 'Extract-Archive' {
             $innerDestination = Join-Path -Path $outerDestination -ChildPath 'inner'
             $innerZipPath = Join-Path -Path $outerDestination -ChildPath 'inner.zip'
 
-            Test-Path -LiteralPath $outerZip | Should -Be $false
-            Test-Path -LiteralPath $innerZipPath | Should -Be $false
-            Test-Path -LiteralPath $innerDestination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $innerDestination -ChildPath 'payload.txt')) | Should -Be 'nested payload'
-            ($result.Results | Where-Object { $_.Archive -eq $outerZip }).Status | Should -Be 'Extracted'
-            ($result.Results | Where-Object { $_.Archive -eq $innerZipPath }).Status | Should -Be 'Extracted'
+            Test-Path -LiteralPath $outerZip | Should-Be $false
+            Test-Path -LiteralPath $innerZipPath | Should-Be $false
+            Test-Path -LiteralPath $innerDestination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $innerDestination -ChildPath 'payload.txt')) | Should-Be 'nested payload'
+            ($result.Results | Where-Object { $_.Archive -eq $outerZip }).Status | Should-Be 'Extracted'
+            ($result.Results | Where-Object { $_.Archive -eq $innerZipPath }).Status | Should-Be 'Extracted'
         }
 
         It 'Deletes multipart archives and all parts after extraction' -Skip:($null -eq (Get-Command -Name '7z', '7za' -ErrorAction SilentlyContinue | Select-Object -First 1)) {
@@ -267,9 +267,9 @@ Describe 'Extract-Archive' {
             $remainingParts | Should -BeNullOrEmpty
 
             $destination = Join-Path -Path $root -ChildPath 'multi'
-            Test-Path -LiteralPath $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'multipart content'
-            ($result.Results | Where-Object { $_.Archive -like '*multi.7z.001' }).Status | Should -Be 'Extracted'
+            Test-Path -LiteralPath $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'multipart content'
+            ($result.Results | Where-Object { $_.Archive -like '*multi.7z.001' }).Status | Should-Be 'Extracted'
         }
 
         It 'Deletes split zip archives that use .z01 style parts after extraction' -Skip:(($null -eq (Get-Command -Name 'zip' -ErrorAction SilentlyContinue)) -or ($null -eq (Get-Command -Name '7z', '7za' -ErrorAction SilentlyContinue | Select-Object -First 1))) {
@@ -303,10 +303,10 @@ Describe 'Extract-Archive' {
                 Where-Object { $_.Name -like 'split.z??' -or $_.Name -like 'split.z???' -or $_.Name -eq 'split.zip' }
 
             $remainingParts | Should -BeNullOrEmpty
-            Test-Path -LiteralPath $destination | Should -Be $true
-            Test-Path -LiteralPath $extractedFile | Should -Be $true
-            (Get-Item -LiteralPath $extractedFile).Length | Should -Be (Get-Item -LiteralPath $payloadFile).Length
-            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should -Be 'Extracted'
+            Test-Path -LiteralPath $destination | Should-Be $true
+            Test-Path -LiteralPath $extractedFile | Should-Be $true
+            (Get-Item -LiteralPath $extractedFile).Length | Should-Be (Get-Item -LiteralPath $payloadFile).Length
+            ($result.Results | Where-Object { $_.Archive -eq $zipPath }).Status | Should-Be 'Extracted'
         }
     }
 
@@ -327,9 +327,9 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root -Include 'alpha*'
 
-            Test-Path (Join-Path -Path $root -ChildPath 'alpha') | Should -Be $true
-            Test-Path (Join-Path -Path $root -ChildPath 'beta') | Should -Be $false
-            $result.TotalArchives | Should -Be 1
+            Test-Path (Join-Path -Path $root -ChildPath 'alpha') | Should-Be $true
+            Test-Path (Join-Path -Path $root -ChildPath 'beta') | Should-Be $false
+            $result.TotalArchives | Should-Be 1
         }
 
         It 'Applies Exclude patterns to skip archives' {
@@ -348,9 +348,9 @@ Describe 'Extract-Archive' {
 
             $result = Extract-Archive -Path $root -Exclude 'beta*'
 
-            Test-Path (Join-Path -Path $root -ChildPath 'alpha') | Should -Be $true
-            Test-Path (Join-Path -Path $root -ChildPath 'beta') | Should -Be $false
-            $result.TotalArchives | Should -Be 1
+            Test-Path (Join-Path -Path $root -ChildPath 'alpha') | Should-Be $true
+            Test-Path (Join-Path -Path $root -ChildPath 'beta') | Should-Be $false
+            $result.TotalArchives | Should-Be 1
         }
 
         It 'Extracts into a custom DestinationRoot while keeping per-archive folders' {
@@ -366,8 +366,8 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root -DestinationRoot $customRoot
 
             $destination = Join-Path -Path $customRoot -ChildPath 'archive'
-            Test-Path $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'payload'
+            Test-Path $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'payload'
             $result.Results | Where-Object { $_.Destination -eq $destination } | Should -Not -BeNullOrEmpty
         }
     }
@@ -394,9 +394,9 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root
 
             $destination = Join-Path -Path $root -ChildPath 'archive'
-            Test-Path $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'tar content'
-            ($result.Results | Where-Object { $_.Archive -eq $tarPath }).Status | Should -Be 'Extracted'
+            Test-Path $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'tar content'
+            ($result.Results | Where-Object { $_.Archive -eq $tarPath }).Status | Should-Be 'Extracted'
         }
 
         It 'Extracts 7z archives when 7z/7za is available' -Skip:($null -eq (Get-Command -Name '7z', '7za' -ErrorAction SilentlyContinue | Select-Object -First 1)) {
@@ -420,9 +420,9 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root
 
             $destination = Join-Path -Path $root -ChildPath 'archive'
-            Test-Path $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be '7z content'
-            ($result.Results | Where-Object { $_.Archive -eq $sevenZipPath }).Status | Should -Be 'Extracted'
+            Test-Path $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be '7z content'
+            ($result.Results | Where-Object { $_.Archive -eq $sevenZipPath }).Status | Should-Be 'Extracted'
         }
 
         It 'Extracts rar archives via 7z/7za when available' -Skip:($null -eq (Get-Command -Name '7z', '7za' -ErrorAction SilentlyContinue | Select-Object -First 1)) {
@@ -446,9 +446,9 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root
 
             $destination = Join-Path -Path $root -ChildPath 'archive'
-            Test-Path $destination | Should -Be $true
-            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should -Be 'rar content'
-            ($result.Results | Where-Object { $_.Archive -eq $rarPath }).Status | Should -Be 'Extracted'
+            Test-Path $destination | Should-Be $true
+            (Get-Content -Path (Join-Path -Path $destination -ChildPath 'file.txt')) | Should-Be 'rar content'
+            ($result.Results | Where-Object { $_.Archive -eq $rarPath }).Status | Should-Be 'Extracted'
         }
     }
 
@@ -499,12 +499,12 @@ Describe 'Extract-Archive' {
             $payloadDestination = Join-Path -Path $wrapperDestination -ChildPath 'payload'
             $extractedFile = Join-Path -Path $payloadDestination -ChildPath 'data.bin'
 
-            Test-Path $wrapperDestination | Should -Be $true
-            Test-Path $payloadDestination | Should -Be $true
-            Test-Path $extractedFile | Should -Be $true
-            (Get-Item -LiteralPath $extractedFile).Length | Should -Be (Get-Item -LiteralPath $payloadFile).Length
-            ($result.Results | Where-Object { $_.Archive -like '*wrapper.zip*' }).Status | Should -Be 'Extracted'
-            ($result.Results | Where-Object { $_.Archive -like '*payload.rar.001' }).Status | Should -Be 'Extracted'
+            Test-Path $wrapperDestination | Should-Be $true
+            Test-Path $payloadDestination | Should-Be $true
+            Test-Path $extractedFile | Should-Be $true
+            (Get-Item -LiteralPath $extractedFile).Length | Should-Be (Get-Item -LiteralPath $payloadFile).Length
+            ($result.Results | Where-Object { $_.Archive -like '*wrapper.zip*' }).Status | Should-Be 'Extracted'
+            ($result.Results | Where-Object { $_.Archive -like '*payload.rar.001' }).Status | Should-Be 'Extracted'
         }
 
         It 'Merges multipart parts across directories when requested' -Skip:($null -eq (Get-Command -Name '7z', '7za' -ErrorAction SilentlyContinue | Select-Object -First 1)) {
@@ -550,11 +550,11 @@ Describe 'Extract-Archive' {
             $payloadDestination = Join-Path -Path $root -ChildPath 'payload'
             $extractedFile = Join-Path -Path $payloadDestination -ChildPath 'data.bin'
 
-            Test-Path $payloadDestination | Should -Be $true
-            Test-Path $extractedFile | Should -Be $true
-            (Get-Item -LiteralPath $extractedFile).Length | Should -Be (Get-Item -LiteralPath $payloadFile).Length
-            ($result.Results | Where-Object { $_.Archive -like '*wrapper1.zip' }).Status | Should -Be 'Extracted'
-            ($result.Results | Where-Object { $_.Archive -like '*payload.rar.001' }).Status | Should -Be 'Extracted'
+            Test-Path $payloadDestination | Should-Be $true
+            Test-Path $extractedFile | Should-Be $true
+            (Get-Item -LiteralPath $extractedFile).Length | Should-Be (Get-Item -LiteralPath $payloadFile).Length
+            ($result.Results | Where-Object { $_.Archive -like '*wrapper1.zip' }).Status | Should-Be 'Extracted'
+            ($result.Results | Where-Object { $_.Archive -like '*payload.rar.001' }).Status | Should-Be 'Extracted'
         }
     }
 
@@ -570,9 +570,9 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root
 
             $entry = $result.Results | Where-Object { $_.Archive -eq (Join-Path -Path $root -ChildPath 'archive.tar') }
-            $entry.Status | Should -Be 'SkippedMissingDependency'
-            $entry.ErrorMessage | Should -Match 'tar'
-            Test-Path (Join-Path -Path $root -ChildPath 'archive') | Should -Be $false
+            $entry.Status | Should-Be 'SkippedMissingDependency'
+            $entry.ErrorMessage | Should-MatchString 'tar'
+            Test-Path (Join-Path -Path $root -ChildPath 'archive') | Should-Be $false
         }
 
         It 'Skips 7z/rar archives when 7z dependency is missing' {
@@ -586,9 +586,9 @@ Describe 'Extract-Archive' {
             $result = Extract-Archive -Path $root
 
             $entry = $result.Results | Where-Object { $_.Archive -eq (Join-Path -Path $root -ChildPath 'archive.7z') }
-            $entry.Status | Should -Be 'SkippedMissingDependency'
-            $entry.ErrorMessage | Should -Match '7z'
-            Test-Path (Join-Path -Path $root -ChildPath 'archive') | Should -Be $false
+            $entry.Status | Should-Be 'SkippedMissingDependency'
+            $entry.ErrorMessage | Should-MatchString '7z'
+            Test-Path (Join-Path -Path $root -ChildPath 'archive') | Should-Be $false
         }
     }
 }

--- a/Tests/Unit/Utilities/Format-Byte.Tests.ps1
+++ b/Tests/Unit/Utilities/Format-Byte.Tests.ps1
@@ -10,87 +10,87 @@ Describe 'Format-Byte' {
     Context 'Storage conversions (IEC 1024)' {
         It 'Converts 1048576 bytes to 1 MB (IEC)' {
             $result = Format-Byte -Value 1048576 -Base 1024
-            $result.Bytes | Should -Be 1048576
-            $result.Kilobytes | Should -Be 1024
-            $result.Megabytes | Should -Be 1
+            $result.Bytes | Should-Be 1048576
+            $result.Kilobytes | Should-Be 1024
+            $result.Megabytes | Should-Be 1
         }
         It 'Parses string "1 MB" as megabytes (IEC base)' {
             $result = Format-Byte -Value '1 MB' -Base 1024
-            $result.Megabytes | Should -Be 1
-            $result.Bytes | Should -Be 1048576
+            $result.Megabytes | Should-Be 1
+            $result.Bytes | Should-Be 1048576
         }
         It 'Parses "1 MiB" using IEC units correctly' {
             $result = Format-Byte -Value '1 MiB' -Base 1024
-            $result.Megabytes | Should -Be 1
-            $result.Bytes | Should -Be 1048576
+            $result.Megabytes | Should-Be 1
+            $result.Bytes | Should-Be 1048576
         }
     }
 
     Context 'Storage conversions (SI 1000)' {
         It 'Converts 1000000 bytes to 1 MB (SI)' {
             $r = Format-Byte -Value 1000000 -Base 1000
-            $r.Megabytes | Should -Be 1
+            $r.Megabytes | Should-Be 1
         }
     }
 
     Context 'Bandwidth conversions' {
         It 'BandwidthOnly returns bits units for "10 Mbps"' {
             $r = Format-Byte -Value '10 Mbps' -BandwidthOnly
-            $r.Bits | Should -Be 10000000
-            $r.Megabits | Should -Be 10
-            $r.Kilobits | Should -Be 10000
+            $r.Bits | Should-Be 10000000
+            $r.Megabits | Should-Be 10
+            $r.Kilobits | Should-Be 10000
         }
         It 'Accepts no-space unit for "10Mbps"' {
             $r = Format-Byte -Value '10Mbps' -BandwidthOnly
-            $r.Bits | Should -Be 10000000
-            $r.Megabits | Should -Be 10
+            $r.Bits | Should-Be 10000000
+            $r.Megabits | Should-Be 10
         }
         It 'Parses spaced "1 Gbps" correctly' {
             $r = Format-Byte -Value '1 Gbps' -BandwidthOnly
-            $r.Gigabits | Should -Be 1
-            $r.Megabits | Should -Be 1000
-            $r.Kilobits | Should -Be 1000000
-            $r.Bits | Should -Be 1000000000
+            $r.Gigabits | Should-Be 1
+            $r.Megabits | Should-Be 1000
+            $r.Kilobits | Should-Be 1000000
+            $r.Bits | Should-Be 1000000000
         }
         It 'Parses no-space "1Gbps" correctly' {
             $r = Format-Byte -Value '1Gbps' -BandwidthOnly
-            $r.Gigabits | Should -Be 1
-            $r.Megabits | Should -Be 1000
-            $r.Kilobits | Should -Be 1000000
-            $r.Bits | Should -Be 1000000000
+            $r.Gigabits | Should-Be 1
+            $r.Megabits | Should-Be 1000
+            $r.Kilobits | Should-Be 1000000
+            $r.Bits | Should-Be 1000000000
         }
         It 'IncludeBandwidth adds bits alongside bytes' {
             $r = Format-Byte -Value 1048576 -IncludeBandwidth -Base 1024
-            $r.Bytes | Should -Be 1048576
-            $r.Bits | Should -Be 8388608
-            $r.Megabytes | Should -Be 1
-            $r.Megabits | Should -BeGreaterThan 0
+            $r.Bytes | Should-Be 1048576
+            $r.Bits | Should-Be 8388608
+            $r.Megabytes | Should-Be 1
+            $r.Megabits | Should-BeGreaterThan 0
         }
     }
 
     Context 'Input parsing robustness' {
         It 'Accepts "1MB" (no space)' {
             $r = Format-Byte -Value '1MB' -Base 1024
-            $r.Bytes | Should -Be 1048576
+            $r.Bytes | Should-Be 1048576
         }
         It 'Accepts spelled out "1 megabyte"' {
             $r = Format-Byte -Value '1 megabyte' -Base 1024
-            $r.Bytes | Should -Be 1048576
+            $r.Bytes | Should-Be 1048576
         }
         It 'Throws on negative numeric input' {
-            { Format-Byte -Value -1 } | Should -Throw
+            { Format-Byte -Value -1 } | Should-Throw
         }
         It 'Throws on negative string input' {
-            { Format-Byte -Value '-10 MB' } | Should -Throw
+            { Format-Byte -Value '-10 MB' } | Should-Throw
         }
         It 'Throws on unknown unit' {
-            { Format-Byte -Value '1 XB' } | Should -Throw
+            { Format-Byte -Value '1 XB' } | Should-Throw
         }
     }
 
     Context 'Parameter validation' {
         It 'Throws when IncludeBandwidth and BandwidthOnly together' {
-            { Format-Byte -Value 1 -IncludeBandwidth -BandwidthOnly } | Should -Throw
+            { Format-Byte -Value 1 -IncludeBandwidth -BandwidthOnly } | Should-Throw
         }
     }
 }

--- a/Tests/Unit/Utilities/Get-CommandAlias.Tests.ps1
+++ b/Tests/Unit/Utilities/Get-CommandAlias.Tests.ps1
@@ -31,9 +31,9 @@ Describe 'Get-CommandAlias' {
 
             # The function outputs formatted table, so we check the string content
             $outputString = $output | Out-String
-            $outputString | Should -Match 'Get-ChildItem'
-            $outputString | Should -Match 'dir'      # Common Windows alias
-            $outputString | Should -Match 'gci'      # PowerShell-style alias
+            $outputString | Should-MatchString 'Get-ChildItem'
+            $outputString | Should-MatchString 'dir'      # Common Windows alias
+            $outputString | Should-MatchString 'gci'      # PowerShell-style alias
         }
 
         It 'Lists aliases for Select-Object and Select-String with wildcard (Example: Get-CommandAlias -Name "Select*")' {
@@ -42,10 +42,10 @@ Describe 'Get-CommandAlias' {
             $output | Should -Not -BeNullOrEmpty
 
             $outputString = $output | Out-String
-            $outputString | Should -Match 'Select-Object'
-            $outputString | Should -Match 'select'   # Alias for Select-Object
-            $outputString | Should -Match 'Select-String'
-            $outputString | Should -Match 'sls'      # Alias for Select-String
+            $outputString | Should-MatchString 'Select-Object'
+            $outputString | Should-MatchString 'select'   # Alias for Select-Object
+            $outputString | Should-MatchString 'Select-String'
+            $outputString | Should-MatchString 'sls'      # Alias for Select-String
         }
     }
 
@@ -57,8 +57,8 @@ Describe 'Get-CommandAlias' {
             $output | Should -Not -BeNullOrEmpty
 
             $outputString = $output | Out-String
-            $outputString | Should -Match 'Get-Process'
-            $outputString | Should -Match 'gps'  # Known alias for Get-Process
+            $outputString | Should-MatchString 'Get-Process'
+            $outputString | Should-MatchString 'gps'  # Known alias for Get-Process
         }
     }
 
@@ -68,24 +68,24 @@ Describe 'Get-CommandAlias' {
             $output | Should -Not -BeNullOrEmpty
 
             $outputString = $output | Out-String
-            $outputString | Should -Match 'Get-ChildItem'
+            $outputString | Should-MatchString 'Get-ChildItem'
         }
 
         It 'Should show warning for non-existent command pattern' {
             $warningOutput = Get-CommandAlias -Name 'NonExistentCommand*' 3>&1
             $warningOutput | Should -Not -BeNullOrEmpty
-            $warningOutput | Should -Match 'No aliases found'
+            $warningOutput | Should-MatchString 'No aliases found'
         }
     }
 
     Context 'Parameter validation' {
         It 'Should require Name parameter when called directly' {
-            { Get-CommandAlias -Name '' -ErrorAction Stop } | Should -Throw
+            { Get-CommandAlias -Name '' -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should handle empty Name parameter with proper validation' {
             # Test with empty string - should throw validation error
-            { Get-CommandAlias -Name '' -ErrorAction Stop } | Should -Throw
+            { Get-CommandAlias -Name '' -ErrorAction Stop } | Should-Throw
         }
     }
 
@@ -96,8 +96,8 @@ Describe 'Get-CommandAlias' {
 
             # Check that it's formatted table output
             $outputString = $output | Out-String
-            $outputString | Should -Match 'Definition\s+Name'  # Table headers
-            $outputString | Should -Match '----------\s+----'  # Table separator
+            $outputString | Should-MatchString 'Definition\s+Name'  # Table headers
+            $outputString | Should-MatchString '----------\s+----'  # Table separator
         }
     }
 
@@ -108,7 +108,7 @@ Describe 'Get-CommandAlias' {
             # Should produce verbose messages
             $verboseMessages = $verboseOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
             $verboseMessages | Should -Not -BeNullOrEmpty
-            $verboseMessages | Should -Match 'alias'
+            $verboseMessages | Should-MatchString 'alias'
         }
     }
 
@@ -119,9 +119,9 @@ Describe 'Get-CommandAlias' {
             $output | Should -Not -BeNullOrEmpty
 
             $outputString = $output | Out-String
-            $outputString | Should -Match 'Get-Location'
-            $outputString | Should -Match 'gl'
-            $outputString | Should -Match 'pwd'
+            $outputString | Should-MatchString 'Get-Location'
+            $outputString | Should-MatchString 'gl'
+            $outputString | Should-MatchString 'pwd'
         }
     }
 
@@ -133,7 +133,7 @@ Describe 'Get-CommandAlias' {
             # Should produce a warning about no aliases found
             if ($warningOutput)
             {
-                $warningOutput | Should -Match 'No aliases found'
+                $warningOutput | Should-MatchString 'No aliases found'
             }
         }
     }

--- a/Tests/Unit/Utilities/Get-CommandAlias.Tests.ps1
+++ b/Tests/Unit/Utilities/Get-CommandAlias.Tests.ps1
@@ -74,7 +74,7 @@ Describe 'Get-CommandAlias' {
         It 'Should show warning for non-existent command pattern' {
             $warningOutput = Get-CommandAlias -Name 'NonExistentCommand*' 3>&1
             $warningOutput | Should -Not -BeNullOrEmpty
-            $warningOutput | Should-MatchString 'No aliases found'
+            ($warningOutput | Out-String) | Should-MatchString 'No aliases found'
         }
     }
 
@@ -108,7 +108,7 @@ Describe 'Get-CommandAlias' {
             # Should produce verbose messages
             $verboseMessages = $verboseOutput | Where-Object { $_ -is [System.Management.Automation.VerboseRecord] }
             $verboseMessages | Should -Not -BeNullOrEmpty
-            $verboseMessages | Should-MatchString 'alias'
+            ($verboseMessages | Out-String) | Should-MatchString 'alias'
         }
     }
 
@@ -133,7 +133,7 @@ Describe 'Get-CommandAlias' {
             # Should produce a warning about no aliases found
             if ($warningOutput)
             {
-                $warningOutput | Should-MatchString 'No aliases found'
+                ($warningOutput | Out-String) | Should-MatchString 'No aliases found'
             }
         }
     }

--- a/Tests/Unit/Utilities/Get-EncodingFromName.Tests.ps1
+++ b/Tests/Unit/Utilities/Get-EncodingFromName.Tests.ps1
@@ -17,18 +17,18 @@ Describe 'Get-EncodingFromName' -Tag 'Unit' {
         $utf8 = Get-EncodingFromName -EncodingName 'UTF8'
         $utf8Bom = Get-EncodingFromName -EncodingName 'UTF8BOM'
 
-        $utf8.CodePage | Should -Be 65001
-        $utf8.GetPreamble().Length | Should -Be 0
-        $utf8Bom.CodePage | Should -Be 65001
-        $utf8Bom.GetPreamble().Length | Should -Be 3
+        $utf8.CodePage | Should-Be 65001
+        $utf8.GetPreamble().Length | Should-Be 0
+        $utf8Bom.CodePage | Should-Be 65001
+        $utf8Bom.GetPreamble().Length | Should-Be 3
     }
 
     It 'Resolves UTF16LE and UTF16BE' {
         $utf16Le = Get-EncodingFromName -EncodingName 'UTF16LE'
         $utf16Be = Get-EncodingFromName -EncodingName 'UTF16BE'
 
-        $utf16Le.CodePage | Should -Be 1200
-        $utf16Be.CodePage | Should -Be 1201
+        $utf16Le.CodePage | Should-Be 1200
+        $utf16Be.CodePage | Should-Be 1201
     }
 
     It 'Returns null and writes error for unsupported encoding' {
@@ -38,6 +38,6 @@ Describe 'Get-EncodingFromName' -Tag 'Unit' {
 
         $result | Should -BeNullOrEmpty
         $errorRecords | Should -Not -BeNullOrEmpty
-        $errorRecords[0].ToString() | Should -Match 'Unsupported encoding'
+        $errorRecords[0].ToString() | Should-MatchString 'Unsupported encoding'
     }
 }

--- a/Tests/Unit/Utilities/Get-FileEncoding.Tests.ps1
+++ b/Tests/Unit/Utilities/Get-FileEncoding.Tests.ps1
@@ -19,8 +19,8 @@ Describe 'Get-FileEncoding' -Tag 'Unit' {
         [System.IO.File]::WriteAllText($path, 'hello café', $utf8NoBom)
 
         $detected = Get-FileEncoding -FilePath $path
-        $detected.CodePage | Should -Be 65001
-        $detected.GetPreamble().Length | Should -Be 0
+        $detected.CodePage | Should-Be 65001
+        $detected.GetPreamble().Length | Should-Be 0
     }
 
     It 'Detects UTF8 with BOM' {
@@ -29,8 +29,8 @@ Describe 'Get-FileEncoding' -Tag 'Unit' {
         [System.IO.File]::WriteAllText($path, 'hello café', $utf8Bom)
 
         $detected = Get-FileEncoding -FilePath $path
-        $detected.CodePage | Should -Be 65001
-        $detected.GetPreamble().Length | Should -Be 3
+        $detected.CodePage | Should-Be 65001
+        $detected.GetPreamble().Length | Should-Be 3
     }
 
     It 'Detects UTF16LE with BOM' {
@@ -38,8 +38,8 @@ Describe 'Get-FileEncoding' -Tag 'Unit' {
         [System.IO.File]::WriteAllText($path, 'hello world', [System.Text.Encoding]::Unicode)
 
         $detected = Get-FileEncoding -FilePath $path
-        $detected.CodePage | Should -Be 1200
-        $detected.GetPreamble().Length | Should -Be 2
+        $detected.CodePage | Should-Be 1200
+        $detected.GetPreamble().Length | Should-Be 2
     }
 
     It 'Returns UTF8 without BOM for empty files' {
@@ -47,7 +47,7 @@ Describe 'Get-FileEncoding' -Tag 'Unit' {
         [System.IO.File]::WriteAllBytes($path, @())
 
         $detected = Get-FileEncoding -FilePath $path
-        $detected.CodePage | Should -Be 65001
-        $detected.GetPreamble().Length | Should -Be 0
+        $detected.CodePage | Should-Be 65001
+        $detected.GetPreamble().Length | Should-Be 0
     }
 }

--- a/Tests/Unit/Utilities/Get-StringHash.Tests.ps1
+++ b/Tests/Unit/Utilities/Get-StringHash.Tests.ps1
@@ -32,168 +32,168 @@ Describe 'Get-StringHash' {
         It 'Should have mandatory InputObject parameter' {
             $command = Get-Command Get-StringHash
             $inputParam = $command.Parameters['InputObject']
-            $inputParam.Attributes.Mandatory | Should -Contain $true
+            $inputParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should accept pipeline input for InputObject' {
             $command = Get-Command Get-StringHash
             $inputParam = $command.Parameters['InputObject']
-            $inputParam.Attributes.ValueFromPipeline | Should -Contain $true
+            $inputParam.Attributes.ValueFromPipeline | Should-ContainCollection $true
         }
 
         It 'Should have optional Algorithm parameter with default SHA256' {
             $command = Get-Command Get-StringHash
             $algoParam = $command.Parameters['Algorithm']
-            $algoParam.Attributes.Mandatory | Should -Not -Contain $true
+            $algoParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should validate Algorithm parameter with correct values' {
             $command = Get-Command Get-StringHash
             $algoParam = $command.Parameters['Algorithm']
             $validateSet = $algoParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
-            $validateSet.ValidValues | Should -Contain 'SHA1'
-            $validateSet.ValidValues | Should -Contain 'SHA256'
-            $validateSet.ValidValues | Should -Contain 'SHA384'
-            $validateSet.ValidValues | Should -Contain 'SHA512'
-            $validateSet.ValidValues | Should -Contain 'MD5'
+            $validateSet.ValidValues | Should-ContainCollection 'SHA1'
+            $validateSet.ValidValues | Should-ContainCollection 'SHA256'
+            $validateSet.ValidValues | Should-ContainCollection 'SHA384'
+            $validateSet.ValidValues | Should-ContainCollection 'SHA512'
+            $validateSet.ValidValues | Should-ContainCollection 'MD5'
         }
 
         It 'Should have optional Encoding parameter with default UTF8' {
             $command = Get-Command Get-StringHash
             $encodingParam = $command.Parameters['Encoding']
-            $encodingParam.Attributes.Mandatory | Should -Not -Contain $true
+            $encodingParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should validate Encoding parameter with correct values' {
             $command = Get-Command Get-StringHash
             $encodingParam = $command.Parameters['Encoding']
             $validateSet = $encodingParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
-            $validateSet.ValidValues | Should -Contain 'ASCII'
-            $validateSet.ValidValues | Should -Contain 'UTF7'
-            $validateSet.ValidValues | Should -Contain 'UTF8'
-            $validateSet.ValidValues | Should -Contain 'UTF32'
-            $validateSet.ValidValues | Should -Contain 'Unicode'
-            $validateSet.ValidValues | Should -Contain 'BigEndianUnicode'
-            $validateSet.ValidValues | Should -Contain 'Default'
+            $validateSet.ValidValues | Should-ContainCollection 'ASCII'
+            $validateSet.ValidValues | Should-ContainCollection 'UTF7'
+            $validateSet.ValidValues | Should-ContainCollection 'UTF8'
+            $validateSet.ValidValues | Should-ContainCollection 'UTF32'
+            $validateSet.ValidValues | Should-ContainCollection 'Unicode'
+            $validateSet.ValidValues | Should-ContainCollection 'BigEndianUnicode'
+            $validateSet.ValidValues | Should-ContainCollection 'Default'
         }
     }
 
     Context 'SHA256 Algorithm (Default)' {
         It 'Should compute correct SHA256 hash for simple string' {
             $result = Get-StringHash -InputObject 'Hello, World!'
-            $result.Algorithm | Should -Be 'SHA256'
-            $result.Hash | Should -Be 'DFFD6021BB2BD5B0AF676290809EC3A53191DD81C7F70A4B28688A362182986F'
-            $result.InputObject | Should -Be 'Hello, World!'
+            $result.Algorithm | Should-Be 'SHA256'
+            $result.Hash | Should-Be 'DFFD6021BB2BD5B0AF676290809EC3A53191DD81C7F70A4B28688A362182986F'
+            $result.InputObject | Should-Be 'Hello, World!'
         }
 
         It 'Should compute correct SHA256 hash for empty string' {
             $result = Get-StringHash -InputObject ''
-            $result.Algorithm | Should -Be 'SHA256'
-            $result.Hash | Should -Be 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
-            $result.InputObject | Should -Be ''
+            $result.Algorithm | Should-Be 'SHA256'
+            $result.Hash | Should-Be 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
+            $result.InputObject | Should-Be ''
         }
 
         It 'Should use SHA256 as default algorithm when not specified' {
             $result = Get-StringHash -InputObject 'test'
-            $result.Algorithm | Should -Be 'SHA256'
+            $result.Algorithm | Should-Be 'SHA256'
         }
 
         It 'Should compute correct SHA256 hash for numeric string' {
             $result = Get-StringHash -InputObject '12345'
-            $result.Algorithm | Should -Be 'SHA256'
-            $result.Hash | Should -Be '5994471ABB01112AFCC18159F6CC74B4F511B99806DA59B3CAF5A9C173CACFC5'
+            $result.Algorithm | Should-Be 'SHA256'
+            $result.Hash | Should-Be '5994471ABB01112AFCC18159F6CC74B4F511B99806DA59B3CAF5A9C173CACFC5'
         }
 
         It 'Should compute correct SHA256 hash for special characters' {
             $result = Get-StringHash -InputObject '!@#$%^&*()'
-            $result.Algorithm | Should -Be 'SHA256'
-            $result.Hash | Should -Be '95CE789C5C9D18490972709838CA3A9719094BCA3AC16332CFEC0652B0236141'
+            $result.Algorithm | Should-Be 'SHA256'
+            $result.Hash | Should-Be '95CE789C5C9D18490972709838CA3A9719094BCA3AC16332CFEC0652B0236141'
         }
     }
 
     Context 'SHA1 Algorithm' {
         It 'Should compute correct SHA1 hash' {
             $result = Get-StringHash -InputObject 'Secret' -Algorithm SHA1
-            $result.Algorithm | Should -Be 'SHA1'
-            $result.Hash | Should -Be 'F4E7A8740DB0B7A0BFD8E63077261475F61FC2A6'
-            $result.InputObject | Should -Be 'Secret'
+            $result.Algorithm | Should-Be 'SHA1'
+            $result.Hash | Should-Be 'F4E7A8740DB0B7A0BFD8E63077261475F61FC2A6'
+            $result.InputObject | Should-Be 'Secret'
         }
 
         It 'Should compute correct SHA1 hash for empty string' {
             $result = Get-StringHash -InputObject '' -Algorithm SHA1
-            $result.Algorithm | Should -Be 'SHA1'
-            $result.Hash | Should -Be 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709'
+            $result.Algorithm | Should-Be 'SHA1'
+            $result.Hash | Should-Be 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709'
         }
     }
 
     Context 'SHA384 Algorithm' {
         It 'Should compute correct SHA384 hash' {
             $result = Get-StringHash -InputObject 'Test' -Algorithm SHA384
-            $result.Algorithm | Should -Be 'SHA384'
-            $result.Hash | Should -Be '7B8F4654076B80EB963911F19CFAD1AAF4285ED48E826F6CDE1B01A79AA73FADB5446E667FC4F90417782C91270540F3'
-            $result.InputObject | Should -Be 'Test'
+            $result.Algorithm | Should-Be 'SHA384'
+            $result.Hash | Should-Be '7B8F4654076B80EB963911F19CFAD1AAF4285ED48E826F6CDE1B01A79AA73FADB5446E667FC4F90417782C91270540F3'
+            $result.InputObject | Should-Be 'Test'
         }
 
         It 'Should compute correct SHA384 hash for empty string' {
             $result = Get-StringHash -InputObject '' -Algorithm SHA384
-            $result.Algorithm | Should -Be 'SHA384'
-            $result.Hash | Should -Be '38B060A751AC96384CD9327EB1B1E36A21FDB71114BE07434C0CC7BF63F6E1DA274EDEBFE76F65FBD51AD2F14898B95B'
+            $result.Algorithm | Should-Be 'SHA384'
+            $result.Hash | Should-Be '38B060A751AC96384CD9327EB1B1E36A21FDB71114BE07434C0CC7BF63F6E1DA274EDEBFE76F65FBD51AD2F14898B95B'
         }
     }
 
     Context 'SHA512 Algorithm' {
         It 'Should compute correct SHA512 hash' {
             $result = Get-StringHash -InputObject 'Test123' -Algorithm SHA512
-            $result.Algorithm | Should -Be 'SHA512'
-            $result.Hash | Should -Be 'C12834F1031F6497214F27D4432F26517AD494156CB88D512BDB1DC4B57DB2D692A3DFA269A19B0A0A2A0FD7D6A2A885E33C839C93C206DA30A187392847ED27'
-            $result.InputObject | Should -Be 'Test123'
+            $result.Algorithm | Should-Be 'SHA512'
+            $result.Hash | Should-Be 'C12834F1031F6497214F27D4432F26517AD494156CB88D512BDB1DC4B57DB2D692A3DFA269A19B0A0A2A0FD7D6A2A885E33C839C93C206DA30A187392847ED27'
+            $result.InputObject | Should-Be 'Test123'
         }
 
         It 'Should compute correct SHA512 hash for empty string' {
             $result = Get-StringHash -InputObject '' -Algorithm SHA512
-            $result.Algorithm | Should -Be 'SHA512'
-            $result.Hash | Should -Be 'CF83E1357EEFB8BDF1542850D66D8007D620E4050B5715DC83F4A921D36CE9CE47D0D13C5D85F2B0FF8318D2877EEC2F63B931BD47417A81A538327AF927DA3E'
+            $result.Algorithm | Should-Be 'SHA512'
+            $result.Hash | Should-Be 'CF83E1357EEFB8BDF1542850D66D8007D620E4050B5715DC83F4A921D36CE9CE47D0D13C5D85F2B0FF8318D2877EEC2F63B931BD47417A81A538327AF927DA3E'
         }
     }
 
     Context 'MD5 Algorithm' {
         It 'Should compute correct MD5 hash' {
             $result = Get-StringHash -InputObject 'PowerShell' -Algorithm MD5
-            $result.Algorithm | Should -Be 'MD5'
-            $result.Hash | Should -Be '3D265B4E1EEEF0DDF17881FA003B18CC'
-            $result.InputObject | Should -Be 'PowerShell'
+            $result.Algorithm | Should-Be 'MD5'
+            $result.Hash | Should-Be '3D265B4E1EEEF0DDF17881FA003B18CC'
+            $result.InputObject | Should-Be 'PowerShell'
         }
 
         It 'Should compute correct MD5 hash for empty string' {
             $result = Get-StringHash -InputObject '' -Algorithm MD5
-            $result.Algorithm | Should -Be 'MD5'
-            $result.Hash | Should -Be 'D41D8CD98F00B204E9800998ECF8427E'
+            $result.Algorithm | Should-Be 'MD5'
+            $result.Hash | Should-Be 'D41D8CD98F00B204E9800998ECF8427E'
         }
     }
 
     Context 'Pipeline Input' {
         It 'Should accept string from pipeline' {
             $result = 'PowerShell' | Get-StringHash -Algorithm MD5
-            $result.Hash | Should -Be '3D265B4E1EEEF0DDF17881FA003B18CC'
+            $result.Hash | Should-Be '3D265B4E1EEEF0DDF17881FA003B18CC'
         }
 
         It 'Should process multiple strings from pipeline' {
             $results = 'test1', 'test2', 'test3' | Get-StringHash -Algorithm SHA256
-            $results.Count | Should -Be 3
-            $results[0].InputObject | Should -Be 'test1'
-            $results[1].InputObject | Should -Be 'test2'
-            $results[2].InputObject | Should -Be 'test3'
-            $results[0].Hash | Should -Not -Be $results[1].Hash
-            $results[1].Hash | Should -Not -Be $results[2].Hash
+            $results.Count | Should-Be 3
+            $results[0].InputObject | Should-Be 'test1'
+            $results[1].InputObject | Should-Be 'test2'
+            $results[2].InputObject | Should-Be 'test3'
+            $results[0].Hash | Should-NotBe $results[1].Hash
+            $results[1].Hash | Should-NotBe $results[2].Hash
         }
 
         It 'Should process empty strings from pipeline' {
             $results = '', 'text', '' | Get-StringHash
-            $results.Count | Should -Be 3
-            $results[0].InputObject | Should -Be ''
-            $results[1].InputObject | Should -Be 'text'
-            $results[2].InputObject | Should -Be ''
-            $results[0].Hash | Should -Be $results[2].Hash
+            $results.Count | Should-Be 3
+            $results[0].InputObject | Should-Be ''
+            $results[1].InputObject | Should-Be 'text'
+            $results[2].InputObject | Should-Be ''
+            $results[0].Hash | Should-Be $results[2].Hash
         }
     }
 
@@ -204,108 +204,108 @@ Describe 'Get-StringHash' {
             $unicodeResult = Get-StringHash -InputObject 'Test' -Encoding Unicode
 
             # For simple ASCII characters, UTF8 and ASCII should be the same
-            $utf8Result.Hash | Should -Be $asciiResult.Hash
+            $utf8Result.Hash | Should-Be $asciiResult.Hash
             # But Unicode (UTF-16LE) should be different
-            $utf8Result.Hash | Should -Not -Be $unicodeResult.Hash
+            $utf8Result.Hash | Should-NotBe $unicodeResult.Hash
         }
 
         It 'Should handle UTF8 encoding (default)' {
             $result = Get-StringHash -InputObject 'Hello' -Encoding UTF8
-            $result.Hash | Should -Be '185F8DB32271FE25F561A6FC938B2E264306EC304EDA518007D1764826381969'
+            $result.Hash | Should-Be '185F8DB32271FE25F561A6FC938B2E264306EC304EDA518007D1764826381969'
         }
 
         It 'Should handle ASCII encoding' {
             $result = Get-StringHash -InputObject 'Hello' -Encoding ASCII
-            $result.Hash | Should -Be '185F8DB32271FE25F561A6FC938B2E264306EC304EDA518007D1764826381969'
+            $result.Hash | Should-Be '185F8DB32271FE25F561A6FC938B2E264306EC304EDA518007D1764826381969'
         }
 
         It 'Should handle Unicode encoding' {
             $result = Get-StringHash -InputObject 'Hello' -Encoding Unicode
-            $result.Hash | Should -Be 'A07E4F7343246C82B26F32E56F85418D518D8B2F2DAE77F1D56FE7AF50DB97AF'
+            $result.Hash | Should-Be 'A07E4F7343246C82B26F32E56F85418D518D8B2F2DAE77F1D56FE7AF50DB97AF'
         }
 
         It 'Should handle UTF32 encoding' {
             $result = Get-StringHash -InputObject 'Hi' -Encoding UTF32
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
         }
 
         It 'Should handle BigEndianUnicode encoding' {
             $result = Get-StringHash -InputObject 'Hi' -Encoding BigEndianUnicode
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
         }
     }
 
     Context 'Object Input' {
         It 'Should convert integer to string and hash it' {
             $result = Get-StringHash -InputObject 42
-            $result.InputObject | Should -Be '42'
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
+            $result.InputObject | Should-Be '42'
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
         }
 
         It 'Should convert DateTime to string and hash it' {
             $date = [DateTime]'2025-01-01'
             $result = Get-StringHash -InputObject $date
-            $result.InputObject | Should -Be $date.ToString()
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
+            $result.InputObject | Should-Be $date.ToString()
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
         }
 
         It 'Should convert boolean to string and hash it' {
             $result = Get-StringHash -InputObject $true
-            $result.InputObject | Should -Be 'True'
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
+            $result.InputObject | Should-Be 'True'
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
         }
 
         It 'Should handle custom object with ToString()' {
             $obj = [PSCustomObject]@{ Name = 'Test'; Value = 123 }
             $result = Get-StringHash -InputObject $obj
-            $result.InputObject | Should -Be $obj.ToString()
+            $result.InputObject | Should-Be $obj.ToString()
         }
     }
 
     Context 'Output Format' {
         It 'Should return object with Algorithm property' {
             $result = Get-StringHash -InputObject 'test'
-            $result.PSObject.Properties.Name | Should -Contain 'Algorithm'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Algorithm'
         }
 
         It 'Should return object with Hash property' {
             $result = Get-StringHash -InputObject 'test'
-            $result.PSObject.Properties.Name | Should -Contain 'Hash'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Hash'
         }
 
         It 'Should return object with InputObject property' {
             $result = Get-StringHash -InputObject 'test'
-            $result.PSObject.Properties.Name | Should -Contain 'InputObject'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'InputObject'
         }
 
         It 'Should return hash in uppercase hexadecimal format' {
             $result = Get-StringHash -InputObject 'test'
-            $result.Hash | Should -Match '^[A-F0-9]+$'
+            $result.Hash | Should-MatchString '^[A-F0-9]+$'
         }
 
         It 'Should return SHA256 hash with 64 characters' {
             $result = Get-StringHash -InputObject 'test' -Algorithm SHA256
-            $result.Hash.Length | Should -Be 64
+            $result.Hash.Length | Should-Be 64
         }
 
         It 'Should return SHA1 hash with 40 characters' {
             $result = Get-StringHash -InputObject 'test' -Algorithm SHA1
-            $result.Hash.Length | Should -Be 40
+            $result.Hash.Length | Should-Be 40
         }
 
         It 'Should return SHA384 hash with 96 characters' {
             $result = Get-StringHash -InputObject 'test' -Algorithm SHA384
-            $result.Hash.Length | Should -Be 96
+            $result.Hash.Length | Should-Be 96
         }
 
         It 'Should return SHA512 hash with 128 characters' {
             $result = Get-StringHash -InputObject 'test' -Algorithm SHA512
-            $result.Hash.Length | Should -Be 128
+            $result.Hash.Length | Should-Be 128
         }
 
         It 'Should return MD5 hash with 32 characters' {
             $result = Get-StringHash -InputObject 'test' -Algorithm MD5
-            $result.Hash.Length | Should -Be 32
+            $result.Hash.Length | Should-Be 32
         }
     }
 
@@ -313,21 +313,21 @@ Describe 'Get-StringHash' {
         It 'Should produce same hash for same input string' {
             $result1 = Get-StringHash -InputObject 'consistent'
             $result2 = Get-StringHash -InputObject 'consistent'
-            $result1.Hash | Should -Be $result2.Hash
+            $result1.Hash | Should-Be $result2.Hash
         }
 
         It 'Should produce different hash for different input strings' {
             $result1 = Get-StringHash -InputObject 'string1'
             $result2 = Get-StringHash -InputObject 'string2'
-            $result1.Hash | Should -Not -Be $result2.Hash
+            $result1.Hash | Should-NotBe $result2.Hash
         }
 
         It 'Should produce same hash when called multiple times with same algorithm' {
             $hash1 = (Get-StringHash -InputObject 'test' -Algorithm SHA256).Hash
             $hash2 = (Get-StringHash -InputObject 'test' -Algorithm SHA256).Hash
             $hash3 = (Get-StringHash -InputObject 'test' -Algorithm SHA256).Hash
-            $hash1 | Should -Be $hash2
-            $hash2 | Should -Be $hash3
+            $hash1 | Should-Be $hash2
+            $hash2 | Should-Be $hash3
         }
 
         It 'Should produce different hash for different algorithms' {
@@ -335,9 +335,9 @@ Describe 'Get-StringHash' {
             $sha512 = Get-StringHash -InputObject 'test' -Algorithm SHA512
             $md5 = Get-StringHash -InputObject 'test' -Algorithm MD5
 
-            $sha256.Hash | Should -Not -Be $sha512.Hash
-            $sha256.Hash | Should -Not -Be $md5.Hash
-            $sha512.Hash | Should -Not -Be $md5.Hash
+            $sha256.Hash | Should-NotBe $sha512.Hash
+            $sha256.Hash | Should-NotBe $md5.Hash
+            $sha512.Hash | Should-NotBe $md5.Hash
         }
     }
 
@@ -345,48 +345,48 @@ Describe 'Get-StringHash' {
         It 'Should handle very long strings' {
             $longString = 'a' * 10000
             $result = Get-StringHash -InputObject $longString
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
-            $result.InputObject.Length | Should -Be 10000
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
+            $result.InputObject.Length | Should-Be 10000
         }
 
         It 'Should handle strings with newlines' {
             $multiline = "Line1`nLine2`nLine3"
             $result = Get-StringHash -InputObject $multiline
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
-            $result.InputObject | Should -Be $multiline
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
+            $result.InputObject | Should-Be $multiline
         }
 
         It 'Should handle strings with tabs' {
             $withTabs = "Tab`tSeparated`tValues"
             $result = Get-StringHash -InputObject $withTabs
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
         }
 
         It 'Should handle Unicode characters' {
             $unicode = '你好世界🌍'
             $result = Get-StringHash -InputObject $unicode
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
-            $result.InputObject | Should -Be $unicode
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
+            $result.InputObject | Should-Be $unicode
         }
 
         It 'Should handle whitespace-only strings' {
             $whitespace = '   '
             $result = Get-StringHash -InputObject $whitespace
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
-            $result.InputObject | Should -Be $whitespace
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
+            $result.InputObject | Should-Be $whitespace
         }
 
         It 'Should handle single character' {
             $result = Get-StringHash -InputObject 'x'
-            $result.Hash | Should -Match '^[A-F0-9]{64}$'
+            $result.Hash | Should-MatchString '^[A-F0-9]{64}$'
         }
     }
 
     Context 'Empty String Handling' {
         It 'Should handle empty string correctly' {
             $result = Get-StringHash -InputObject ''
-            $result.InputObject | Should -Be ''
-            $result.Hash | Should -Be 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
+            $result.InputObject | Should-Be ''
+            $result.Hash | Should-Be 'E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855'
         }
     }
 

--- a/Tests/Unit/Utilities/Get-WhichCommand.Tests.ps1
+++ b/Tests/Unit/Utilities/Get-WhichCommand.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
         }
 
         It 'Should require Name parameter' {
-            { Get-WhichCommand -Name '' -ErrorAction Stop } | Should -Throw
+            { Get-WhichCommand -Name '' -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should accept All switch parameter' {
@@ -34,14 +34,14 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
         It 'Should find Get-Process cmdlet' {
             $result = Get-WhichCommand -Name 'Get-Process'
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -BeOfType [String]
-            $result | Should -Match 'Microsoft.PowerShell.Management'
+            $result | Should-HaveType ([String])
+            $result | Should-MatchString 'Microsoft.PowerShell.Management'
         }
 
         It 'Should return module path for cmdlets' {
             $result = Get-WhichCommand -Name 'Get-Process'
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -BeOfType [String]
+            $result | Should-HaveType ([String])
         }
     }
 
@@ -49,13 +49,13 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
         It 'Should find dir alias (cross-platform test)' {
             $result = Get-WhichCommand -Name 'dir'
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -BeOfType [String]
+            $result | Should-HaveType ([String])
         }
 
         It 'Should show alias definition with arrow notation' {
             $result = Get-WhichCommand -Name 'dir'
-            $result | Should -Match '->'
-            $result | Should -Match 'Get-ChildItem'
+            $result | Should-MatchString '->'
+            $result | Should-MatchString 'Get-ChildItem'
         }
 
         It 'Should resolve common aliases (gci, dir, select)' {
@@ -64,8 +64,8 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
             {
                 $result = Get-WhichCommand -Name $alias
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [String]
-                $result | Should -Match '->'
+                $result | Should-HaveType ([String])
+                $result | Should-MatchString '->'
             }
         }
     }
@@ -77,7 +77,7 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
                 function Test-WhichCommandTempFunction { 'This is a test function' }
                 $result = Get-WhichCommand -Name 'Test-WhichCommandTempFunction'
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [String]
+                $result | Should-HaveType ([String])
             }
         }
 
@@ -88,9 +88,9 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
             {
                 $result = Get-WhichCommand -Name 'Test-WhichTemp2'
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -BeOfType [String]
+                $result | Should-HaveType ([String])
                 # Should be either a file path or indicate it's a function
-                ($result -match '\(Function\)' -or (Test-Path $result -PathType Leaf -ErrorAction SilentlyContinue)) | Should -Be $true
+                ($result -match '\(Function\)' -or (Test-Path $result -PathType Leaf -ErrorAction SilentlyContinue)) | Should-Be $true
             }
             finally
             {
@@ -103,14 +103,14 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
         It 'Should find pwsh executable' {
             $result = Get-WhichCommand -Name 'pwsh'
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -BeOfType [String]
-            $result | Should -Match 'pwsh'
+            $result | Should-HaveType ([String])
+            $result | Should-MatchString 'pwsh'
         }
 
         It 'Should return full path for executables' {
             $result = Get-WhichCommand -Name 'pwsh'
             $result | Should -Not -BeNullOrEmpty
-            [System.IO.Path]::IsPathRooted($result) | Should -Be $true
+            [System.IO.Path]::IsPathRooted($result) | Should-Be $true
         }
 
         It 'Should find platform-specific commands' {
@@ -127,7 +127,7 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
             {
                 $result = Get-WhichCommand -Name 'cmd'
                 $result | Should -Not -BeNullOrEmpty
-                $result | Should -Match 'cmd\.exe'
+                $result | Should-MatchString 'cmd\.exe'
             }
             else
             {
@@ -143,7 +143,7 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
                         break
                     }
                 }
-                $foundCommand | Should -Be $true
+                $foundCommand | Should-Be $true
             }
         }
     }
@@ -153,7 +153,7 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
             $warningMessage = $null
             Get-WhichCommand -Name 'ThisCommandDefinitelyDoesNotExist123456789' -WarningVariable warningMessage -WarningAction SilentlyContinue
             $warningMessage | Should -Not -BeNullOrEmpty
-            $warningMessage | Should -Match 'not found'
+            $warningMessage | Should-MatchString 'not found'
         }
 
         It 'Should not throw for non-existent commands' {
@@ -165,7 +165,7 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
         It 'Should return only first match without -All' {
             # Test with a well-known cmdlet that has only one match
             $result = Get-WhichCommand -Name 'Get-Process'
-            @($result).Count | Should -Be 1
+            @($result).Count | Should-Be 1
         }
 
         It 'Should handle commands with multiple matches when -All is specified' {
@@ -182,13 +182,13 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
         It 'Should process multiple commands from pipeline' {
             $commands = @('Get-Process', 'ls')
             $results = $commands | Get-WhichCommand
-            @($results).Count | Should -BeGreaterThan 0
+            @($results).Count | Should-BeGreaterThan 0
         }
 
         It 'Should handle mixed valid and invalid commands from pipeline' {
             $commands = @('Get-Process', 'NonExistentCommand999', 'ls')
             $results = $commands | Get-WhichCommand -WarningAction SilentlyContinue
-            @($results).Count | Should -BeGreaterThan 0
+            @($results).Count | Should-BeGreaterThan 0
         }
     }
 
@@ -198,26 +198,26 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
             $result = Get-WhichCommand -Name 'dir'
             $result | Should -Not -BeNullOrEmpty
             # PowerShell prioritizes aliases, so should show alias notation
-            $result | Should -Match '->'
+            $result | Should-MatchString '->'
         }
     }
 
     Context 'Output Format' {
         It 'Should return String for aliases' {
             $result = Get-WhichCommand -Name 'dir'
-            $result | Should -BeOfType [String]
-            $result | Should -Match '->'
+            $result | Should-HaveType ([String])
+            $result | Should-MatchString '->'
         }
 
         It 'Should return String for executables' {
             $result = Get-WhichCommand -Name 'pwsh'
-            $result | Should -BeOfType [String]
-            [System.IO.Path]::IsPathRooted($result) | Should -Be $true
+            $result | Should-HaveType ([String])
+            [System.IO.Path]::IsPathRooted($result) | Should-Be $true
         }
 
         It 'Should return String for cmdlets' {
             $result = Get-WhichCommand -Name 'Get-Process'
-            $result | Should -BeOfType [String]
+            $result | Should-HaveType ([String])
         }
     }
 

--- a/Tests/Unit/Utilities/Get-WhichCommand.Tests.ps1
+++ b/Tests/Unit/Utilities/Get-WhichCommand.Tests.ps1
@@ -153,7 +153,7 @@ Describe 'Get-WhichCommand' -Tag 'Unit' {
             $warningMessage = $null
             Get-WhichCommand -Name 'ThisCommandDefinitelyDoesNotExist123456789' -WarningVariable warningMessage -WarningAction SilentlyContinue
             $warningMessage | Should -Not -BeNullOrEmpty
-            $warningMessage | Should-MatchString 'not found'
+            ($warningMessage | Out-String) | Should-MatchString 'not found'
         }
 
         It 'Should not throw for non-existent commands' {

--- a/Tests/Unit/Utilities/New-RandomString.Tests.ps1
+++ b/Tests/Unit/Utilities/New-RandomString.Tests.ps1
@@ -30,42 +30,42 @@ Describe 'New-RandomString' {
             # Test the default behavior - 32 character alphanumeric string
             $result = New-RandomString
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 32
-            $result | Should -MatchExactly '^[0-9A-Za-z]+$'
+            $result.Length | Should-Be 32
+            $result | Should-MatchString '^[0-9A-Za-z]+$' -CaseSensitive
         }
 
         It 'Returns a random 16-character string when Length is specified (Example: New-RandomString -Length 16)' {
             # Test custom length specification
             $result = New-RandomString -Length 16
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 16
-            $result | Should -MatchExactly '^[0-9A-Za-z]+$'
+            $result.Length | Should-Be 16
+            $result | Should-MatchString '^[0-9A-Za-z]+$' -CaseSensitive
         }
 
         It 'Returns a random 64-character string without ambiguous characters when ExcludeAmbiguous is specified (Example: New-RandomString -Length 64 -ExcludeAmbiguous)' {
             # Test exclusion of potentially confusing characters: 0, 1, O, I, l, o, i
             $result = New-RandomString -Length 64 -ExcludeAmbiguous
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 64
+            $result.Length | Should-Be 64
             # Should exclude all ambiguous characters: 0, 1, O, I, l, o, i
-            $result | Should -Not -Match '[01OIlio]'
-            $result | Should -MatchExactly '^[2-9A-HJ-KM-NP-Za-hj-km-np-z]+$'
+            $result | Should-NotMatchString '[01OIlio]'
+            $result | Should-MatchString '^[2-9A-HJ-KM-NP-Za-hj-km-np-z]+$' -CaseSensitive
         }
 
         It 'Returns a 20-character string including symbols when IncludeSymbols and Secure are specified (Example: New-RandomString -Length 20 -IncludeSymbols -Secure)' {
             # Test symbol inclusion and cryptographically secure generation
             $result = New-RandomString -Length 20 -IncludeSymbols -Secure
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 20
+            $result.Length | Should-Be 20
             # Should allow alphanumeric and symbols
-            $result | Should -MatchExactly '^[0-9A-Za-z!@#$%^&*]+$'
+            $result | Should-MatchString '^[0-9A-Za-z!@#$%^&*]+$' -CaseSensitive
         }
 
         It 'Returns different values on multiple calls' {
             # Verify randomness - multiple calls should produce different results
             $result1 = New-RandomString -Length 10
             $result2 = New-RandomString -Length 10
-            $result1 | Should -Not -Be $result2
+            $result1 | Should-NotBe $result2
         }
     }
 
@@ -76,36 +76,36 @@ Describe 'New-RandomString' {
         }
 
         It 'Should reject Length values outside valid range' {
-            { New-RandomString -Length 0 } | Should -Throw
-            { New-RandomString -Length 10001 } | Should -Throw
-            { New-RandomString -Length -1 } | Should -Throw
+            { New-RandomString -Length 0 } | Should-Throw
+            { New-RandomString -Length 10001 } | Should-Throw
+            { New-RandomString -Length -1 } | Should-Throw
         }
     }
 
     Context 'Character set validation' {
         It 'Should include numbers when not excluding ambiguous' {
             $result = New-RandomString -Length 1000  # Large sample to increase probability
-            $result | Should -Match '[0-9]'
+            $result | Should-MatchString '[0-9]'
         }
 
         It 'Should include uppercase letters' {
             $result = New-RandomString -Length 1000
-            $result | Should -Match '[A-Z]'
+            $result | Should-MatchString '[A-Z]'
         }
 
         It 'Should include lowercase letters' {
             $result = New-RandomString -Length 1000
-            $result | Should -Match '[a-z]'
+            $result | Should-MatchString '[a-z]'
         }
 
         It 'Should include symbols when IncludeSymbols is specified' {
             $result = New-RandomString -Length 1000 -IncludeSymbols
-            $result | Should -Match '[!@#$%^&*]'
+            $result | Should-MatchString '[!@#$%^&*]'
         }
 
         It 'Should not include symbols when IncludeSymbols is not specified' {
             $result = New-RandomString -Length 100
-            $result | Should -Not -Match '[!@#$%^&*]'
+            $result | Should-NotMatchString '[!@#$%^&*]'
         }
     }
 
@@ -115,15 +115,15 @@ Describe 'New-RandomString' {
             1..10 | ForEach-Object {
                 $result = New-RandomString -Length 100 -ExcludeAmbiguous
                 # Should exclude all ambiguous characters: 0, 1, O, I, l, o, i
-                $result | Should -Not -Match '[01OIlio]'
+                $result | Should-NotMatchString '[01OIlio]'
             }
         }
 
         It 'Should still include non-ambiguous numbers and letters when ExcludeAmbiguous is specified' {
             $result = New-RandomString -Length 1000 -ExcludeAmbiguous
-            $result | Should -Match '[2-9]'  # Non-ambiguous numbers
-            $result | Should -Match '[A-HJ-KM-NP-Z]'  # Uppercase letters excluding I, L, O
-            $result | Should -Match '[a-hj-km-np-z]'  # Lowercase letters excluding i, l, o
+            $result | Should-MatchString '[2-9]'  # Non-ambiguous numbers
+            $result | Should-MatchString '[A-HJ-KM-NP-Z]'  # Uppercase letters excluding I, L, O
+            $result | Should-MatchString '[a-hj-km-np-z]'  # Lowercase letters excluding i, l, o
         }
     }
 
@@ -132,12 +132,12 @@ Describe 'New-RandomString' {
             $excludedChars = @('0', '1', 'A', 'a')
             $result = New-RandomString -Length 100 -ExcludeCharacters $excludedChars
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
+            $result.Length | Should-Be 100
 
             # None of the excluded characters should appear
             foreach ($char in $excludedChars)
             {
-                $result.Contains($char) | Should -Be $false
+                $result.Contains($char) | Should-Be $false
             }
         }
 
@@ -145,12 +145,12 @@ Describe 'New-RandomString' {
             $excludedSymbols = @('!', '@', '#')
             $result = New-RandomString -Length 200 -IncludeSymbols -ExcludeCharacters $excludedSymbols
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 200
+            $result.Length | Should-Be 200
 
             # Excluded symbols should not appear
             foreach ($symbol in $excludedSymbols)
             {
-                $result.Contains($symbol) | Should -Be $false
+                $result.Contains($symbol) | Should-Be $false
             }
 
             # But other symbols should still be possible
@@ -165,22 +165,22 @@ Describe 'New-RandomString' {
                     break
                 }
             }
-            $foundAllowedSymbol | Should -Be $true
+            $foundAllowedSymbol | Should-Be $true
         }
 
         It 'Should work in combination with ExcludeAmbiguous' {
             $additionalExclusions = @('X', 'Y', 'Z')
             $result = New-RandomString -Length 100 -ExcludeAmbiguous -ExcludeCharacters $additionalExclusions
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
+            $result.Length | Should-Be 100
 
             # Should exclude ambiguous characters: 0, 1, O, I, l, o, i
-            $result | Should -Not -Match '[01OIlio]'
+            $result | Should-NotMatchString '[01OIlio]'
 
             # Should also exclude additional characters
             foreach ($char in $additionalExclusions)
             {
-                $result.Contains($char) | Should -Be $false
+                $result.Contains($char) | Should-Be $false
             }
         }
 
@@ -188,12 +188,12 @@ Describe 'New-RandomString' {
             $excludedChars = @('0', 'O', '1', 'I')
             $result = New-RandomString -Length 50 -ExcludeCharacters $excludedChars -Secure
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 50
+            $result.Length | Should-Be 50
 
             # None of the excluded characters should appear
             foreach ($char in $excludedChars)
             {
-                $result.Contains($char) | Should -Be $false
+                $result.Contains($char) | Should-Be $false
             }
         }
 
@@ -206,35 +206,35 @@ Describe 'New-RandomString' {
 
             $allChars = $numbers + $upperCase + $lowerCase
 
-            { New-RandomString -Length 10 -ExcludeCharacters $allChars } | Should -Throw -ExpectedMessage '*All available characters have been excluded*'
+            { New-RandomString -Length 10 -ExcludeCharacters $allChars } | Should-Throw -ExceptionMessage '*All available characters have been excluded*'
         }
 
         It 'Should handle empty ExcludeCharacters array' {
             $result = New-RandomString -Length 20 -ExcludeCharacters @()
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 20
-            $result | Should -MatchExactly '^[0-9A-Za-z]+$'
+            $result.Length | Should-Be 20
+            $result | Should-MatchString '^[0-9A-Za-z]+$' -CaseSensitive
         }
 
         It 'Should exclude single character correctly' {
             $result = New-RandomString -Length 100 -ExcludeCharacters @('X')
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
-            $result.Contains('X') | Should -Be $false
+            $result.Length | Should-Be 100
+            $result.Contains('X') | Should-Be $false
         }
 
         It 'Should handle case-sensitive exclusions' {
             # Test excluding uppercase 'A'
             $result = New-RandomString -Length 100 -ExcludeCharacters @('A')
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
-            $result.Contains('A') | Should -Be $false
+            $result.Length | Should-Be 100
+            $result.Contains('A') | Should-Be $false
 
             # Test excluding lowercase 'a'
             $result2 = New-RandomString -Length 100 -ExcludeCharacters @('a')
             $result2 | Should -Not -BeNullOrEmpty
-            $result2.Length | Should -Be 100
-            $result2.Contains('a') | Should -Be $false
+            $result2.Length | Should-Be 100
+            $result2.Contains('a') | Should-Be $false
         }
 
         It 'Should split multi-character exclusion entries into individual characters' {
@@ -248,7 +248,7 @@ Describe 'New-RandomString' {
             }
 
             $result = New-RandomString -Length 50 -ExcludeCharacters ($charactersToExclude + @('AB', '12'))
-            $result | Should -Be ($allowedCharacter * 50)
+            $result | Should-Be ($allowedCharacter * 50)
         }
 
         It 'Should treat ExcludeCharacters as case-sensitive when only one case remains in the pool' {
@@ -261,7 +261,7 @@ Describe 'New-RandomString' {
             }
 
             $result = New-RandomString -Length 20 -ExcludeCharacters $charactersToExclude
-            $result | Should -Be ('a' * 20)
+            $result | Should-Be ('a' * 20)
         }
     }
 
@@ -270,15 +270,15 @@ Describe 'New-RandomString' {
             $customChars = @('-', '_', '.')
             $result = New-RandomString -Length 200 -IncludeCharacters $customChars -ExcludeCharacters $script:DefaultRandomStringCharacters
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 200
-            $result | Should -MatchExactly '^[-_.]+$'
+            $result.Length | Should-Be 200
+            $result | Should-MatchString '^[-_.]+$' -CaseSensitive
         }
 
         It 'Should work with special ASCII characters' {
             $specialChars = @('-', '_', '.', '|')
             $result = New-RandomString -Length 100 -IncludeCharacters $specialChars
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
+            $result.Length | Should-Be 100
 
             # Test multiple times to increase probability of finding special characters
             $foundSpecialChar = $false
@@ -295,27 +295,27 @@ Describe 'New-RandomString' {
                 }
                 if ($foundSpecialChar) { break }
             }
-            $foundSpecialChar | Should -Be $true
+            $foundSpecialChar | Should-Be $true
         }
 
         It 'Should work in combination with IncludeSymbols' {
             $customChars = @('-', '_', '.')
             $result = New-RandomString -Length 200 -IncludeCharacters $customChars -IncludeSymbols
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 200
+            $result.Length | Should-Be 200
 
             # Should allow standard symbols and custom characters
-            $result | Should -MatchExactly '^[0-9A-Za-z!@#$%^&*._-]+$'
+            $result | Should-MatchString '^[0-9A-Za-z!@#$%^&*._-]+$' -CaseSensitive
         }
 
         It 'Should work in combination with ExcludeAmbiguous' {
             $customChars = @('+', '=', '%')
             $result = New-RandomString -Length 100 -IncludeCharacters $customChars -ExcludeAmbiguous
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
+            $result.Length | Should-Be 100
 
             # Should exclude ambiguous characters: 0, 1, O, I, l, o, i
-            $result | Should -Not -Match '[01OIlio]'
+            $result | Should-NotMatchString '[01OIlio]'
 
             # Test multiple times to find custom characters
             $foundCustomChar = $false
@@ -332,7 +332,7 @@ Describe 'New-RandomString' {
                 }
                 if ($foundCustomChar) { break }
             }
-            $foundCustomChar | Should -Be $true
+            $foundCustomChar | Should-Be $true
         }
 
         It 'Should respect ExcludeCharacters even when characters are in IncludeCharacters' {
@@ -340,12 +340,12 @@ Describe 'New-RandomString' {
             $excludeChars = @('X', 'Z')  # Exclude some of the custom characters
             $result = New-RandomString -Length 100 -IncludeCharacters $customChars -ExcludeCharacters $excludeChars
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
+            $result.Length | Should-Be 100
 
             # Excluded characters should not appear, even if they were in IncludeCharacters
             foreach ($char in $excludeChars)
             {
-                $result.Contains($char) | Should -Be $false
+                $result.Contains($char) | Should-Be $false
             }
 
             # But non-excluded custom characters should still be possible
@@ -359,14 +359,14 @@ Describe 'New-RandomString' {
                     break
                 }
             }
-            $foundAllowedCustomChar | Should -Be $true
+            $foundAllowedCustomChar | Should-Be $true
         }
 
         It 'Should work with Secure parameter' {
             $customChars = @('+', '=', '%', '~')
             $result = New-RandomString -Length 50 -IncludeCharacters $customChars -Secure
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 50
+            $result.Length | Should-Be 50
 
             # Test multiple times to find custom characters with secure generation
             $foundCustomChar = $false
@@ -383,21 +383,21 @@ Describe 'New-RandomString' {
                 }
                 if ($foundCustomChar) { break }
             }
-            $foundCustomChar | Should -Be $true
+            $foundCustomChar | Should-Be $true
         }
 
         It 'Should handle empty IncludeCharacters array' {
             $result = New-RandomString -Length 20 -IncludeCharacters @()
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 20
-            $result | Should -MatchExactly '^[0-9A-Za-z]+$'
+            $result.Length | Should-Be 20
+            $result | Should-MatchString '^[0-9A-Za-z]+$' -CaseSensitive
         }
 
         It 'Should handle single custom character' {
             $customChar = @('-')
             $result = New-RandomString -Length 100 -IncludeCharacters $customChar
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
+            $result.Length | Should-Be 100
 
             # Test multiple times to find the custom character
             $foundCustomChar = $false
@@ -410,14 +410,14 @@ Describe 'New-RandomString' {
                     break
                 }
             }
-            $foundCustomChar | Should -Be $true
+            $foundCustomChar | Should-Be $true
         }
 
         It 'Should handle duplicate characters in IncludeCharacters array' {
             $customChars = @('X', 'X', 'Y', 'Y', 'Z')  # Duplicates should not cause issues
             $result = New-RandomString -Length 100 -IncludeCharacters $customChars
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 100
+            $result.Length | Should-Be 100
 
             # Test multiple times to find custom characters
             $foundCustomChar = $false
@@ -430,24 +430,24 @@ Describe 'New-RandomString' {
                     break
                 }
             }
-            $foundCustomChar | Should -Be $true
+            $foundCustomChar | Should-Be $true
         }
 
         It 'Should split multi-character IncludeCharacters entries into individual characters without changing the requested length' {
             $result = New-RandomString -Length 40 -ExcludeCharacters $script:DefaultRandomStringCharacters -IncludeCharacters @('AB', '-_')
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 40
-            $result | Should -MatchExactly '^[AB_-]+$'
+            $result.Length | Should-Be 40
+            $result | Should-MatchString '^[AB_-]+$' -CaseSensitive
         }
 
         It 'Should work with separator characters' {
             $separators = @('-', '_', '.', '|')
             $result = New-RandomString -Length 50 -IncludeCharacters $separators
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 50
+            $result.Length | Should-Be 50
 
             # Should allow alphanumeric and separator characters
-            $result | Should -MatchExactly '^[0-9A-Za-z._|-]+$'
+            $result | Should-MatchString '^[0-9A-Za-z._|-]+$' -CaseSensitive
         }
     }
 
@@ -455,47 +455,47 @@ Describe 'New-RandomString' {
         It 'Should not generate adjacent duplicates when NoAdjacentDuplicates is specified' {
             $result = New-RandomString -Length 200 -NoAdjacentDuplicates
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 200
+            $result.Length | Should-Be 200
 
             for ($i = 1; $i -lt $result.Length; $i++)
             {
-                $result[$i] | Should -Not -Be $result[$i - 1]
+                $result[$i] | Should-NotBe $result[$i - 1]
             }
         }
 
         It 'Should work with custom-only pools when NoAdjacentDuplicates is specified' {
             $result = New-RandomString -Length 40 -ExcludeCharacters $script:DefaultRandomStringCharacters -IncludeCharacters @('-', '_') -NoAdjacentDuplicates
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 40
-            $result | Should -MatchExactly '^[-_]+$'
+            $result.Length | Should-Be 40
+            $result | Should-MatchString '^[-_]+$' -CaseSensitive
 
             for ($i = 1; $i -lt $result.Length; $i++)
             {
-                $result[$i] | Should -Not -Be $result[$i - 1]
+                $result[$i] | Should-NotBe $result[$i - 1]
             }
         }
 
         It 'Should throw when NoAdjacentDuplicates is impossible' {
             { New-RandomString -Length 2 -ExcludeCharacters $script:DefaultRandomStringCharacters -IncludeCharacters @('-') -NoAdjacentDuplicates } |
-                Should -Throw -ExpectedMessage '*At least two distinct characters are required*'
+                Should-Throw -ExceptionMessage '*At least two distinct characters are required*'
         }
 
         It 'Should generate unique characters when UniqueCharacters is specified' {
             $result = New-RandomString -Length 40 -UniqueCharacters
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 40
-            ($result.ToCharArray() | Select-Object -Unique).Count | Should -Be 40
+            $result.Length | Should-Be 40
+            ($result.ToCharArray() | Select-Object -Unique).Count | Should-Be 40
         }
 
         It 'Should honor NoAdjacentDuplicates when combined with UniqueCharacters' {
             $result = New-RandomString -Length 20 -UniqueCharacters -NoAdjacentDuplicates
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 20
-            ($result.ToCharArray() | Select-Object -Unique).Count | Should -Be 20
+            $result.Length | Should-Be 20
+            ($result.ToCharArray() | Select-Object -Unique).Count | Should-Be 20
 
             for ($i = 1; $i -lt $result.Length; $i++)
             {
-                $result[$i] | Should -Not -Be $result[$i - 1]
+                $result[$i] | Should-NotBe $result[$i - 1]
             }
         }
 
@@ -503,25 +503,25 @@ Describe 'New-RandomString' {
             $customChars = @('-', '_', '.', '+')
             $result = New-RandomString -Length 4 -ExcludeCharacters $script:DefaultRandomStringCharacters -IncludeCharacters $customChars -UniqueCharacters
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 4
-            ($result.ToCharArray() | Select-Object -Unique).Count | Should -Be 4
+            $result.Length | Should-Be 4
+            ($result.ToCharArray() | Select-Object -Unique).Count | Should-Be 4
 
             foreach ($char in $customChars)
             {
-                $result.Contains($char) | Should -Be $true
+                $result.Contains($char) | Should-Be $true
             }
         }
 
         It 'Should support WithoutReplacement as an alias for UniqueCharacters' {
             $result = New-RandomString -Length 20 -WithoutReplacement
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 20
-            ($result.ToCharArray() | Select-Object -Unique).Count | Should -Be 20
+            $result.Length | Should-Be 20
+            ($result.ToCharArray() | Select-Object -Unique).Count | Should-Be 20
         }
 
         It 'Should throw when UniqueCharacters exceeds pool size' {
             { New-RandomString -Length 63 -UniqueCharacters } |
-                Should -Throw -ExpectedMessage '*exceeds the number of unique characters available*'
+                Should-Throw -ExceptionMessage '*exceeds the number of unique characters available*'
         }
     }
 
@@ -530,23 +530,23 @@ Describe 'New-RandomString' {
             # We can't directly test cryptographic security, but we can test that it works
             $result = New-RandomString -Length 32 -Secure
             $result | Should -Not -BeNullOrEmpty
-            $result.Length | Should -Be 32
+            $result.Length | Should-Be 32
         }
 
         It 'Should support repeat control options when Secure is specified' {
             $noAdjacentResult = New-RandomString -Length 100 -NoAdjacentDuplicates -Secure
             $noAdjacentResult | Should -Not -BeNullOrEmpty
-            $noAdjacentResult.Length | Should -Be 100
+            $noAdjacentResult.Length | Should-Be 100
 
             for ($i = 1; $i -lt $noAdjacentResult.Length; $i++)
             {
-                $noAdjacentResult[$i] | Should -Not -Be $noAdjacentResult[$i - 1]
+                $noAdjacentResult[$i] | Should-NotBe $noAdjacentResult[$i - 1]
             }
 
             $uniqueResult = New-RandomString -Length 20 -UniqueCharacters -Secure
             $uniqueResult | Should -Not -BeNullOrEmpty
-            $uniqueResult.Length | Should -Be 20
-            ($uniqueResult.ToCharArray() | Select-Object -Unique).Count | Should -Be 20
+            $uniqueResult.Length | Should-Be 20
+            ($uniqueResult.ToCharArray() | Select-Object -Unique).Count | Should-Be 20
         }
 
         It 'Should work with all parameter combinations when Secure is specified' {
@@ -558,7 +558,7 @@ Describe 'New-RandomString' {
             {
                 $result = New-RandomString -Length 100 -ExcludeAmbiguous -IncludeSymbols -Secure
                 $result | Should -Not -BeNullOrEmpty
-                $result.Length | Should -Be 100
+                $result.Length | Should-Be 100
 
                 # Check that no ambiguous characters are present: 0, 1, O, I, l, o, i
                 if ($result -match '[01OIlio]')
@@ -573,15 +573,15 @@ Describe 'New-RandomString' {
                 }
             }
 
-            $foundNoAmbiguous | Should -Be $true
-            $foundSymbol | Should -Be $true
+            $foundNoAmbiguous | Should-Be $true
+            $foundSymbol | Should-Be $true
         }
     }
 
     Context 'Output type' {
         It 'Should return a string' {
             $result = New-RandomString
-            $result | Should -BeOfType [String]
+            $result | Should-HaveType ([String])
         }
     }
 }

--- a/Tests/Unit/Utilities/New-SymbolicLink.Tests.ps1
+++ b/Tests/Unit/Utilities/New-SymbolicLink.Tests.ps1
@@ -56,32 +56,32 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should create a symbolic link to a file' {
             New-SymbolicLink -Path $script:linkPath -Target $script:targetFile
 
-            Test-Path -Path $script:linkPath | Should -Be $true
+            Test-Path -Path $script:linkPath | Should-Be $true
 
             $linkItem = Get-Item -Path $script:linkPath
-            $linkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should -Be ([System.IO.FileAttributes]::ReparsePoint)
+            $linkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should-Be ([System.IO.FileAttributes]::ReparsePoint)
         }
 
         It 'Should create a symbolic link that points to correct content' {
             New-SymbolicLink -Path $script:linkPath -Target $script:targetFile
 
             $content = Get-Content -Path $script:linkPath
-            $content | Should -Be 'test content'
+            $content | Should-Be 'test content'
         }
 
         It 'Should return FileInfo when PassThru is specified' {
             $result = New-SymbolicLink -Path $script:linkPath -Target $script:targetFile -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Name | Should -Be 'link-to-file.txt'
-            $result.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should -Be ([System.IO.FileAttributes]::ReparsePoint)
+            $result.Name | Should-Be 'link-to-file.txt'
+            $result.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should-Be ([System.IO.FileAttributes]::ReparsePoint)
         }
 
         It 'Should fail when target does not exist and Force is not specified' {
             $nonExistentTarget = Join-Path -Path $script:targetDir -ChildPath 'does-not-exist.txt'
 
             { New-SymbolicLink -Path $script:linkPath -Target $nonExistentTarget -ErrorAction Stop } |
-            Should -Throw '*does not exist*'
+            Should-Throw '*does not exist*'
         }
 
         It 'Should create link to non-existent target when Force is specified' {
@@ -89,9 +89,9 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
 
             New-SymbolicLink -Path $script:linkPath -Target $nonExistentTarget -Force
 
-            Test-Path -Path $script:linkPath | Should -Be $true
+            Test-Path -Path $script:linkPath | Should-Be $true
             $linkItem = Get-Item -Path $script:linkPath
-            $linkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should -Be ([System.IO.FileAttributes]::ReparsePoint)
+            $linkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should-Be ([System.IO.FileAttributes]::ReparsePoint)
         }
 
         It 'Should fail when path already exists and Force is not specified' {
@@ -100,7 +100,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
 
             # Try to create another link at the same path
             { New-SymbolicLink -Path $script:linkPath -Target $script:targetFile -ErrorAction Stop } |
-            Should -Throw '*already exists*'
+            Should-Throw '*already exists*'
         }
 
         It 'Should overwrite existing link when Force is specified' {
@@ -115,7 +115,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             New-SymbolicLink -Path $script:linkPath -Target $targetFile2 -Force
 
             $content = Get-Content -Path $script:linkPath
-            $content | Should -Be 'different content'
+            $content | Should-Be 'different content'
 
             # Cleanup second target
             Remove-Item -Path $targetFile2 -Force -ErrorAction SilentlyContinue
@@ -132,7 +132,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             {
                 New-SymbolicLink -Path $script:linkPath -Target $replacementTarget -Force
 
-                Get-Content -Path $script:linkPath | Should -Be 'replacement content'
+                Get-Content -Path $script:linkPath | Should-Be 'replacement content'
             }
             finally
             {
@@ -170,26 +170,26 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should create a symbolic link to a directory' {
             New-SymbolicLink -Path $script:dirLinkPath -Target $script:targetSubDir
 
-            Test-Path -Path $script:dirLinkPath | Should -Be $true
+            Test-Path -Path $script:dirLinkPath | Should-Be $true
 
             $linkItem = Get-Item -Path $script:dirLinkPath
-            $linkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should -Be ([System.IO.FileAttributes]::ReparsePoint)
+            $linkItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint | Should-Be ([System.IO.FileAttributes]::ReparsePoint)
         }
 
         It 'Should allow access to files through directory symbolic link' {
             New-SymbolicLink -Path $script:dirLinkPath -Target $script:targetSubDir
 
             $fileViaLink = Join-Path -Path $script:dirLinkPath -ChildPath 'file-in-dir.txt'
-            Test-Path -Path $fileViaLink | Should -Be $true
+            Test-Path -Path $fileViaLink | Should-Be $true
 
             $content = Get-Content -Path $fileViaLink
-            $content | Should -Be 'content in subdir'
+            $content | Should-Be 'content in subdir'
         }
 
         It 'Should auto-detect directory type' {
             $result = New-SymbolicLink -Path $script:dirLinkPath -Target $script:targetSubDir -PassThru
 
-            $result.PSIsContainer | Should -Be $true
+            $result.PSIsContainer | Should-Be $true
         }
     }
 
@@ -202,7 +202,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
 
             New-SymbolicLink -Path $nestedLinkPath -Target $targetFile
 
-            Test-Path -Path $nestedLinkPath | Should -Be $true
+            Test-Path -Path $nestedLinkPath | Should-Be $true
 
             # Cleanup
             $nestedParent = Join-Path -Path $script:linkDir -ChildPath 'nested'
@@ -230,7 +230,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             New-SymbolicLink -Path $script:linkPath -Target $targetFile -ItemType File
 
             $linkItem = Get-Item -Path $script:linkPath
-            $linkItem.PSIsContainer | Should -Be $false
+            $linkItem.PSIsContainer | Should-Be $false
 
             Remove-Item -Path $targetFile -Force -ErrorAction SilentlyContinue
         }
@@ -242,7 +242,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             New-SymbolicLink -Path $script:linkPath -Target $targetSubDir -ItemType Directory
 
             $linkItem = Get-Item -Path $script:linkPath
-            $linkItem.PSIsContainer | Should -Be $true
+            $linkItem.PSIsContainer | Should-Be $true
 
             Remove-Item -Path $targetSubDir -Force -ErrorAction SilentlyContinue
         }
@@ -257,7 +257,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
 
             New-SymbolicLink -Path $linkPath -Target $targetFile -WhatIf
 
-            Test-Path -Path $linkPath | Should -Be $false
+            Test-Path -Path $linkPath | Should-Be $false
 
             Remove-Item -Path $targetFile -Force -ErrorAction SilentlyContinue
         }
@@ -276,7 +276,7 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             {
                 New-SymbolicLink -Path './links/relative-link.txt' -Target './targets/relative-target.txt'
 
-                Test-Path -Path $linkPath | Should -Be $true
+                Test-Path -Path $linkPath | Should-Be $true
             }
             finally
             {
@@ -292,12 +292,12 @@ Describe 'New-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
     Context 'Error Handling' {
         It 'Should provide clear error when path is null or empty' {
             { New-SymbolicLink -Path '' -Target 'sometarget' -ErrorAction Stop } |
-            Should -Throw
+            Should-Throw
         }
 
         It 'Should provide clear error when target is null or empty' {
             { New-SymbolicLink -Path 'somepath' -Target '' -ErrorAction Stop } |
-            Should -Throw
+            Should-Throw
         }
     }
 }

--- a/Tests/Unit/Utilities/Remove-OldFile.Tests.ps1
+++ b/Tests/Unit/Utilities/Remove-OldFile.Tests.ps1
@@ -35,38 +35,38 @@ Describe 'Remove-OldFile' {
         It 'Should have mandatory OlderThan parameter' {
             $command = Get-Command Remove-OldFile
             $olderThanParam = $command.Parameters['OlderThan']
-            $olderThanParam.Attributes.Mandatory | Should -Contain $true
+            $olderThanParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should validate OlderThan is positive integer' {
             $command = Get-Command Remove-OldFile
             $olderThanParam = $command.Parameters['OlderThan']
             $validateRange = $olderThanParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
-            $validateRange.MinRange | Should -Be 1
-            $validateRange.MaxRange | Should -Be ([Int32]::MaxValue)
+            $validateRange.MinRange | Should-Be 1
+            $validateRange.MaxRange | Should-Be ([Int32]::MaxValue)
         }
 
         It 'Should have optional Path parameter with default value' {
             $command = Get-Command Remove-OldFile
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Mandatory | Should -Not -Contain $true
+            $pathParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should accept pipeline input for Path' {
             $command = Get-Command Remove-OldFile
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.ValueFromPipeline | Should -Contain $true
+            $pathParam.Attributes.ValueFromPipeline | Should-ContainCollection $true
         }
 
         It 'Should validate Unit parameter has correct values' {
             $command = Get-Command Remove-OldFile
             $unitParam = $command.Parameters['Unit']
             $validateSet = $unitParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
-            $validateSet.ValidValues | Should -Contain 'Days'
-            $validateSet.ValidValues | Should -Contain 'Hours'
-            $validateSet.ValidValues | Should -Contain 'Months'
-            $validateSet.ValidValues | Should -Contain 'Years'
-            $validateSet.ValidValues.Count | Should -Be 4
+            $validateSet.ValidValues | Should-ContainCollection 'Days'
+            $validateSet.ValidValues | Should-ContainCollection 'Hours'
+            $validateSet.ValidValues | Should-ContainCollection 'Months'
+            $validateSet.ValidValues | Should-ContainCollection 'Years'
+            $validateSet.ValidValues.Count | Should-Be 4
         }
 
         It 'Should have default Unit value of Days' {
@@ -77,15 +77,15 @@ Describe 'Remove-OldFile' {
 
         It 'Should support ShouldProcess (WhatIf/Confirm)' {
             $command = Get-Command Remove-OldFile
-            $command.Parameters.ContainsKey('WhatIf') | Should -Be $true
-            $command.Parameters.ContainsKey('Confirm') | Should -Be $true
+            $command.Parameters.ContainsKey('WhatIf') | Should-Be $true
+            $command.Parameters.ContainsKey('Confirm') | Should-Be $true
         }
 
         It 'Should expose optional Recurse switch' {
             $command = Get-Command Remove-OldFile
             $recurseParam = $command.Parameters['Recurse']
             $recurseParam | Should -Not -BeNullOrEmpty
-            $recurseParam.Attributes.Mandatory | Should -Not -Contain $true
+            $recurseParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should have OutputType attribute defined' {
@@ -111,8 +111,8 @@ Describe 'Remove-OldFile' {
             (Get-Item $testFile).LastWriteTime = $oldDate
 
             $result = Remove-OldFile -Path $script:testDir -OlderThan 5 -Unit Days -WhatIf
-            $result.OldestDate | Should -BeOfType [DateTime]
-            $result.OldestDate.Date | Should -Be (Get-Date).AddDays(-5).Date
+            $result.OldestDate | Should-HaveType ([DateTime])
+            $result.OldestDate.Date | Should-Be (Get-Date).AddDays(-5).Date
         }
 
         It 'Should calculate cutoff date for Hours unit' {
@@ -120,11 +120,11 @@ Describe 'Remove-OldFile' {
             'test' | Set-Content -Path $testFile
 
             $result = Remove-OldFile -Path $script:testDir -OlderThan 24 -Unit Hours -WhatIf
-            $result.OldestDate | Should -BeOfType [DateTime]
+            $result.OldestDate | Should-HaveType ([DateTime])
             # Allow small time difference for test execution
             $expectedDate = (Get-Date).AddHours(-24)
-            $result.OldestDate | Should -BeGreaterThan $expectedDate.AddMinutes(-1)
-            $result.OldestDate | Should -BeLessThan $expectedDate.AddMinutes(1)
+            $result.OldestDate | Should-BeGreaterThan $expectedDate.AddMinutes(-1)
+            $result.OldestDate | Should-BeLessThan $expectedDate.AddMinutes(1)
         }
 
         It 'Should calculate cutoff date for Months unit' {
@@ -132,10 +132,10 @@ Describe 'Remove-OldFile' {
             'test' | Set-Content -Path $testFile
 
             $result = Remove-OldFile -Path $script:testDir -OlderThan 3 -Unit Months -WhatIf
-            $result.OldestDate | Should -BeOfType [DateTime]
+            $result.OldestDate | Should-HaveType ([DateTime])
             $expectedDate = (Get-Date).AddMonths(-3)
             # Month calculations can vary by day, so check within reason
-            $result.OldestDate.Date | Should -Be $expectedDate.Date
+            $result.OldestDate.Date | Should-Be $expectedDate.Date
         }
 
         It 'Should calculate cutoff date for Years unit' {
@@ -143,9 +143,9 @@ Describe 'Remove-OldFile' {
             'test' | Set-Content -Path $testFile
 
             $result = Remove-OldFile -Path $script:testDir -OlderThan 1 -Unit Years -WhatIf
-            $result.OldestDate | Should -BeOfType [DateTime]
+            $result.OldestDate | Should-HaveType ([DateTime])
             $expectedDate = (Get-Date).AddYears(-1)
-            $result.OldestDate.Date | Should -Be $expectedDate.Date
+            $result.OldestDate.Date | Should-Be $expectedDate.Date
         }
     }
 
@@ -174,7 +174,7 @@ Describe 'Remove-OldFile' {
         It 'Should handle non-existent path gracefully' {
             $nonExistentPath = Join-Path -Path $TestDrive -ChildPath 'NonExistent'
 
-            { Remove-OldFile -Path $nonExistentPath -OlderThan 1 -ErrorAction Stop } | Should -Throw
+            { Remove-OldFile -Path $nonExistentPath -OlderThan 1 -ErrorAction Stop } | Should-Throw
         }
     }
 
@@ -188,28 +188,28 @@ Describe 'Remove-OldFile' {
             $result = Remove-OldFile -Path $script:testDir -OlderThan 1 -WhatIf
 
             $result | Should -Not -BeNullOrEmpty
-            $result.PSObject.Properties.Name | Should -Contain 'FilesRemoved'
-            $result.PSObject.Properties.Name | Should -Contain 'DirectoriesRemoved'
-            $result.PSObject.Properties.Name | Should -Contain 'TotalSpaceFreed'
-            $result.PSObject.Properties.Name | Should -Contain 'TotalSpaceFreedMB'
-            $result.PSObject.Properties.Name | Should -Contain 'Errors'
-            $result.PSObject.Properties.Name | Should -Contain 'OldestDate'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FilesRemoved'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'DirectoriesRemoved'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'TotalSpaceFreed'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'TotalSpaceFreedMB'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Errors'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'OldestDate'
         }
 
         It 'Should initialize counters to zero with WhatIf' {
             $result = Remove-OldFile -Path $script:testDir -OlderThan 1 -WhatIf
 
-            $result.FilesRemoved | Should -Be 0
-            $result.DirectoriesRemoved | Should -Be 0
-            $result.TotalSpaceFreed | Should -Be 0
-            $result.Errors | Should -Be 0
+            $result.FilesRemoved | Should-Be 0
+            $result.DirectoriesRemoved | Should-Be 0
+            $result.TotalSpaceFreed | Should-Be 0
+            $result.Errors | Should-Be 0
         }
 
         It 'Should include OldestDate in summary' {
             $result = Remove-OldFile -Path $script:testDir -OlderThan 7 -Unit Days -WhatIf
 
-            $result.OldestDate | Should -BeOfType [DateTime]
-            $result.OldestDate | Should -BeLessThan (Get-Date)
+            $result.OldestDate | Should-HaveType ([DateTime])
+            $result.OldestDate | Should-BeLessThan (Get-Date)
         }
     }
 
@@ -229,13 +229,13 @@ Describe 'Remove-OldFile' {
 
             Remove-OldFile -Path $script:testDir -OlderThan 7 -WhatIf
 
-            Test-Path $testFile | Should -Be $true
+            Test-Path $testFile | Should-Be $true
         }
 
         It 'Should report zero files removed with WhatIf' {
             $result = Remove-OldFile -Path $script:testDir -OlderThan 7 -WhatIf
 
-            $result.FilesRemoved | Should -Be 0
+            $result.FilesRemoved | Should-Be 0
         }
     }
 
@@ -254,9 +254,9 @@ Describe 'Remove-OldFile' {
 
             $result = Remove-OldFile -Path $root -OlderThan 30 -WhatIf
 
-            $result.FilesRemoved | Should -Be 0
-            Test-Path $rootFile | Should -BeTrue
-            Test-Path $childFile | Should -BeTrue
+            $result.FilesRemoved | Should-Be 0
+            Test-Path $rootFile | Should-BeTruthy
+            Test-Path $childFile | Should-BeTruthy
         }
     }
 
@@ -277,9 +277,9 @@ Describe 'Remove-OldFile' {
 
             $result = Remove-OldFile -Path $root -OlderThan 30 -ExcludeDirectory 'Keep*' -Recurse -Confirm:$false
 
-            $result.FilesRemoved | Should -Be 1
-            Test-Path $keptFile | Should -BeTrue
-            Test-Path $removedFile | Should -BeFalse
+            $result.FilesRemoved | Should-Be 1
+            Test-Path $keptFile | Should-BeTruthy
+            Test-Path $removedFile | Should-BeFalsy
         }
     }
 }

--- a/Tests/Unit/Utilities/Remove-SymbolicLink.Tests.ps1
+++ b/Tests/Unit/Utilities/Remove-SymbolicLink.Tests.ps1
@@ -57,23 +57,23 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should remove a file symbolic link' {
             Remove-SymbolicLink -Path $script:linkPath
 
-            Test-Path -Path $script:linkPath | Should -Be $false
+            Test-Path -Path $script:linkPath | Should-Be $false
         }
 
         It 'Should not remove the target file when removing symbolic link' {
             Remove-SymbolicLink -Path $script:linkPath
 
-            Test-Path -Path $script:targetFile | Should -Be $true
-            Get-Content -Path $script:targetFile | Should -Be 'test content'
+            Test-Path -Path $script:targetFile | Should-Be $true
+            Get-Content -Path $script:targetFile | Should-Be 'test content'
         }
 
         It 'Should return information when PassThru is specified' {
             $result = Remove-SymbolicLink -Path $script:linkPath -PassThru
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Path | Should -Be $script:linkPath
-            $result.Removed | Should -Be $true
-            $result.ItemType | Should -Be 'File'
+            $result.Path | Should-Be $script:linkPath
+            $result.Removed | Should-Be $true
+            $result.ItemType | Should-Be 'File'
         }
 
         It 'Should remove a dangling symbolic link without touching the missing target path' {
@@ -81,9 +81,9 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
 
             $result = Remove-SymbolicLink -Path $script:linkPath -PassThru
 
-            Test-Path -Path $script:linkPath | Should -Be $false
-            Test-Path -Path $script:targetFile | Should -Be $false
-            $result.Removed | Should -Be $true
+            Test-Path -Path $script:linkPath | Should-Be $false
+            Test-Path -Path $script:targetFile | Should-Be $false
+            $result.Removed | Should-Be $true
         }
     }
 
@@ -116,24 +116,24 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should remove a directory symbolic link' {
             Remove-SymbolicLink -Path $script:dirLinkPath
 
-            Test-Path -Path $script:dirLinkPath | Should -Be $false
+            Test-Path -Path $script:dirLinkPath | Should-Be $false
         }
 
         It 'Should not remove the target directory or its contents when removing symbolic link' {
             Remove-SymbolicLink -Path $script:dirLinkPath
 
-            Test-Path -Path $script:targetSubDir | Should -Be $true
+            Test-Path -Path $script:targetSubDir | Should-Be $true
 
             $fileInDir = Join-Path -Path $script:targetSubDir -ChildPath 'file-in-dir.txt'
-            Test-Path -Path $fileInDir | Should -Be $true
-            Get-Content -Path $fileInDir | Should -Be 'content in subdir'
+            Test-Path -Path $fileInDir | Should-Be $true
+            Get-Content -Path $fileInDir | Should-Be 'content in subdir'
         }
 
         It 'Should return directory ItemType in PassThru output' {
             $result = Remove-SymbolicLink -Path $script:dirLinkPath -PassThru
 
-            $result.ItemType | Should -Be 'Directory'
-            $result.Removed | Should -Be $true
+            $result.ItemType | Should-Be 'Directory'
+            $result.Removed | Should-Be $true
         }
     }
 
@@ -142,7 +142,7 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             $nonExistentPath = Join-Path -Path $script:linkDir -ChildPath 'does-not-exist'
 
             { Remove-SymbolicLink -Path $nonExistentPath -ErrorAction Stop } |
-            Should -Throw '*not found*'
+            Should-Throw '*not found*'
         }
 
         It 'Should return error info in PassThru when path does not exist' {
@@ -151,8 +151,8 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             $result = Remove-SymbolicLink -Path $nonExistentPath -PassThru -ErrorAction SilentlyContinue
 
             $result | Should -Not -BeNullOrEmpty
-            $result.Removed | Should -Be $false
-            $result.Error | Should -Be 'Path not found'
+            $result.Removed | Should-Be $false
+            $result.Error | Should-Be 'Path not found'
         }
 
         It 'Should fail when path is not a symbolic link' {
@@ -163,7 +163,7 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             try
             {
                 { Remove-SymbolicLink -Path $regularFile -ErrorAction Stop } |
-                Should -Throw '*not a symbolic link*'
+                Should-Throw '*not a symbolic link*'
             }
             finally
             {
@@ -178,7 +178,7 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
 
             Remove-SymbolicLink -Path $regularFile -Force
 
-            Test-Path -Path $regularFile | Should -Be $false
+            Test-Path -Path $regularFile | Should-Be $false
         }
     }
 
@@ -223,32 +223,32 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should remove multiple symbolic links via array parameter' {
             Remove-SymbolicLink -Path $script:linkPath1, $script:linkPath2, $script:linkPath3
 
-            Test-Path -Path $script:linkPath1 | Should -Be $false
-            Test-Path -Path $script:linkPath2 | Should -Be $false
-            Test-Path -Path $script:linkPath3 | Should -Be $false
+            Test-Path -Path $script:linkPath1 | Should-Be $false
+            Test-Path -Path $script:linkPath2 | Should-Be $false
+            Test-Path -Path $script:linkPath3 | Should-Be $false
         }
 
         It 'Should preserve all target files when removing multiple links' {
             Remove-SymbolicLink -Path $script:linkPath1, $script:linkPath2, $script:linkPath3
 
-            Test-Path -Path $script:targetFile1 | Should -Be $true
-            Test-Path -Path $script:targetFile2 | Should -Be $true
-            Test-Path -Path $script:targetFile3 | Should -Be $true
+            Test-Path -Path $script:targetFile1 | Should-Be $true
+            Test-Path -Path $script:targetFile2 | Should-Be $true
+            Test-Path -Path $script:targetFile3 | Should-Be $true
         }
 
         It 'Should return results for all links when PassThru is specified' {
             $results = Remove-SymbolicLink -Path $script:linkPath1, $script:linkPath2, $script:linkPath3 -PassThru
 
-            $results.Count | Should -Be 3
-            $results | ForEach-Object { $_.Removed | Should -Be $true }
+            $results.Count | Should-Be 3
+            $results | ForEach-Object { $_.Removed | Should-Be $true }
         }
 
         It 'Should process symbolic links via pipeline' {
             $script:linkPath1, $script:linkPath2, $script:linkPath3 | Remove-SymbolicLink
 
-            Test-Path -Path $script:linkPath1 | Should -Be $false
-            Test-Path -Path $script:linkPath2 | Should -Be $false
-            Test-Path -Path $script:linkPath3 | Should -Be $false
+            Test-Path -Path $script:linkPath1 | Should-Be $false
+            Test-Path -Path $script:linkPath2 | Should-Be $false
+            Test-Path -Path $script:linkPath3 | Should-Be $false
         }
     }
 
@@ -277,14 +277,14 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should not remove link when WhatIf is specified' {
             Remove-SymbolicLink -Path $script:linkPath -WhatIf
 
-            Test-Path -Path $script:linkPath | Should -Be $true
+            Test-Path -Path $script:linkPath | Should-Be $true
         }
 
         It 'Should return WhatIf status in PassThru output' {
             $result = Remove-SymbolicLink -Path $script:linkPath -WhatIf -PassThru
 
-            $result.Removed | Should -Be $false
-            $result.Error | Should -Be 'WhatIf mode - not removed'
+            $result.Removed | Should-Be $false
+            $result.Error | Should-Be 'WhatIf mode - not removed'
         }
     }
 
@@ -315,7 +315,7 @@ Describe 'Remove-SymbolicLink Unit Tests' -Tag 'Unit', 'Utilities' {
             {
                 Remove-SymbolicLink -Path './links/relative-link.txt'
 
-                Test-Path -Path $script:linkPath | Should -Be $false
+                Test-Path -Path $script:linkPath | Should-Be $false
             }
             finally
             {

--- a/Tests/Unit/Utilities/Rename-File.Tests.ps1
+++ b/Tests/Unit/Utilities/Rename-File.Tests.ps1
@@ -37,13 +37,13 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should convert filename to uppercase' {
             Rename-File -LiteralPath $script:testFile -ToUpper
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Be 'TESTFILE.TXT'
+            $result.Name | Should-Be 'TESTFILE.TXT'
         }
 
         It 'Should convert filename to lowercase' {
             Rename-File -LiteralPath $script:testFile -ToLower
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Be 'testfile.txt'
+            $result.Name | Should-Be 'testfile.txt'
         }
 
         It 'Should convert filename to title case' {
@@ -53,7 +53,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             'content' | Out-File -FilePath $testFile2 -Encoding UTF8
             Rename-File -LiteralPath $testFile2 -ToTitleCase
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Be 'Test File Name.txt'
+            $result.Name | Should-Be 'Test File Name.txt'
         }
 
         It 'Should convert filename to camel case' {
@@ -63,7 +63,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             'content' | Out-File -FilePath $testFile2 -Encoding UTF8
             Rename-File -LiteralPath $testFile2 -ToCamelCase
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Be 'testFileName.txt'
+            $result.Name | Should-Be 'testFileName.txt'
         }
 
         It 'Should convert filename to pascal case' {
@@ -73,7 +73,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             'content' | Out-File -FilePath $testFile2 -Encoding UTF8
             Rename-File -LiteralPath $testFile2 -ToPascalCase
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Be 'TestFileName.txt'
+            $result.Name | Should-Be 'TestFileName.txt'
         }
     }
 
@@ -89,26 +89,26 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should replace spaces with underscores' {
             Rename-File -LiteralPath $script:testFile -ReplaceSpacesWith '_'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file.txt') | Should-Be $true
         }
 
         It 'Should replace spaces with dashes' {
             Rename-File -LiteralPath $script:testFile -ReplaceSpacesWith '-'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test-file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test-file.txt') | Should-Be $true
         }
 
         It 'Should replace underscores with spaces' {
             $testFile2 = Join-Path -Path $script:testRoot -ChildPath 'test_file.txt'
             'content' | Out-File -FilePath $testFile2 -Encoding UTF8
             Rename-File -LiteralPath $testFile2 -ReplaceUnderscoresWith ' '
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should-Be $true
         }
 
         It 'Should replace dashes with spaces' {
             $testFile2 = Join-Path -Path $script:testRoot -ChildPath 'test-file.txt'
             'content' | Out-File -FilePath $testFile2 -Encoding UTF8
             Rename-File -LiteralPath $testFile2 -ReplaceDashesWith ' '
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should-Be $true
         }
     }
 
@@ -121,21 +121,21 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             $testFile = Join-Path -Path $script:testRoot -ChildPath '  test file  .txt'
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -Trim
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should-Be $true
         }
 
         It 'Should trim leading spaces only' {
             $testFile = Join-Path -Path $script:testRoot -ChildPath '  test file.txt'
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -TrimStart
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should-Be $true
         }
 
         It 'Should trim trailing spaces only' {
             $testFile = Join-Path -Path $script:testRoot -ChildPath 'test file  .txt'
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -TrimEnd
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should-Be $true
         }
     }
 
@@ -151,17 +151,17 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should prepend text to filename' {
             Rename-File -LiteralPath $script:testFile -Prepend 'prefix_'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'prefix_file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'prefix_file.txt') | Should-Be $true
         }
 
         It 'Should append text to filename' {
             Rename-File -LiteralPath $script:testFile -Append '_suffix'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'file_suffix.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'file_suffix.txt') | Should-Be $true
         }
 
         It 'Should prepend and append text to filename' {
             Rename-File -LiteralPath $script:testFile -Prepend 'prefix_' -Append '_suffix'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'prefix_file_suffix.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'prefix_file_suffix.txt') | Should-Be $true
         }
     }
 
@@ -174,14 +174,14 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             $testFile = Join-Path -Path $script:testRoot -ChildPath 'test%20file.txt'
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -UrlDecode
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file.txt') | Should-Be $true
         }
 
         It 'Should URL decode filename with multiple encoded characters' {
             $testFile = Join-Path -Path $script:testRoot -ChildPath 'test%20file%2B%2D.txt'
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -UrlDecode
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file+-.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test file+-.txt') | Should-Be $true
         }
     }
 
@@ -195,7 +195,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -Normalize
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Be 'cafe.txt'
+            $result.Name | Should-Be 'cafe.txt'
         }
 
         It 'Should normalize and trim leading/trailing whitespace' {
@@ -203,7 +203,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -Normalize
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Be 'cafe.txt'
+            $result.Name | Should-Be 'cafe.txt'
         }
     }
 
@@ -216,7 +216,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             $testFile = Join-Path -Path $script:testRoot -ChildPath 'test(file).txt'
             'content' | Out-File -FilePath $testFile -Encoding UTF8
             Rename-File -LiteralPath $testFile -RemoveShellMetaCharacters
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'testfile.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'testfile.txt') | Should-Be $true
         }
     }
 
@@ -232,12 +232,12 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should remove file extension' {
             Rename-File -LiteralPath $script:testFile -RemoveExtension
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'file') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'file') | Should-Be $true
         }
 
         It 'Should change file extension' {
             Rename-File -LiteralPath $script:testFile -NewExtension '.dat'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'file.dat') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'file.dat') | Should-Be $true
         }
     }
 
@@ -253,12 +253,12 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should replace text using hashtable' {
             Rename-File -LiteralPath $script:testFile -Replace @{ 'old' = 'new'; 'test' = 'prod' }
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'new_file_prod.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'new_file_prod.txt') | Should-Be $true
         }
 
         It 'Should replace text using regex pattern' {
             Rename-File -LiteralPath $script:testFile -RegexReplace @{ '_\w+_' = '_' }
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'old_test.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'old_test.txt') | Should-Be $true
         }
     }
 
@@ -274,12 +274,12 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should apply script block transformation' {
             Rename-File -LiteralPath $script:testFile -Expression { $_.Substring(0, 4) }
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'long.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'long.txt') | Should-Be $true
         }
 
         It 'Should apply script block with string manipulation' {
             Rename-File -LiteralPath $script:testFile -Expression { "backup_$_" }
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'backup_long_filename_test.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'backup_long_filename_test.txt') | Should-Be $true
         }
     }
 
@@ -299,21 +299,21 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should add counter with default format (D3)' {
             Get-ChildItem -Path $script:testRoot -Filter 'file*.txt' | Rename-File -Prepend 'img_' -Counter
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'img_file1001.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'img_file2002.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'img_file3003.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'img_file1001.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'img_file2002.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'img_file3003.txt') | Should-Be $true
         }
 
         It 'Should add counter with custom format (D2)' {
             Get-ChildItem -Path $script:testRoot -Filter 'file*.txt' | Rename-File -Prepend 'doc_' -Counter -CounterFormat 'D2'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'doc_file101.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'doc_file202.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'doc_file101.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'doc_file202.txt') | Should-Be $true
         }
 
         It 'Should add counter with custom start value' {
             Get-ChildItem -Path $script:testRoot -Filter 'file*.txt' | Rename-File -Prepend 'test_' -Counter -CounterStart 10
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file1010.txt') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file2011.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file1010.txt') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file2011.txt') | Should-Be $true
         }
     }
 
@@ -333,9 +333,9 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should use NewName with counter placeholder' {
             Get-ChildItem -Path $script:testRoot -Filter 'IMG_*.jpg' | Rename-File -NewName 'photo_{0:D4}.jpg' -Counter
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_0001.jpg') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_0002.jpg') | Should -Be $true
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_0003.jpg') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_0001.jpg') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_0002.jpg') | Should-Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'photo_0003.jpg') | Should-Be $true
         }
     }
 
@@ -358,7 +358,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
             # Now try to rename file1 to same name - should create unique name
             Rename-File -LiteralPath $script:testFile1 -NewName 'target.txt'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'target_2.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'target_2.txt') | Should-Be $true
         }
     }
 
@@ -375,14 +375,14 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should apply multiple transformations in correct order' {
             Rename-File -LiteralPath $script:testFile -ReplaceSpacesWith '_' -ToLower -Prepend '2024_'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024_test_file_name.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath '2024_test_file_name.txt') | Should-Be $true
         }
 
         It 'Should combine normalization, case conversion, and whitespace replacement' {
             $testFile2 = Join-Path -Path $script:testRoot -ChildPath 'Café File.txt'
             'content' | Out-File -FilePath $testFile2 -Encoding UTF8
             Rename-File -LiteralPath $testFile2 -Normalize -ToLower -ReplaceSpacesWith '-'
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'cafe-file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'cafe-file.txt') | Should-Be $true
         }
     }
 
@@ -397,7 +397,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
             # After sanitization, colons should be replaced
             Rename-File -LiteralPath $testFile -SanitizeForCrossPlatform
             $result = Get-ChildItem -Path $script:testRoot -File
-            $result.Name | Should -Match '^file_test\.txt$'
+            $result.Name | Should-MatchString '^file_test\.txt$'
         }
     }
 
@@ -415,8 +415,8 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should return FileInfo object when PassThru is specified' {
             $result = Rename-File -LiteralPath $script:testFile -ToUpper -PassThru
             $result | Should -Not -BeNullOrEmpty
-            $result | Should -BeOfType [System.IO.FileInfo]
-            $result.Name | Should -Be 'TEST.TXT'
+            $result | Should-HaveType ([System.IO.FileInfo])
+            $result.Name | Should-Be 'TEST.TXT'
         }
     }
 
@@ -437,10 +437,10 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
         It 'Should process multiple files with wildcard pattern' {
             Rename-File -Path (Join-Path -Path $script:testRoot -ChildPath 'test*.txt') -ToUpper
             $files = Get-ChildItem -Path $script:testRoot -File | Sort-Object Name
-            $files | Should -HaveCount 3
-            $files[0].Name | Should -Be 'TEST1.TXT'
-            $files[1].Name | Should -Be 'TEST2.TXT'
-            $files[2].Name | Should -Be 'TEST3.TXT'
+            $files | Should-BeCollection -Count 3
+            $files[0].Name | Should-Be 'TEST1.TXT'
+            $files[1].Name | Should-Be 'TEST2.TXT'
+            $files[2].Name | Should-Be 'TEST3.TXT'
         }
     }
 
@@ -467,7 +467,7 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
                 Pop-Location
             }
 
-            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $script:testRoot -ChildPath 'test_file.txt') | Should-Be $true
         }
 
         It 'Should honor Recurse when Path is not specified' {
@@ -486,13 +486,13 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
                 Pop-Location
             }
 
-            Test-Path (Join-Path -Path $subDir -ChildPath 'test_file.txt') | Should -Be $true
+            Test-Path (Join-Path -Path $subDir -ChildPath 'test_file.txt') | Should-Be $true
         }
     }
 
     Context 'Error Handling' {
         It 'Should handle non-existent file gracefully' {
-            { Rename-File -Path 'C:\NonExistent\File.txt' -ToUpper -ErrorAction Stop } | Should -Throw
+            { Rename-File -Path 'C:\NonExistent\File.txt' -ToUpper -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should skip directories when not using Recurse' {
@@ -516,11 +516,11 @@ Describe 'Rename-File Unit Tests' -Tag 'Unit', 'Utilities' {
 
         It 'Should not rename file when WhatIf is specified' {
             Rename-File -LiteralPath $script:testFile -ToUpper -WhatIf
-            Test-Path $script:testFile | Should -Be $true
+            Test-Path $script:testFile | Should-Be $true
             # On case-insensitive file systems, TEST.TXT and test.txt are the same file
             # Verify the actual file name hasn't changed by checking the FileInfo object
             $actualFile = Get-Item -LiteralPath $script:testFile
-            $actualFile.Name | Should -Be 'test.txt'
+            $actualFile.Name | Should-Be 'test.txt'
         }
     }
 }

--- a/Tests/Unit/Utilities/Replace-StringInFile.Tests.ps1
+++ b/Tests/Unit/Utilities/Replace-StringInFile.Tests.ps1
@@ -24,15 +24,15 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
     Context 'Parameter Validation' {
         It 'Should have mandatory Path parameter' {
-            (Get-Command Replace-StringInFile).Parameters['Path'].Attributes.Mandatory | Should -Contain $true
+            (Get-Command Replace-StringInFile).Parameters['Path'].Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should have mandatory OldString parameter' {
-            (Get-Command Replace-StringInFile).Parameters['OldString'].Attributes.Mandatory | Should -Contain $true
+            (Get-Command Replace-StringInFile).Parameters['OldString'].Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should have mandatory NewString parameter' {
-            (Get-Command Replace-StringInFile).Parameters['NewString'].Attributes.Mandatory | Should -Contain $true
+            (Get-Command Replace-StringInFile).Parameters['NewString'].Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should accept valid encoding values' {
@@ -55,9 +55,9 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'World' -NewString 'PowerShell'
 
-            $result.MatchCount | Should -Be 1
-            $result.ReplacementsMade | Should -Be $true
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Hello PowerShell'
+            $result.MatchCount | Should-Be 1
+            $result.ReplacementsMade | Should-Be $true
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Hello PowerShell'
         }
 
         It 'Should replace multiple occurrences' {
@@ -66,9 +66,9 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'foo' -NewString 'test'
 
-            $result.MatchCount | Should -Be 3
-            $result.ReplacementsMade | Should -Be $true
-            (Get-Content -Path $testFile -Raw) | Should -Be 'test bar test baz test'
+            $result.MatchCount | Should-Be 3
+            $result.ReplacementsMade | Should-Be $true
+            (Get-Content -Path $testFile -Raw) | Should-Be 'test bar test baz test'
         }
 
         It 'Should handle empty replacement string' {
@@ -77,8 +77,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'World' -NewString ''
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Hello !'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Hello !'
         }
 
         It 'Should return zero matches when string not found' {
@@ -87,8 +87,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'xyz' -NewString 'abc'
 
-            $result.MatchCount | Should -Be 0
-            $result.ReplacementsMade | Should -Be $false
+            $result.MatchCount | Should-Be 0
+            $result.ReplacementsMade | Should-Be $false
         }
 
         It 'Should be case-sensitive by default' {
@@ -97,8 +97,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'hi'
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Hello hi HELLO'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Hello hi HELLO'
         }
     }
 
@@ -109,8 +109,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'hi' -CaseInsensitive
 
-            $result.MatchCount | Should -Be 3
-            (Get-Content -Path $testFile -Raw) | Should -Be 'hi hi hi'
+            $result.MatchCount | Should-Be 3
+            (Get-Content -Path $testFile -Raw) | Should-Be 'hi hi hi'
         }
     }
 
@@ -121,8 +121,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString '\d{3}-\d{3}-\d{4}' -NewString 'XXX-XXX-XXXX' -Regex
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Phone: XXX-XXX-XXXX'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Phone: XXX-XXX-XXXX'
         }
 
         It 'Should support regex capture groups' {
@@ -131,8 +131,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString '(\d{4})-(\d{2})-(\d{2})' -NewString '$3/$2/$1' -Regex
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Date: 14/11/2024'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Date: 14/11/2024'
         }
 
         It 'Should handle complex regex patterns' {
@@ -141,8 +141,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString '\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b' -NewString 'REDACTED' -Regex
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Contact: REDACTED for help'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Contact: REDACTED for help'
         }
     }
 
@@ -153,8 +153,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString '$100.00' -NewString '$200.00'
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Price: $200.00'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Price: $200.00'
         }
 
         It 'Should handle parentheses and brackets literally' {
@@ -163,8 +163,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString '[0]' -NewString '[1]'
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Be 'Array[1] = (value)'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-Be 'Array[1] = (value)'
         }
     }
 
@@ -175,10 +175,10 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'original' -NewString 'modified' -Backup
 
-            $result.BackupCreated | Should -Be $true
-            Test-Path "$testFile.bak" | Should -Be $true
-            (Get-Content -Path "$testFile.bak" -Raw) | Should -Be 'original content'
-            (Get-Content -Path $testFile -Raw) | Should -Be 'modified content'
+            $result.BackupCreated | Should-Be $true
+            Test-Path "$testFile.bak" | Should-Be $true
+            (Get-Content -Path "$testFile.bak" -Raw) | Should-Be 'original content'
+            (Get-Content -Path $testFile -Raw) | Should-Be 'modified content'
         }
 
         It 'Should not create backup by default' {
@@ -187,8 +187,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'content' -NewString 'new'
 
-            $result.BackupCreated | Should -Be $false
-            Test-Path "$testFile.bak" | Should -Be $false
+            $result.BackupCreated | Should-Be $false
+            Test-Path "$testFile.bak" | Should-Be $false
         }
     }
 
@@ -201,10 +201,10 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $results = Replace-StringInFile -Path $file1, $file2 -OldString 'bar' -NewString 'test'
 
-            $results.Count | Should -Be 2
-            ($results | Where-Object { $_.ReplacementsMade }).Count | Should -Be 2
-            (Get-Content -Path $file1 -Raw) | Should -Be 'foo test'
-            (Get-Content -Path $file2 -Raw) | Should -Be 'test baz'
+            $results.Count | Should-Be 2
+            ($results | Where-Object { $_.ReplacementsMade }).Count | Should-Be 2
+            (Get-Content -Path $file1 -Raw) | Should-Be 'foo test'
+            (Get-Content -Path $file2 -Raw) | Should-Be 'test baz'
         }
 
         It 'Should handle wildcards in path' {
@@ -218,10 +218,10 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
             $pattern = Join-Path -Path $script:testDir -ChildPath '*.txt'
             $results = Replace-StringInFile -Path $pattern -OldString 'foo' -NewString 'bar'
 
-            $results.Count | Should -Be 2
-            (Get-Content -Path $file1 -Raw) | Should -Be 'bar'
-            (Get-Content -Path $file2 -Raw) | Should -Be 'bar'
-            (Get-Content -Path $file3 -Raw) | Should -Be 'foo'
+            $results.Count | Should-Be 2
+            (Get-Content -Path $file1 -Raw) | Should-Be 'bar'
+            (Get-Content -Path $file2 -Raw) | Should-Be 'bar'
+            (Get-Content -Path $file3 -Raw) | Should-Be 'foo'
         }
     }
 
@@ -232,7 +232,7 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             Replace-StringInFile -Path $testFile -OldString 'original' -NewString 'modified' -WhatIf
 
-            (Get-Content -Path $testFile -Raw) | Should -Be 'original'
+            (Get-Content -Path $testFile -Raw) | Should-Be 'original'
         }
     }
 
@@ -243,8 +243,8 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'new' -Encoding UTF8
 
-            $result.ReplacementsMade | Should -Be $true
-            (Get-Content -Path $testFile -Raw) | Should -Be 'new'
+            $result.ReplacementsMade | Should-Be $true
+            (Get-Content -Path $testFile -Raw) | Should-Be 'new'
         }
     }
 
@@ -256,7 +256,7 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $null = Replace-StringInFile -Path $binaryFile -OldString 'test' -NewString 'new' -WarningVariable warnings -WarningAction SilentlyContinue
 
-            $warnings | Should -Match 'binary'
+            $warnings | Should-MatchString 'binary'
         }
     }
 
@@ -271,8 +271,8 @@ Line 3
 
             $result = Replace-StringInFile -Path $testFile -OldString 'Line 2' -NewString 'Modified Line'
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Match 'Modified Line'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-MatchString 'Modified Line'
         }
 
         It 'Should handle empty files' {
@@ -281,8 +281,8 @@ Line 3
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'new'
 
-            $result.MatchCount | Should -Be 0
-            $result.ReplacementsMade | Should -Be $false
+            $result.MatchCount | Should-Be 0
+            $result.ReplacementsMade | Should-Be $false
         }
 
         It 'Should handle very long lines' {
@@ -292,8 +292,8 @@ Line 3
 
             $result = Replace-StringInFile -Path $testFile -OldString 'REPLACE' -NewString 'DONE'
 
-            $result.MatchCount | Should -Be 1
-            (Get-Content -Path $testFile -Raw) | Should -Match 'DONE'
+            $result.MatchCount | Should-Be 1
+            (Get-Content -Path $testFile -Raw) | Should-MatchString 'DONE'
         }
     }
 
@@ -301,7 +301,7 @@ Line 3
         It 'Should handle non-existent files gracefully' {
             $nonExistent = Join-Path -Path $script:testDir -ChildPath 'doesnotexist.txt'
 
-            { Replace-StringInFile -Path $nonExistent -OldString 'test' -NewString 'new' -ErrorAction Stop } | Should -Throw
+            { Replace-StringInFile -Path $nonExistent -OldString 'test' -NewString 'new' -ErrorAction Stop } | Should-Throw
         }
 
         It 'Should skip directories' {
@@ -317,7 +317,7 @@ Line 3
             $testFile = Join-Path -Path $script:testDir -ChildPath 'invalidregex.txt'
             'test' | Set-Content -Path $testFile -NoNewline
 
-            { Replace-StringInFile -Path $testFile -OldString '(' -NewString 'new' -Regex -ErrorAction Stop } | Should -Throw
+            { Replace-StringInFile -Path $testFile -OldString '(' -NewString 'new' -Regex -ErrorAction Stop } | Should-Throw
         }
     }
 
@@ -329,11 +329,11 @@ Line 3
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'new'
 
             $result | Should -Not -BeNullOrEmpty
-            $result.PSObject.Properties.Name | Should -Contain 'FilePath'
-            $result.PSObject.Properties.Name | Should -Contain 'MatchCount'
-            $result.PSObject.Properties.Name | Should -Contain 'ReplacementsMade'
-            $result.PSObject.Properties.Name | Should -Contain 'BackupCreated'
-            $result.PSObject.Properties.Name | Should -Contain 'Error'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'FilePath'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'MatchCount'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'ReplacementsMade'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'BackupCreated'
+            $result.PSObject.Properties.Name | Should-ContainCollection 'Error'
         }
 
         # Skip on Linux when running as root because root can write to read-only files
@@ -379,10 +379,10 @@ Line 3
 
             $result = Replace-StringInFile -Path $testFile -OldString 'target' -NewString 'value'
 
-            $result.MatchCount | Should -Be 1
-            $result.Matches[0].Line | Should -Be 2
-            $result.Matches[0].Column | Should -Be 7
-            $result.Matches[0].LineContent | Should -Be 'alpha target'
+            $result.MatchCount | Should-Be 1
+            $result.Matches[0].Line | Should-Be 2
+            $result.Matches[0].Column | Should-Be 7
+            $result.Matches[0].LineContent | Should-Be 'alpha target'
         }
 
         It 'Should compute line and column accurately for mixed newline styles' {
@@ -392,10 +392,10 @@ Line 3
 
             $result = Replace-StringInFile -Path $testFile -OldString 'match' -NewString 'done'
 
-            $result.MatchCount | Should -Be 1
-            $result.Matches[0].Line | Should -Be 2
-            $result.Matches[0].Column | Should -Be 5
-            $result.Matches[0].LineContent | Should -Be 'two match'
+            $result.MatchCount | Should-Be 1
+            $result.Matches[0].Line | Should-Be 2
+            $result.Matches[0].Column | Should-Be 5
+            $result.Matches[0].LineContent | Should-Be 'two match'
         }
     }
 
@@ -418,7 +418,7 @@ Line 3
 
             {
                 Replace-StringInFile -Path $testFile -OldString 'foo' -NewString 'bar' -Regex -PreserveCase -CaseInsensitive -ErrorAction Stop
-            } | Should -Throw -ExpectedMessage 'PreserveCase cannot be used with Regex mode'
+            } | Should-Throw -ExceptionMessage 'PreserveCase cannot be used with Regex mode'
         }
 
         It 'Should throw when PreserveCase is used without CaseInsensitive' {
@@ -427,7 +427,7 @@ Line 3
 
             {
                 Replace-StringInFile -Path $testFile -OldString 'foo' -NewString 'bar' -PreserveCase -ErrorAction Stop
-            } | Should -Throw -ExpectedMessage 'PreserveCase requires CaseInsensitive to be enabled'
+            } | Should-Throw -ExceptionMessage 'PreserveCase requires CaseInsensitive to be enabled'
         }
 
         It 'Should accept valid parameter combinations' {
@@ -448,9 +448,9 @@ Line 3
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'GOODBYE world'
-            $result.ReplacementsMade | Should -Be $true
-            $result.MatchCount | Should -Be 1
+            $content | Should-Be 'GOODBYE world'
+            $result.ReplacementsMade | Should-Be $true
+            $result.MatchCount | Should-Be 1
         }
 
         It 'Should preserve all lowercase case' {
@@ -460,8 +460,8 @@ Line 3
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'GOODBYE' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'goodbye WORLD'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'goodbye WORLD'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve First Capital case' {
@@ -471,8 +471,8 @@ Line 3
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'Goodbye world'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'Goodbye world'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve Title Case for multi-word strings' {
@@ -482,8 +482,8 @@ Line 3
             $result = Replace-StringInFile -Path $testFile -OldString 'hello world' -NewString 'goodbye universe' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'Goodbye Universe from everyone'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'Goodbye Universe from everyone'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should handle multiple matches with different cases' {
@@ -497,11 +497,11 @@ Foo is everywhere
             $result = Replace-StringInFile -Path $testFile -OldString 'foo' -NewString 'bar' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Match 'bar is here'
-            $content | Should -Match 'BAR is there'
-            $content | Should -Match 'Bar is everywhere'
-            $result.MatchCount | Should -Be 3
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-MatchString 'bar is here'
+            $content | Should-MatchString 'BAR is there'
+            $content | Should-MatchString 'Bar is everywhere'
+            $result.MatchCount | Should-Be 3
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should handle mixed case by using replacement as-is' {
@@ -512,8 +512,8 @@ Foo is everywhere
 
             $content = Get-Content -Path $testFile -Raw
             # Mixed case that doesn't match a clear pattern uses replacement as-is
-            $content | Should -Be 'goodbye world'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'goodbye world'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should work with single character replacements' {
@@ -523,8 +523,8 @@ Foo is everywhere
             $result = Replace-StringInFile -Path $testFile -OldString 'a' -NewString 'x' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'X B C x b c'
-            $result.MatchCount | Should -Be 2
+            $content | Should-Be 'X B C x b c'
+            $result.MatchCount | Should-Be 2
         }
 
         It 'Should preserve case with underscores and special characters' {
@@ -534,8 +534,8 @@ Foo is everywhere
             $result = Replace-StringInFile -Path $testFile -OldString 'old_name' -NewString 'better_name' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'BETTER_NAME new_name'
-            $result.MatchCount | Should -Be 1
+            $content | Should-Be 'BETTER_NAME new_name'
+            $result.MatchCount | Should-Be 1
         }
 
         It 'Should handle empty lines without errors' {
@@ -549,9 +549,9 @@ hello
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Match 'GOODBYE'
-            $content | Should -Match "`n`ngoodbye"
-            $result.MatchCount | Should -Be 2
+            $content | Should-MatchString 'GOODBYE'
+            $content | Should-MatchString "`n`ngoodbye"
+            $result.MatchCount | Should-Be 2
         }
 
         It 'Should not modify content when no matches found' {
@@ -562,9 +562,9 @@ hello
             $result = Replace-StringInFile -Path $testFile -OldString 'foo' -NewString 'bar' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be $originalContent
-            $result.MatchCount | Should -Be 0
-            $result.ReplacementsMade | Should -Be $false
+            $content | Should-Be $originalContent
+            $result.MatchCount | Should-Be 0
+            $result.ReplacementsMade | Should-Be $false
         }
 
         It 'Should preserve camelCase pattern' {
@@ -574,8 +574,8 @@ hello
             $result = Replace-StringInFile -Path $testFile -OldString 'username' -NewString 'account id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'accountId is required'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'accountId is required'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve PascalCase pattern' {
@@ -585,8 +585,8 @@ hello
             $result = Replace-StringInFile -Path $testFile -OldString 'username' -NewString 'account id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'AccountId is required'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'AccountId is required'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve camelCase with multi-word replacement' {
@@ -596,8 +596,8 @@ hello
             $result = Replace-StringInFile -Path $testFile -OldString 'oldusername' -NewString 'new account id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'newAccountId'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'newAccountId'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve PascalCase with multi-word replacement' {
@@ -607,8 +607,8 @@ hello
             $result = Replace-StringInFile -Path $testFile -OldString 'oldusername' -NewString 'new account id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'NewAccountId'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'NewAccountId'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should handle multiple camelCase/PascalCase variations' {
@@ -622,10 +622,10 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'username' -NewString 'account id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Match 'accountId'
-            $content | Should -Match 'AccountId'
-            $content | Should -Match 'ACCOUNT ID'  # ALL CAPS preserves spaces
-            $result.MatchCount | Should -Be 3
+            $content | Should-MatchString 'accountId'
+            $content | Should-MatchString 'AccountId'
+            $content | Should-MatchString 'ACCOUNT ID'  # ALL CAPS preserves spaces
+            $result.MatchCount | Should-Be 3
         }
 
         It 'Should preserve snake_case pattern' {
@@ -635,8 +635,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'user_name' -NewString 'account_id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'account_id is required'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'account_id is required'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve SCREAMING_SNAKE_CASE pattern' {
@@ -646,8 +646,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'user_name' -NewString 'account_id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'ACCOUNT_ID is required'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'ACCOUNT_ID is required'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve kebab-case pattern' {
@@ -657,8 +657,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'user-name' -NewString 'account-id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'account-id is required'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'account-id is required'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should preserve SCREAMING-KEBAB-CASE pattern' {
@@ -668,8 +668,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'user-name' -NewString 'account-id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'ACCOUNT-ID is required'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'ACCOUNT-ID is required'
+            $result.ReplacementsMade | Should-Be $true
         }
 
         It 'Should replace cross-separator variations with PreserveCase (camelCase to snake_case)' {
@@ -679,8 +679,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'userName' -NewString 'accountId' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'accountId is the account_id'
-            $result.MatchCount | Should -Be 2
+            $content | Should-Be 'accountId is the account_id'
+            $result.MatchCount | Should-Be 2
         }
 
         It 'Should replace cross-separator variations with PreserveCase (PascalCase to SCREAMING_SNAKE_CASE)' {
@@ -690,8 +690,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'userName' -NewString 'accountId' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'AccountId is the ACCOUNT_ID'
-            $result.MatchCount | Should -Be 2
+            $content | Should-Be 'AccountId is the ACCOUNT_ID'
+            $result.MatchCount | Should-Be 2
         }
 
         It 'Should replace cross-separator variations with PreserveCase (kebab-case to snake_case)' {
@@ -701,8 +701,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'userName' -NewString 'accountId' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'account-id and account_id'
-            $result.MatchCount | Should -Be 2
+            $content | Should-Be 'account-id and account_id'
+            $result.MatchCount | Should-Be 2
         }
 
         It 'Should replace all separator variations when using separator-aware matching' {
@@ -720,14 +720,14 @@ USER-NAME
             $result = Replace-StringInFile -Path $testFile -OldString 'userName' -NewString 'accountId' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Match 'accountId'
-            $content | Should -Match 'AccountId'
-            $content | Should -Match 'ACCOUNTID'
-            $content | Should -Match 'account_id'
-            $content | Should -Match 'ACCOUNT_ID'
-            $content | Should -Match 'account-id'
-            $content | Should -Match 'ACCOUNT-ID'
-            $result.MatchCount | Should -Be 7
+            $content | Should-MatchString 'accountId'
+            $content | Should-MatchString 'AccountId'
+            $content | Should-MatchString 'ACCOUNTID'
+            $content | Should-MatchString 'account_id'
+            $content | Should-MatchString 'ACCOUNT_ID'
+            $content | Should-MatchString 'account-id'
+            $content | Should-MatchString 'ACCOUNT-ID'
+            $result.MatchCount | Should-Be 7
         }
 
         It 'Should not perform cross-separator matching when pattern has no word boundaries' {
@@ -738,8 +738,8 @@ USER-NAME
 
             $content = Get-Content -Path $testFile -Raw
             # 'username' (all lowercase) has no word boundaries, so it should NOT match 'user_name'
-            $content | Should -Be 'accountid and user_name'
-            $result.MatchCount | Should -Be 1
+            $content | Should-Be 'accountid and user_name'
+            $result.MatchCount | Should-Be 1
         }
 
         It 'Should handle mixed case patterns in same file' {
@@ -753,10 +753,10 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'username' -NewString 'account id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Match 'accountId'
-            $content | Should -Match 'AccountId'
-            $content | Should -Match 'ACCOUNT ID'
-            $result.MatchCount | Should -Be 3
+            $content | Should-MatchString 'accountId'
+            $content | Should-MatchString 'AccountId'
+            $content | Should-MatchString 'ACCOUNT ID'
+            $result.MatchCount | Should-Be 3
         }
 
         It 'Should convert between different separator styles' {
@@ -767,8 +767,8 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'user_name' -NewString 'account-id' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'account_id'  # Preserves snake_case pattern
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'account_id'  # Preserves snake_case pattern
+            $result.ReplacementsMade | Should-Be $true
         }
     }
 
@@ -779,11 +779,11 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase -Backup
 
-            $result.BackupCreated | Should -Be $true
-            Test-Path -Path "$testFile.bak" | Should -Be $true
+            $result.BackupCreated | Should-Be $true
+            Test-Path -Path "$testFile.bak" | Should-Be $true
 
             $backupContent = Get-Content -Path "$testFile.bak" -Raw
-            $backupContent | Should -Be 'HELLO world'
+            $backupContent | Should-Be 'HELLO world'
         }
 
         It 'Should support WhatIf with PreserveCase' {
@@ -793,9 +793,9 @@ USERNAME
             $result = Replace-StringInFile -Path $testFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase -WhatIf
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'HELLO world'  # Should not be modified
-            $result.ReplacementsMade | Should -Be $false
-            $result.MatchCount | Should -Be 1  # Should still report matches found
+            $content | Should-Be 'HELLO world'  # Should not be modified
+            $result.ReplacementsMade | Should-Be $false
+            $result.MatchCount | Should-Be 1  # Should still report matches found
         }
 
         It 'Should work with pipeline input' {
@@ -805,8 +805,8 @@ USERNAME
             $result = Get-Item -Path $testFile | Replace-StringInFile -OldString 'hello' -NewString 'goodbye' -CaseInsensitive -PreserveCase
 
             $content = Get-Content -Path $testFile -Raw
-            $content | Should -Be 'GOODBYE world'
-            $result.ReplacementsMade | Should -Be $true
+            $content | Should-Be 'GOODBYE world'
+            $result.ReplacementsMade | Should-Be $true
         }
     }
 
@@ -819,11 +819,11 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # First byte should NOT be BOM (0xEF)
-            $bytes[0] | Should -Not -Be 0xEF
-            (Get-Content -Path $testFile -Raw) | Should -Be 'This is a sample file'
+            $bytes[0] | Should-NotBe 0xEF
+            (Get-Content -Path $testFile -Raw) | Should-Be 'This is a sample file'
         }
 
         It 'Should auto-detect and preserve UTF-8 with BOM' {
@@ -834,12 +834,12 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # Should have UTF-8 BOM (EF BB BF)
-            $bytes[0] | Should -Be 0xEF
-            $bytes[1] | Should -Be 0xBB
-            $bytes[2] | Should -Be 0xBF
+            $bytes[0] | Should-Be 0xEF
+            $bytes[1] | Should-Be 0xBB
+            $bytes[2] | Should-Be 0xBF
         }
 
         It 'Should auto-detect and preserve UTF-16 LE encoding' {
@@ -850,13 +850,13 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # Should have UTF-16 LE BOM (FF FE)
-            $bytes[0] | Should -Be 0xFF
-            $bytes[1] | Should -Be 0xFE
+            $bytes[0] | Should-Be 0xFF
+            $bytes[1] | Should-Be 0xFE
             # Verify it's not UTF-32 LE (which also starts with FF FE)
-            $bytes[2] | Should -Not -Be 0x00
+            $bytes[2] | Should-NotBe 0x00
         }
 
         It 'Should auto-detect and preserve UTF-16 BE encoding' {
@@ -867,11 +867,11 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # Should have UTF-16 BE BOM (FE FF)
-            $bytes[0] | Should -Be 0xFE
-            $bytes[1] | Should -Be 0xFF
+            $bytes[0] | Should-Be 0xFE
+            $bytes[1] | Should-Be 0xFF
         }
 
         It 'Should auto-detect and preserve UTF-32 LE encoding' {
@@ -882,13 +882,13 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # Should have UTF-32 LE BOM (FF FE 00 00)
-            $bytes[0] | Should -Be 0xFF
-            $bytes[1] | Should -Be 0xFE
-            $bytes[2] | Should -Be 0x00
-            $bytes[3] | Should -Be 0x00
+            $bytes[0] | Should-Be 0xFF
+            $bytes[1] | Should-Be 0xFE
+            $bytes[2] | Should-Be 0x00
+            $bytes[3] | Should-Be 0x00
         }
 
         It 'Should auto-detect and preserve UTF-32 BE encoding' {
@@ -899,13 +899,13 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # Should have UTF-32 BE BOM (00 00 FE FF)
-            $bytes[0] | Should -Be 0x00
-            $bytes[1] | Should -Be 0x00
-            $bytes[2] | Should -Be 0xFE
-            $bytes[3] | Should -Be 0xFF
+            $bytes[0] | Should-Be 0x00
+            $bytes[1] | Should-Be 0x00
+            $bytes[2] | Should-Be 0xFE
+            $bytes[3] | Should-Be 0xFF
         }
 
         It 'Should auto-detect and preserve ASCII encoding' {
@@ -916,11 +916,11 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             # Read back and verify all bytes are within ASCII range (0-127)
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             $nonAsciiBytes = $bytes | Where-Object { $_ -gt 127 }
-            $nonAsciiBytes.Count | Should -Be 0
+            $nonAsciiBytes.Count | Should-Be 0
         }
 
         It 'Should convert to UTF-8 with BOM when explicitly specified' {
@@ -931,16 +931,16 @@ USERNAME
 
             # Verify no BOM before conversion
             $beforeBytes = [System.IO.File]::ReadAllBytes($testFile)
-            $beforeBytes[0] | Should -Not -Be 0xEF
+            $beforeBytes[0] | Should-NotBe 0xEF
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample' -Encoding UTF8BOM
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # Should now have UTF-8 BOM (EF BB BF)
-            $bytes[0] | Should -Be 0xEF
-            $bytes[1] | Should -Be 0xBB
-            $bytes[2] | Should -Be 0xBF
+            $bytes[0] | Should-Be 0xEF
+            $bytes[1] | Should-Be 0xBB
+            $bytes[2] | Should-Be 0xBF
         }
 
         It 'Should convert to UTF-16 LE when explicitly specified' {
@@ -951,11 +951,11 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample' -Encoding UTF16LE
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
             # Should have UTF-16 LE BOM (FF FE)
-            $bytes[0] | Should -Be 0xFF
-            $bytes[1] | Should -Be 0xFE
+            $bytes[0] | Should-Be 0xFF
+            $bytes[1] | Should-Be 0xFE
         }
 
         It 'Should handle empty files with Auto encoding' {
@@ -964,8 +964,8 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'test' -NewString 'sample'
 
-            $result.MatchCount | Should -Be 0
-            $result.ReplacementsMade | Should -Be $false
+            $result.MatchCount | Should-Be 0
+            $result.ReplacementsMade | Should-Be $false
         }
 
         It 'Should not modify UTF-16 LE files binary detection' {
@@ -977,9 +977,9 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'Test' -NewString 'Sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $newContent = [System.IO.File]::ReadAllText($testFile, $utf16LE)
-            $newContent | Should -Match 'Sample'
+            $newContent | Should-MatchString 'Sample'
         }
 
         It 'Should not modify UTF-32 files binary detection' {
@@ -991,9 +991,9 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'Test' -NewString 'Sample'
 
-            $result.ReplacementsMade | Should -Be $true
+            $result.ReplacementsMade | Should-Be $true
             $newContent = [System.IO.File]::ReadAllText($testFile, $utf32LE)
-            $newContent | Should -Match 'Sample'
+            $newContent | Should-MatchString 'Sample'
         }
 
         It 'Should preserve encoding when no matches found' {
@@ -1004,12 +1004,12 @@ USERNAME
 
             $result = Replace-StringInFile -Path $testFile -OldString 'xyz' -NewString 'abc'
 
-            $result.MatchCount | Should -Be 0
+            $result.MatchCount | Should-Be 0
             # BOM should still be present (file should be unchanged)
             $bytes = [System.IO.File]::ReadAllBytes($testFile)
-            $bytes[0] | Should -Be 0xEF
-            $bytes[1] | Should -Be 0xBB
-            $bytes[2] | Should -Be 0xBF
+            $bytes[0] | Should-Be 0xEF
+            $bytes[1] | Should-Be 0xBB
+            $bytes[2] | Should-Be 0xBF
         }
 
         It 'Should work with multiple files having different encodings' {
@@ -1026,18 +1026,18 @@ USERNAME
             # Process both files
             $results = Replace-StringInFile -Path $file1, $file2 -OldString 'test' -NewString 'sample'
 
-            $results.Count | Should -Be 2
-            $results[0].ReplacementsMade | Should -Be $true
-            $results[1].ReplacementsMade | Should -Be $true
+            $results.Count | Should-Be 2
+            $results[0].ReplacementsMade | Should-Be $true
+            $results[1].ReplacementsMade | Should-Be $true
 
             # Verify each file preserved its encoding
             $bytes1 = [System.IO.File]::ReadAllBytes($file1)
-            $bytes1[0] | Should -Not -Be 0xEF  # No BOM
+            $bytes1[0] | Should-NotBe 0xEF  # No BOM
 
             $bytes2 = [System.IO.File]::ReadAllBytes($file2)
-            $bytes2[0] | Should -Be 0xEF  # Has BOM
-            $bytes2[1] | Should -Be 0xBB
-            $bytes2[2] | Should -Be 0xBF
+            $bytes2[0] | Should-Be 0xEF  # Has BOM
+            $bytes2[1] | Should-Be 0xBB
+            $bytes2[2] | Should-Be 0xBF
         }
     }
 }

--- a/Tests/Unit/Utilities/Replace-StringInFile.Tests.ps1
+++ b/Tests/Unit/Utilities/Replace-StringInFile.Tests.ps1
@@ -256,7 +256,7 @@ Describe 'Replace-StringInFile' -Tag 'Unit' {
 
             $null = Replace-StringInFile -Path $binaryFile -OldString 'test' -NewString 'new' -WarningVariable warnings -WarningAction SilentlyContinue
 
-            $warnings | Should-MatchString 'binary'
+            ($warnings | Out-String) | Should-MatchString 'binary'
         }
     }
 

--- a/Tests/Unit/Utilities/Search-DelimitedFile.Tests.ps1
+++ b/Tests/Unit/Utilities/Search-DelimitedFile.Tests.ps1
@@ -43,76 +43,76 @@ Describe 'Search-DelimitedFile' {
         It 'Declares Criteria as mandatory and Path as optional' {
             $command = Get-Command -Name Search-DelimitedFile
 
-            $command.Parameters.Path.Attributes.Mandatory | Should -Not -Contain $true
-            $command.Parameters.Criteria.Attributes.Mandatory | Should -Contain $true
+            $command.Parameters.Path.Attributes.Mandatory | Should-NotContainCollection $true
+            $command.Parameters.Criteria.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Accepts Path from the pipeline and by property name' {
             $pathParameter = (Get-Command -Name Search-DelimitedFile).Parameters.Path
 
-            $pathParameter.Attributes.ValueFromPipeline | Should -Contain $true
-            $pathParameter.Attributes.ValueFromPipelineByPropertyName | Should -Contain $true
-            $pathParameter.Aliases | Should -Contain 'FullName'
+            $pathParameter.Attributes.ValueFromPipeline | Should-ContainCollection $true
+            $pathParameter.Attributes.ValueFromPipelineByPropertyName | Should-ContainCollection $true
+            $pathParameter.Aliases | Should-ContainCollection 'FullName'
         }
 
         It 'Declares object output' {
-            (Get-Command -Name Search-DelimitedFile).OutputType.Name | Should -Contain 'System.Management.Automation.PSObject'
+            (Get-Command -Name Search-DelimitedFile).OutputType.Name | Should-ContainCollection 'System.Management.Automation.PSObject'
         }
 
         It 'exposes recursive directory search and multiple filters' {
             $command = Get-Command -Name Search-DelimitedFile
 
-            $command.Parameters.ContainsKey('Recurse') | Should -BeTrue
-            $command.Parameters.Filter.ParameterType | Should -Be ([String[]])
+            $command.Parameters.ContainsKey('Recurse') | Should-BeTruthy
+            $command.Parameters.Filter.ParameterType | Should-Be ([String[]])
             $command.Parameters.Filter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateNotNullOrEmptyAttribute] } | Should -Not -BeNullOrEmpty
         }
 
         It 'documents generated names for duplicate headers in command examples' {
             $examples = Get-Help -Name Search-DelimitedFile -Examples | Out-String
 
-            $examples | Should -Match 'duplicate-headers\.tsv'
-            $examples | Should -Match 'File1'
-            $examples | Should -Match 'File2'
+            $examples | Should-MatchString 'duplicate-headers\.tsv'
+            $examples | Should-MatchString 'File1'
+            $examples | Should-MatchString 'File2'
         }
 
         It 'exposes OutputPath as a string parameter' {
             $command = Get-Command -Name Search-DelimitedFile
             $outputParameter = $command.Parameters.OutputPath
 
-            $command.Parameters.ContainsKey('OutputPath') | Should -BeTrue
-            $outputParameter.ParameterType | Should -Be ([String])
+            $command.Parameters.ContainsKey('OutputPath') | Should-BeTruthy
+            $outputParameter.ParameterType | Should-Be ([String])
         }
 
         It 'exposes OutputFileNameSuffix as a string parameter' {
             $outputFileNameSuffixParameter = (Get-Command -Name Search-DelimitedFile).Parameters.OutputFileNameSuffix
 
-            $outputFileNameSuffixParameter.ParameterType | Should -Be ([String])
+            $outputFileNameSuffixParameter.ParameterType | Should-Be ([String])
         }
 
         It 'exposes UseQuotes with CSV-style quote modes' {
             $useQuotesParameter = (Get-Command -Name Search-DelimitedFile).Parameters.UseQuotes
 
-            $useQuotesParameter.ParameterType | Should -Be ([String])
+            $useQuotesParameter.ParameterType | Should-Be ([String])
             $validateSet = $useQuotesParameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
-            $validateSet.ValidValues | Should -Be @('AsNeeded', 'Always', 'Never')
+            $validateSet.ValidValues | Should-BeCollection @('AsNeeded', 'Always', 'Never')
         }
 
         It 'exposes IncludeRowNumber as a switch parameter' {
             $rowNumberParameter = (Get-Command -Name Search-DelimitedFile).Parameters.IncludeRowNumber
 
-            $rowNumberParameter.ParameterType | Should -Be ([Switch])
+            $rowNumberParameter.ParameterType | Should-Be ([Switch])
         }
 
         It 'exposes OutputBySourceFile as a switch parameter' {
             $outputBySourceFileParameter = (Get-Command -Name Search-DelimitedFile).Parameters.OutputBySourceFile
 
-            $outputBySourceFileParameter.ParameterType | Should -Be ([Switch])
+            $outputBySourceFileParameter.ParameterType | Should-Be ([Switch])
         }
 
         It 'exposes NoEmptyOutputFiles as a switch parameter' {
             $noEmptyOutputFilesParameter = (Get-Command -Name Search-DelimitedFile).Parameters.NoEmptyOutputFiles
 
-            $noEmptyOutputFilesParameter.ParameterType | Should -Be ([Switch])
+            $noEmptyOutputFilesParameter.ParameterType | Should-Be ([Switch])
         }
     }
 
@@ -123,34 +123,34 @@ Describe 'Search-DelimitedFile' {
                     Status = '^Active$'
                 })
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Alice'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Alice'
         }
 
         It 'matches regular expressions case-insensitively by default' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^alice$' })
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Alice'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Alice'
         }
 
         It 'supports case-sensitive regular expressions' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^alice$' } -CaseSensitive)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
         }
 
         It 'treats patterns as literal substrings with Literal' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ Note = 'a+b' } -Literal)
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
         }
 
         It 'supports exact literal matching' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ Status = 'Active' } -Literal -Exact)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Alice'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Alice'
         }
 
         It 'supports alternative patterns for one column' {
@@ -158,9 +158,9 @@ Describe 'Search-DelimitedFile' {
                     Status = @('^Active$', '^Pending$')
                 })
 
-            $result.Count | Should -Be 2
-            $result.Name | Should -Contain 'Alice'
-            $result.Name | Should -Contain 'Bob'
+            $result.Count | Should-Be 2
+            $result.Name | Should-ContainCollection 'Alice'
+            $result.Name | Should-ContainCollection 'Bob'
         }
 
         It 'returns rows matching any criterion with Any' {
@@ -169,14 +169,14 @@ Describe 'Search-DelimitedFile' {
                     Status = '^Pending$'
                 } -Any)
 
-            $result.Count | Should -Be 3
+            $result.Count | Should-Be 3
         }
 
         It 'can address a headered file by zero-based column index' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ 1 = '^Seattle$'; 2 = '^Pending$' })
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Bob'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Bob'
         }
 
         It 'returns only searched columns in file order' {
@@ -186,8 +186,8 @@ Describe 'Search-DelimitedFile' {
             }
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria $criteria -MatchColumnsOnly)
 
-            $result.Count | Should -Be 1
-            @($result[0].PSObject.Properties.Name) | Should -Be @('City', 'Status')
+            $result.Count | Should-Be 1
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('City', 'Status')
         }
     }
 
@@ -197,8 +197,8 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $tsvPath -Criteria @{ Level = '^Error$'; Message = 'out$' })
 
-            $result.Count | Should -Be 1
-            $result[0].Id | Should -Be '1'
+            $result.Count | Should-Be 1
+            $result[0].Id | Should-Be '1'
         }
 
         It 'infers a tab delimiter for TSV files discovered by directory filter' {
@@ -208,9 +208,9 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $directory -Filter '*.tsv' -Criteria @{ Name = @('West') })
 
-            $result.Count | Should -Be 1
-            $result[0].Connection | Should -Be 'A'
-            $result[0].Name | Should -Be 'West'
+            $result.Count | Should-Be 1
+            $result[0].Connection | Should-Be 'A'
+            $result[0].Name | Should-Be 'West'
         }
 
         It 'infers a tab delimiter for .tab files' {
@@ -218,8 +218,8 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $tabPath -Criteria @{ Level = '^Error$'; Message = 'out$' })
 
-            $result.Count | Should -Be 1
-            $result[0].Id | Should -Be '1'
+            $result.Count | Should-Be 1
+            $result[0].Id | Should-Be '1'
         }
 
         It 'detects tab-delimited headers when delimiter inference would otherwise choose comma' {
@@ -227,9 +227,9 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ Name = @('West') })
 
-            $result.Count | Should -Be 1
-            $result[0].Connection | Should -Be 'A'
-            $result[0].Name | Should -Be 'West'
+            $result.Count | Should-Be 1
+            $result[0].Connection | Should-Be 'A'
+            $result[0].Name | Should-Be 'West'
         }
 
         It 'detects tab-delimited headers in TXT files discovered by wildcard path' {
@@ -240,16 +240,16 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $pathPattern -Criteria @{ Name = @('West') })
 
-            $result.Count | Should -Be 1
-            $result[0].Connection | Should -Be 'A'
-            $result[0].Name | Should -Be 'West'
+            $result.Count | Should-Be 1
+            $result[0].Connection | Should-Be 'A'
+            $result[0].Name | Should-Be 'West'
         }
 
         It 'honors an explicit comma delimiter even when the first record contains tabs' {
             $path = Initialize-DelimitedTestFile -Name 'explicit-comma.tsv' -Content "Connection`tName`tData`nA`tWest`t1"
 
             { Search-DelimitedFile -Path $path -Delimiter ',' -Criteria @{ Name = @('West') } -ErrorAction Stop } |
-            Should -Throw "*Available columns: Connection`tName`tData*"
+            Should-Throw "*Available columns: Connection`tName`tData*"
         }
 
         It 'preserves empty TSV fields from adjacent and trailing tabs' {
@@ -261,10 +261,10 @@ Describe 'Search-DelimitedFile' {
                     Note = '^$'
                 })
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Alice'
-            $result[0].Middle | Should -Be ''
-            $result[0].Note | Should -Be ''
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Alice'
+            $result[0].Middle | Should-Be ''
+            $result[0].Note | Should-Be ''
         }
 
         It 'preserves tabs inside quoted TSV fields' {
@@ -272,15 +272,15 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $tsvPath -Criteria @{ Note = "one`ttwo" } -Literal -Exact)
 
-            $result.Count | Should -Be 1
-            $result[0].Note | Should -Be "one`ttwo"
+            $result.Count | Should-Be 1
+            $result[0].Note | Should-Be "one`ttwo"
         }
 
         It 'validates criteria against header-only TSV files' {
             $tsvPath = Initialize-DelimitedTestFile -Name 'header-only.tsv' -Content "Name`tStatus"
 
             { Search-DelimitedFile -Path $tsvPath -Criteria @{ Missing = 'value' } -ErrorAction Stop } |
-            Should -Throw "*Column 'Missing' was not found*"
+            Should-Throw "*Column 'Missing' was not found*"
         }
 
         It 'supports an arbitrary delimiter character' {
@@ -288,8 +288,8 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $pipePath -Criteria @{ State = 'NY' } -Delimiter '|' -Literal -Exact)
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Alice'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Alice'
         }
 
         It 'generates zero-based names for a headerless file' {
@@ -299,9 +299,9 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ 0 = '^Alice\|A$'; 2 = '^NY$' } -Delimiter '|' -NoHeader)
 
-            $result.Count | Should -Be 1
-            @($result[0].PSObject.Properties.Name) | Should -Be @('Column0', 'Column1', 'Column2')
-            $result[0].Column0 | Should -Be 'Alice|A'
+            $result.Count | Should-Be 1
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('Column0', 'Column1', 'Column2')
+            $result[0].Column0 | Should-Be 'Alice|A'
         }
 
         It 'applies custom names to a headerless file' {
@@ -309,8 +309,8 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ Name = '^Alice$'; State = '^NY$' } -Delimiter ';' -Header Name, Age, State)
 
-            $result.Count | Should -Be 1
-            $result[0].Age | Should -Be '42'
+            $result.Count | Should-Be 1
+            $result[0].Age | Should-Be '42'
         }
 
         It 'preserves delimiters inside quoted fields' {
@@ -319,8 +319,8 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ Note = '^one,two$' })
 
-            $result.Count | Should -Be 1
-            $result[0].Note | Should -Be 'one,two'
+            $result.Count | Should-Be 1
+            $result[0].Note | Should-Be 'one,two'
         }
 
         It 'rejects blank TSV headers with index-search guidance' {
@@ -329,11 +329,11 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ Status = 'Active' } -Literal -ErrorAction SilentlyContinue -ErrorVariable searchErrors)
 
-            $result.Count | Should -Be 0
-            $searchErrors.Count | Should -Be 1
-            $searchErrors[0].ToString() | Should -Match 'empty column headers'
-            $searchErrors[0].ToString() | Should -Match 'zero-based indexes: 1'
-            $searchErrors[0].ToString() | Should -Match '\-NoHeader and integer Criteria keys'
+            $result.Count | Should-Be 0
+            $searchErrors.Count | Should-Be 1
+            $searchErrors[0].ToString() | Should-MatchString 'empty column headers'
+            $searchErrors[0].ToString() | Should-MatchString 'zero-based indexes: 1'
+            $searchErrors[0].ToString() | Should-MatchString '\-NoHeader and integer Criteria keys'
         }
 
         It 'suffixes duplicate file headers and searches by generated names' {
@@ -341,10 +341,10 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ File1 = 'Before'; File2 = 'After' } -Literal -Exact)
 
-            $result.Count | Should -Be 1
-            @($result[0].PSObject.Properties.Name) | Should -Be @('File1', 'Status', 'File2')
-            $result[0].File1 | Should -Be 'Before'
-            $result[0].File2 | Should -Be 'After'
+            $result.Count | Should-Be 1
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('File1', 'Status', 'File2')
+            $result[0].File1 | Should-Be 'Before'
+            $result[0].File2 | Should-Be 'After'
         }
 
         It 'avoids collisions between generated duplicate names and existing headers' {
@@ -352,11 +352,11 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ File2 = 'Before'; File3 = 'After' } -Literal -Exact)
 
-            $result.Count | Should -Be 1
-            @($result[0].PSObject.Properties.Name) | Should -Be @('File2', 'File1', 'File3')
-            $result[0].File1 | Should -Be 'Existing'
-            $result[0].File2 | Should -Be 'Before'
-            $result[0].File3 | Should -Be 'After'
+            $result.Count | Should-Be 1
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('File2', 'File1', 'File3')
+            $result[0].File1 | Should-Be 'Existing'
+            $result[0].File2 | Should-Be 'Before'
+            $result[0].File3 | Should-Be 'After'
         }
 
         It 'searches a duplicate-header file by index when NoHeader is used' {
@@ -364,9 +364,9 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ 0 = 'Alice'; 1 = 'Passed' } -NoHeader -Literal -Exact)
 
-            $result.Count | Should -Be 1
-            $result[0].Column0 | Should -Be 'Alice'
-            $result[0].Column2 | Should -Be 'Alias'
+            $result.Count | Should-Be 1
+            $result[0].Column0 | Should-Be 'Alice'
+            $result[0].Column2 | Should-Be 'Alias'
         }
     }
 
@@ -374,39 +374,39 @@ Describe 'Search-DelimitedFile' {
         It 'searches multiple path values' {
             $result = @(Search-DelimitedFile -Path $script:csvPath, $script:archivePath -Criteria @{ Status = '^Active$' })
 
-            $result.Count | Should -Be 2
-            $result.Name | Should -Contain 'Alice'
-            $result.Name | Should -Contain 'Dave'
+            $result.Count | Should-Be 2
+            $result.Name | Should-ContainCollection 'Alice'
+            $result.Name | Should-ContainCollection 'Dave'
         }
 
         It 'expands wildcard paths without returning duplicate files' {
             $pattern = Join-Path -Path $TestDrive -ChildPath 'people*.csv'
             $result = @(Search-DelimitedFile -Path $pattern, $script:csvPath -Criteria @{ Status = '^Active$' })
 
-            $result.Count | Should -Be 2
+            $result.Count | Should-Be 2
         }
 
         It 'accepts FileInfo objects from the pipeline' {
             $result = @(Get-Item -LiteralPath $script:archivePath | Search-DelimitedFile -Criteria @{ Status = '^Active$' })
 
-            $result.Count | Should -Be 1
-            $result[0].Name | Should -Be 'Dave'
+            $result.Count | Should-Be 1
+            $result[0].Name | Should-Be 'Dave'
         }
 
         It 'adds the source file name and absolute path on request' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -IncludeFileName -IncludeFilePath -MatchColumnsOnly)
 
-            @($result[0].PSObject.Properties.Name) | Should -Be @('FileName', 'FilePath', 'Name')
-            $result[0].FileName | Should -Be 'people.csv'
-            $result[0].FilePath | Should -Be $script:csvPath
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('FileName', 'FilePath', 'Name')
+            $result[0].FileName | Should-Be 'people.csv'
+            $result[0].FilePath | Should-Be $script:csvPath
         }
 
         It 'adds the one-based source row number on request' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ City = '^Boston$' } -IncludeRowNumber -MatchColumnsOnly)
 
-            $result.Count | Should -Be 2
-            @($result[0].PSObject.Properties.Name) | Should -Be @('RowNumber', 'City')
-            @($result.RowNumber) | Should -Be @(2, 4)
+            $result.Count | Should-Be 2
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('RowNumber', 'City')
+            @($result.RowNumber) | Should-BeCollection @(2, 4)
         }
 
         It 'starts row numbers at one for headerless files' {
@@ -414,9 +414,9 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ 1 = '^Active$' } -NoHeader -IncludeRowNumber -MatchColumnsOnly)
 
-            $result.Count | Should -Be 2
-            @($result[0].PSObject.Properties.Name) | Should -Be @('RowNumber', 'Column1')
-            @($result.RowNumber) | Should -Be @(1, 3)
+            $result.Count | Should-Be 2
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('RowNumber', 'Column1')
+            @($result.RowNumber) | Should-BeCollection @(1, 3)
         }
 
         It 'suffixes the row number metadata name when RowNumber already exists' {
@@ -424,10 +424,10 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ Value = '^one$' } -IncludeRowNumber)
 
-            $result.Count | Should -Be 1
-            @($result[0].PSObject.Properties.Name) | Should -Be @('RowNumber1', 'RowNumber', 'Value')
-            $result[0].RowNumber1 | Should -Be 2
-            $result[0].RowNumber | Should -Be '100'
+            $result.Count | Should-Be 1
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('RowNumber1', 'RowNumber', 'Value')
+            $result[0].RowNumber1 | Should-Be 2
+            $result[0].RowNumber | Should-Be '100'
         }
 
         It 'uses the next available row number metadata suffix' {
@@ -435,11 +435,11 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $path -Criteria @{ Value = '^one$' } -IncludeRowNumber)
 
-            $result.Count | Should -Be 1
-            @($result[0].PSObject.Properties.Name) | Should -Be @('RowNumber2', 'RowNumber', 'RowNumber1', 'Value')
-            $result[0].RowNumber2 | Should -Be 2
-            $result[0].RowNumber | Should -Be '100'
-            $result[0].RowNumber1 | Should -Be 'existing'
+            $result.Count | Should-Be 1
+            @($result[0].PSObject.Properties.Name) | Should-BeCollection @('RowNumber2', 'RowNumber', 'RowNumber1', 'Value')
+            $result[0].RowNumber2 | Should-Be 2
+            $result[0].RowNumber | Should-Be '100'
+            $result[0].RowNumber1 | Should-Be 'existing'
         }
 
         It 'searches a directory non-recursively using the default filters' {
@@ -453,9 +453,9 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $directory -Criteria @{ Status = '^Active$' } -IncludeFileName)
 
-            $result.FileName | Should -Contain 'people.csv'
-            $result.FileName | Should -Not -Contain 'ignored.txt'
-            $result.FileName | Should -Not -Contain 'nested.csv'
+            $result.FileName | Should-ContainCollection 'people.csv'
+            $result.FileName | Should-NotContainCollection 'ignored.txt'
+            $result.FileName | Should-NotContainCollection 'nested.csv'
         }
 
         It 'searches directories recursively with multiple filters' {
@@ -469,9 +469,9 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $directory -Criteria @{ Status = 'Active' } -Filter '*.txt', '*.log' -Delimiter '|' -Literal -Exact -Recurse -IncludeFileName)
 
-            $result.Count | Should -Be 2
-            $result.FileName | Should -Contain 'first.txt'
-            $result.FileName | Should -Contain 'second.log'
+            $result.Count | Should-Be 2
+            $result.FileName | Should-ContainCollection 'first.txt'
+            $result.FileName | Should-ContainCollection 'second.log'
         }
 
         It 'excludes matching directory names during recursive searches' {
@@ -486,14 +486,14 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $directory -Criteria @{ Name = 'Included|Excluded' } -Recurse -IncludeFileName)
 
-            $result.FileName | Should -Contain 'included.csv'
-            $result.FileName | Should -Not -Contain 'excluded.csv'
+            $result.FileName | Should-ContainCollection 'included.csv'
+            $result.FileName | Should-NotContainCollection 'excluded.csv'
         }
 
         It 'does not apply Filter to explicit file paths' {
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -Filter '*.tsv')
 
-            $result.Count | Should -Be 1
+            $result.Count | Should-Be 1
         }
 
         It 'does not return duplicates from overlapping filters' {
@@ -503,7 +503,7 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $directory -Criteria @{ Name = '^Alice$' } -Filter '*.csv', 'people.csv')
 
-            $result.Count | Should -Be 1
+            $result.Count | Should-Be 1
         }
     }
 
@@ -513,11 +513,11 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ City = '^Boston$' } -OutputPath $outputPath)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
             $exportedRows = @(Import-Csv -LiteralPath $outputPath)
-            $exportedRows.Count | Should -Be 2
-            $exportedRows.Name | Should -Contain 'Alice'
-            $exportedRows.Name | Should -Contain 'Carol'
+            $exportedRows.Count | Should-Be 2
+            $exportedRows.Name | Should-ContainCollection 'Alice'
+            $exportedRows.Name | Should-ContainCollection 'Carol'
         }
 
         It 'appends a suffix to aggregate output file names before the extension' {
@@ -526,11 +526,11 @@ Describe 'Search-DelimitedFile' {
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath -OutputFileNameSuffix '-active'
 
-            Test-Path -LiteralPath $outputPath | Should -BeFalse
-            Test-Path -LiteralPath $suffixedOutputPath -PathType Leaf | Should -BeTrue
+            Test-Path -LiteralPath $outputPath | Should-BeFalsy
+            Test-Path -LiteralPath $suffixedOutputPath -PathType Leaf | Should-BeTruthy
             $exportedRows = @(Import-Csv -LiteralPath $suffixedOutputPath)
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Name | Should -Be 'Alice'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Name | Should-Be 'Alice'
         }
 
         It 'uses the suffixed aggregate output path when checking explicit input conflicts' {
@@ -539,10 +539,10 @@ Describe 'Search-DelimitedFile' {
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath -OutputFileNameSuffix '-matches'
 
-            Test-Path -LiteralPath $suffixedOutputPath -PathType Leaf | Should -BeTrue
+            Test-Path -LiteralPath $suffixedOutputPath -PathType Leaf | Should-BeTruthy
             $exportedRows = @(Import-Csv -LiteralPath $suffixedOutputPath)
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Name | Should -Be 'Alice'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Name | Should-Be 'Alice'
         }
 
         It 'writes matching rows to TSV instead of the pipeline' {
@@ -550,14 +550,14 @@ Describe 'Search-DelimitedFile' {
 
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ City = '^Boston$' } -OutputPath $outputPath)
 
-            $result.Count | Should -Be 0
-            (Get-Content -LiteralPath $outputPath -Raw) | Should -Match "`t"
+            $result.Count | Should-Be 0
+            (Get-Content -LiteralPath $outputPath -Raw) | Should-MatchString "`t"
             $exportedRows = @(Import-Csv -LiteralPath $outputPath -Delimiter ([Char]9))
-            $exportedRows.Count | Should -Be 2
-            @($exportedRows[0].PSObject.Properties.Name) | Should -Be @('Name', 'City', 'Status', 'Note')
-            $exportedRows.Name | Should -Contain 'Alice'
-            $exportedRows.Name | Should -Contain 'Carol'
-            $exportedRows.City | Should -Contain 'Boston'
+            $exportedRows.Count | Should-Be 2
+            @($exportedRows[0].PSObject.Properties.Name) | Should-BeCollection @('Name', 'City', 'Status', 'Note')
+            $exportedRows.Name | Should-ContainCollection 'Alice'
+            $exportedRows.Name | Should-ContainCollection 'Carol'
+            $exportedRows.City | Should-ContainCollection 'Boston'
         }
 
         It 'uses as-needed quotes for CSV output by default' {
@@ -571,9 +571,9 @@ Bob,Active,"say ""hi"""
             Search-DelimitedFile -Path $inputPath -Criteria @{ Status = '^Active$' } -OutputPath $outputPath
 
             $lines = (Get-Content -LiteralPath $outputPath -Raw) -split '\r?\n' | Where-Object { $_ }
-            $lines[0] | Should -Be 'Name,Status,Note'
-            $lines[1] | Should -Be 'Alice,Active,"one,two"'
-            $lines[2] | Should -Be 'Bob,Active,"say ""hi"""'
+            $lines[0] | Should-Be 'Name,Status,Note'
+            $lines[1] | Should-Be 'Alice,Active,"one,two"'
+            $lines[2] | Should-Be 'Bob,Active,"say ""hi"""'
         }
 
         It 'quotes every CSV header and field when requested' {
@@ -582,8 +582,8 @@ Bob,Active,"say ""hi"""
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath -UseQuotes Always
 
             $lines = (Get-Content -LiteralPath $outputPath -Raw) -split '\r?\n' | Where-Object { $_ }
-            $lines[0] | Should -Be '"Name","City","Status","Note"'
-            $lines[1] | Should -Be '"Alice","Boston","Active","a+b"'
+            $lines[0] | Should-Be '"Name","City","Status","Note"'
+            $lines[1] | Should-Be '"Alice","Boston","Active","a+b"'
         }
 
         It 'suppresses all CSV quoting when requested' {
@@ -596,8 +596,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $inputPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath -UseQuotes Never
 
             $lines = (Get-Content -LiteralPath $outputPath -Raw) -split '\r?\n' | Where-Object { $_ }
-            $lines[0] | Should -Be 'Name,Status,Note'
-            $lines[1] | Should -Be 'Alice,Active,one,two'
+            $lines[0] | Should-Be 'Name,Status,Note'
+            $lines[1] | Should-Be 'Alice,Active,one,two'
         }
 
         It 'applies as-needed quotes to TSV output' {
@@ -607,8 +607,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $inputPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath
 
             $lines = (Get-Content -LiteralPath $outputPath -Raw) -split '\r?\n' | Where-Object { $_ }
-            $lines[0] | Should -Be "Name`tStatus`tNote"
-            $lines[1] | Should -Be "Alice`tActive`t`"one`ttwo`""
+            $lines[0] | Should-Be "Name`tStatus`tNote"
+            $lines[1] | Should-Be "Alice`tActive`t`"one`ttwo`""
         }
 
         It 'writes matching rows to a JSON array' {
@@ -616,12 +616,12 @@ Alice,Active,"one,two"
 
             $result = @(Search-DelimitedFile -Path $script:csvPath -Criteria @{ Status = '^Active$' } -MatchColumnsOnly -IncludeFileName -OutputPath $outputPath)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
             $jsonText = Get-Content -LiteralPath $outputPath -Raw
-            $jsonText.TrimStart() | Should -Match '^\['
+            $jsonText.TrimStart() | Should-MatchString '^\['
             [Array]$exportedRows = $jsonText | ConvertFrom-Json
-            $exportedRows.Count | Should -Be 1
-            @($exportedRows[0].PSObject.Properties.Name) | Should -Be @('FileName', 'Status')
+            $exportedRows.Count | Should-Be 1
+            @($exportedRows[0].PSObject.Properties.Name) | Should-BeCollection @('FileName', 'Status')
         }
 
         It 'writes row numbers to output files when requested' {
@@ -630,9 +630,9 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ City = '^Boston$' } -IncludeRowNumber -MatchColumnsOnly -OutputPath $outputPath
 
             $exportedRows = @(Import-Csv -LiteralPath $outputPath)
-            $exportedRows.Count | Should -Be 2
-            @($exportedRows[0].PSObject.Properties.Name) | Should -Be @('RowNumber', 'City')
-            @($exportedRows.RowNumber) | Should -Be @('2', '4')
+            $exportedRows.Count | Should-Be 2
+            @($exportedRows[0].PSObject.Properties.Name) | Should-BeCollection @('RowNumber', 'City')
+            @($exportedRows.RowNumber) | Should-BeCollection @('2', '4')
         }
 
         It 'writes suffixed row number metadata to output files when RowNumber already exists' {
@@ -642,10 +642,10 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $path -Criteria @{ Value = '^one$' } -IncludeRowNumber -OutputPath $outputPath
 
             $exportedRows = @(Import-Csv -LiteralPath $outputPath)
-            $exportedRows.Count | Should -Be 1
-            @($exportedRows[0].PSObject.Properties.Name) | Should -Be @('RowNumber1', 'RowNumber', 'Value')
-            $exportedRows[0].RowNumber1 | Should -Be '2'
-            $exportedRows[0].RowNumber | Should -Be '100'
+            $exportedRows.Count | Should-Be 1
+            @($exportedRows[0].PSObject.Properties.Name) | Should-BeCollection @('RowNumber1', 'RowNumber', 'Value')
+            $exportedRows[0].RowNumber1 | Should-Be '2'
+            $exportedRows[0].RowNumber | Should-Be '100'
         }
 
         It 'preserves duplicate source headers in CSV output' {
@@ -655,8 +655,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $path -Criteria @{ File1 = '^Before$'; File2 = '^After$' } -OutputPath $outputPath
 
             $lines = (Get-Content -LiteralPath $outputPath -Raw) -split '\r?\n' | Where-Object { $_ }
-            $lines[0] | Should -Be 'File,Status,File'
-            $lines[1] | Should -Be 'Before,Passed,After'
+            $lines[0] | Should-Be 'File,Status,File'
+            $lines[1] | Should-Be 'Before,Passed,After'
         }
 
         It 'preserves duplicate source headers for matched-column CSV output' {
@@ -666,8 +666,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $path -Criteria @{ File1 = '^Before$'; File2 = '^After$' } -MatchColumnsOnly -OutputPath $outputPath
 
             $lines = (Get-Content -LiteralPath $outputPath -Raw) -split '\r?\n' | Where-Object { $_ }
-            $lines[0] | Should -Be 'File,File'
-            $lines[1] | Should -Be 'Before,After'
+            $lines[0] | Should-Be 'File,File'
+            $lines[1] | Should-Be 'Before,After'
         }
 
         It 'keeps generated duplicate header names in JSON output' {
@@ -677,9 +677,9 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $path -Criteria @{ File1 = '^Before$'; File2 = '^After$' } -OutputPath $outputPath
 
             [Array]$exportedRows = Get-Content -LiteralPath $outputPath -Raw | ConvertFrom-Json
-            @($exportedRows[0].PSObject.Properties.Name) | Should -Be @('File1', 'Status', 'File2')
-            $exportedRows[0].File1 | Should -Be 'Before'
-            $exportedRows[0].File2 | Should -Be 'After'
+            @($exportedRows[0].PSObject.Properties.Name) | Should-BeCollection @('File1', 'Status', 'File2')
+            $exportedRows[0].File1 | Should-Be 'Before'
+            $exportedRows[0].File2 | Should-Be 'After'
         }
 
         It 'writes matching rows to per-source output files in the output directory' {
@@ -688,18 +688,18 @@ Alice,Active,"one,two"
 
             $result = @(Search-DelimitedFile -Path $script:csvPath, $script:archivePath -Criteria @{ Status = '^Active$' } -OutputPath $outputDirectory -OutputBySourceFile)
 
-            $result.Count | Should -Be 0
+            $result.Count | Should-Be 0
             $peopleOutputPath = Join-Path -Path $outputDirectory -ChildPath 'people.csv'
             $archiveOutputPath = Join-Path -Path $outputDirectory -ChildPath 'people-archive.csv'
-            Test-Path -LiteralPath $peopleOutputPath -PathType Leaf | Should -BeTrue
-            Test-Path -LiteralPath $archiveOutputPath -PathType Leaf | Should -BeTrue
+            Test-Path -LiteralPath $peopleOutputPath -PathType Leaf | Should-BeTruthy
+            Test-Path -LiteralPath $archiveOutputPath -PathType Leaf | Should-BeTruthy
 
             $peopleRows = @(Import-Csv -LiteralPath $peopleOutputPath)
             $archiveRows = @(Import-Csv -LiteralPath $archiveOutputPath)
-            $peopleRows.Count | Should -Be 1
-            $peopleRows[0].Name | Should -Be 'Alice'
-            $archiveRows.Count | Should -Be 1
-            $archiveRows[0].Name | Should -Be 'Dave'
+            $peopleRows.Count | Should-Be 1
+            $peopleRows[0].Name | Should-Be 'Alice'
+            $archiveRows.Count | Should-Be 1
+            $archiveRows[0].Name | Should-Be 'Dave'
         }
 
         It 'appends a suffix to per-source output file names before the extension' {
@@ -710,16 +710,16 @@ Alice,Active,"one,two"
 
             $peopleOutputPath = Join-Path -Path $outputDirectory -ChildPath 'people-active.csv'
             $archiveOutputPath = Join-Path -Path $outputDirectory -ChildPath 'people-archive-active.csv'
-            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people.csv') | Should -BeFalse
-            Test-Path -LiteralPath $peopleOutputPath -PathType Leaf | Should -BeTrue
-            Test-Path -LiteralPath $archiveOutputPath -PathType Leaf | Should -BeTrue
+            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people.csv') | Should-BeFalsy
+            Test-Path -LiteralPath $peopleOutputPath -PathType Leaf | Should-BeTruthy
+            Test-Path -LiteralPath $archiveOutputPath -PathType Leaf | Should-BeTruthy
 
             $peopleRows = @(Import-Csv -LiteralPath $peopleOutputPath)
             $archiveRows = @(Import-Csv -LiteralPath $archiveOutputPath)
-            $peopleRows.Count | Should -Be 1
-            $peopleRows[0].Name | Should -Be 'Alice'
-            $archiveRows.Count | Should -Be 1
-            $archiveRows[0].Name | Should -Be 'Dave'
+            $peopleRows.Count | Should-Be 1
+            $peopleRows[0].Name | Should-Be 'Alice'
+            $archiveRows.Count | Should-Be 1
+            $archiveRows[0].Name | Should-Be 'Dave'
         }
 
         It 'preserves the source delimiter when writing per-source TSV outputs' {
@@ -730,10 +730,10 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $inputPath -Criteria @{ Level = '^Error$' } -OutputPath $outputDirectory -OutputBySourceFile
 
             $outputPath = Join-Path -Path $outputDirectory -ChildPath 'per-source-events.tsv'
-            (Get-Content -LiteralPath $outputPath -Raw) | Should -Match "`t"
+            (Get-Content -LiteralPath $outputPath -Raw) | Should-MatchString "`t"
             $exportedRows = @(Import-Csv -LiteralPath $outputPath -Delimiter ([Char]9))
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Id | Should -Be '1'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Id | Should-Be '1'
         }
 
         It 'preserves duplicate source headers in per-source output files' {
@@ -745,8 +745,8 @@ Alice,Active,"one,two"
 
             $outputPath = Join-Path -Path $outputDirectory -ChildPath 'duplicate-per-source-headers.tsv'
             $lines = (Get-Content -LiteralPath $outputPath -Raw) -split '\r?\n' | Where-Object { $_ }
-            $lines[0] | Should -Be "File`tStatus`tFile"
-            $lines[1] | Should -Be "Before`tPassed`tAfter"
+            $lines[0] | Should-Be "File`tStatus`tFile"
+            $lines[1] | Should-Be "Before`tPassed`tAfter"
         }
 
         It 'creates an empty per-source output file when a valid source has no matches' {
@@ -756,8 +756,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputDirectory -OutputBySourceFile
 
             $outputPath = Join-Path -Path $outputDirectory -ChildPath 'people.csv'
-            Test-Path -LiteralPath $outputPath -PathType Leaf | Should -BeTrue
-            (Get-Item -LiteralPath $outputPath).Length | Should -Be 0
+            Test-Path -LiteralPath $outputPath -PathType Leaf | Should-BeTruthy
+            (Get-Item -LiteralPath $outputPath).Length | Should-Be 0
         }
 
         It 'skips per-source output files with no matches when empty output files are disabled' {
@@ -766,7 +766,7 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputDirectory -OutputBySourceFile -NoEmptyOutputFiles
 
-            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people.csv') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people.csv') | Should-BeFalsy
         }
 
         It 'removes existing per-source output files with no matches when empty output files are disabled' {
@@ -777,7 +777,7 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputDirectory -OutputBySourceFile -NoEmptyOutputFiles
 
-            Test-Path -LiteralPath $outputPath | Should -BeFalse
+            Test-Path -LiteralPath $outputPath | Should-BeFalsy
         }
 
         It 'still writes per-source output files with matches when empty output files are disabled' {
@@ -786,8 +786,8 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath, $script:archivePath -Criteria @{ Name = '^Alice$' } -OutputPath $outputDirectory -OutputBySourceFile -NoEmptyOutputFiles
 
-            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people.csv') -PathType Leaf | Should -BeTrue
-            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people-archive.csv') | Should -BeFalse
+            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people.csv') -PathType Leaf | Should-BeTruthy
+            Test-Path -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people-archive.csv') | Should-BeFalsy
         }
 
         It 'continues writing other per-source outputs when one output path cannot be written' {
@@ -798,11 +798,11 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath, $script:archivePath -Criteria @{ Status = '^Active$' } -OutputPath $outputDirectory -OutputBySourceFile -ErrorAction SilentlyContinue -ErrorVariable writeErrors
 
-            $writeErrors.Count | Should -BeGreaterThan 0
-            ($writeErrors | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine | Should -Match 'people\.csv'
+            $writeErrors.Count | Should-BeGreaterThan 0
+            ($writeErrors | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine | Should-MatchString 'people\.csv'
             $archiveRows = @(Import-Csv -LiteralPath (Join-Path -Path $outputDirectory -ChildPath 'people-archive.csv'))
-            $archiveRows.Count | Should -Be 1
-            $archiveRows[0].Name | Should -Be 'Dave'
+            $archiveRows.Count | Should-Be 1
+            $archiveRows[0].Name | Should-Be 'Dave'
         }
 
         It 'creates the per-source output directory when it does not exist' {
@@ -810,11 +810,11 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputDirectory -OutputBySourceFile
 
-            Test-Path -LiteralPath $outputDirectory -PathType Container | Should -BeTrue
+            Test-Path -LiteralPath $outputDirectory -PathType Container | Should-BeTruthy
             $outputPath = Join-Path -Path $outputDirectory -ChildPath 'people.csv'
             $exportedRows = @(Import-Csv -LiteralPath $outputPath)
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Name | Should -Be 'Alice'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Name | Should-Be 'Alice'
         }
 
         It 'skips existing per-source output files discovered during recursive input discovery' {
@@ -827,8 +827,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $directory -Criteria @{ Status = '^Active$' } -Recurse -OutputPath $outputDirectory -OutputBySourceFile
 
             $exportedRows = @(Import-Csv -LiteralPath (Join-Path $outputDirectory 'input.csv'))
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Name | Should -Be 'Alice'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Name | Should-Be 'Alice'
         }
 
         It 'aggregates results from multiple input files into one output file' {
@@ -837,9 +837,9 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $script:csvPath, $script:archivePath -Criteria @{ Status = '^Active$' } -OutputPath $outputPath
 
             [Array]$exportedRows = Get-Content -LiteralPath $outputPath -Raw | ConvertFrom-Json
-            $exportedRows.Count | Should -Be 2
-            $exportedRows.Name | Should -Contain 'Alice'
-            $exportedRows.Name | Should -Contain 'Dave'
+            $exportedRows.Count | Should-Be 2
+            $exportedRows.Name | Should-ContainCollection 'Alice'
+            $exportedRows.Name | Should-ContainCollection 'Dave'
         }
 
         It 'writes an empty JSON array when no rows match' {
@@ -847,7 +847,7 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputPath
 
-            (Get-Content -LiteralPath $outputPath -Raw).Trim() | Should -Be '[]'
+            (Get-Content -LiteralPath $outputPath -Raw).Trim() | Should-Be '[]'
         }
 
         It 'creates an empty CSV file when no rows match' {
@@ -855,8 +855,8 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputPath
 
-            Test-Path -LiteralPath $outputPath -PathType Leaf | Should -BeTrue
-            (Get-Item -LiteralPath $outputPath).Length | Should -Be 0
+            Test-Path -LiteralPath $outputPath -PathType Leaf | Should-BeTruthy
+            (Get-Item -LiteralPath $outputPath).Length | Should-Be 0
         }
 
         It 'skips aggregate CSV output when no rows match and empty output files are disabled' {
@@ -864,7 +864,7 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputPath -NoEmptyOutputFiles
 
-            Test-Path -LiteralPath $outputPath | Should -BeFalse
+            Test-Path -LiteralPath $outputPath | Should-BeFalsy
         }
 
         It 'removes an existing aggregate output when no rows match and empty output files are disabled' {
@@ -873,7 +873,7 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputPath -NoEmptyOutputFiles
 
-            Test-Path -LiteralPath $outputPath | Should -BeFalse
+            Test-Path -LiteralPath $outputPath | Should-BeFalsy
         }
 
         It 'creates an empty TSV file when no rows match' {
@@ -881,8 +881,8 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputPath
 
-            Test-Path -LiteralPath $outputPath -PathType Leaf | Should -BeTrue
-            (Get-Item -LiteralPath $outputPath).Length | Should -Be 0
+            Test-Path -LiteralPath $outputPath -PathType Leaf | Should-BeTruthy
+            (Get-Item -LiteralPath $outputPath).Length | Should-Be 0
         }
 
         It 'skips aggregate JSON output when no rows match and empty output files are disabled' {
@@ -890,7 +890,7 @@ Alice,Active,"one,two"
 
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Missing$' } -OutputPath $outputPath -NoEmptyOutputFiles
 
-            Test-Path -LiteralPath $outputPath | Should -BeFalse
+            Test-Path -LiteralPath $outputPath | Should-BeFalsy
         }
 
         It 'overwrites an existing output file' {
@@ -900,8 +900,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath
 
             [Array]$exportedRows = Get-Content -LiteralPath $outputPath -Raw | ConvertFrom-Json
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Name | Should -Be 'Alice'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Name | Should-Be 'Alice'
         }
 
         It 'skips an existing output file found during directory discovery' {
@@ -914,8 +914,8 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $directory -Criteria @{ Status = '^Active$' } -OutputPath $outputPath
 
             $exportedRows = @(Import-Csv -LiteralPath $outputPath)
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Name | Should -Be 'Alice'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Name | Should-Be 'Alice'
         }
 
         It 'skips an existing output file matched by an input wildcard' {
@@ -929,42 +929,42 @@ Alice,Active,"one,two"
             Search-DelimitedFile -Path $inputPattern -Criteria @{ Status = '^Active$' } -OutputPath $outputPath
 
             $exportedRows = @(Import-Csv -LiteralPath $outputPath)
-            $exportedRows.Count | Should -Be 1
-            $exportedRows[0].Name | Should -Be 'Alice'
+            $exportedRows.Count | Should-Be 1
+            $exportedRows[0].Name | Should-Be 'Alice'
         }
 
         It 'rejects unsupported output file extensions' {
             $outputPath = Join-Path -Path $TestDrive -ChildPath 'matches.txt'
 
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath } |
-            Should -Throw '*must use a .csv, .tsv, or .json extension*'
+            Should-Throw '*must use a .csv, .tsv, or .json extension*'
         }
 
         It 'rejects UseQuotes without OutputPath' {
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -UseQuotes Never } |
-            Should -Throw '*requires OutputPath*'
+            Should-Throw '*requires OutputPath*'
         }
 
         It 'rejects OutputFileNameSuffix without OutputPath' {
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputFileNameSuffix '-matches' } |
-            Should -Throw '*requires OutputPath*'
+            Should-Throw '*requires OutputPath*'
         }
 
         It 'rejects an output file name suffix that contains a path separator' {
             $outputPath = Join-Path -Path $TestDrive -ChildPath 'matches.csv'
 
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath -OutputFileNameSuffix 'nested/name' } |
-            Should -Throw '*cannot contain path separator*'
+            Should-Throw '*cannot contain path separator*'
         }
 
         It 'rejects OutputBySourceFile without OutputPath' {
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputBySourceFile } |
-            Should -Throw '*requires OutputPath*'
+            Should-Throw '*requires OutputPath*'
         }
 
         It 'rejects NoEmptyOutputFiles without OutputPath' {
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -NoEmptyOutputFiles } |
-            Should -Throw '*requires OutputPath*'
+            Should-Throw '*requires OutputPath*'
         }
 
         It 'rejects OutputBySourceFile when OutputPath is an existing file' {
@@ -972,14 +972,14 @@ Alice,Active,"one,two"
             Set-Content -LiteralPath $outputPath -Value 'existing file' -Encoding UTF8
 
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath -OutputBySourceFile } |
-            Should -Throw '*must identify a directory*'
+            Should-Throw '*must identify a directory*'
         }
 
         It 'rejects UseQuotes with JSON output' {
             $outputPath = Join-Path -Path $TestDrive -ChildPath 'matches.json'
 
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath -UseQuotes Always } |
-            Should -Throw '*only to CSV and TSV*'
+            Should-Throw '*only to CSV and TSV*'
         }
 
         It 'rejects duplicate per-source output file names' {
@@ -992,67 +992,67 @@ Alice,Active,"one,two"
             Set-Content -LiteralPath (Join-Path $secondDirectory 'data.csv') -Value "Name,Status`nSecond,Active" -Encoding UTF8
 
             { Search-DelimitedFile -Path $directory -Criteria @{ Status = '^Active$' } -Recurse -OutputPath $outputDirectory -OutputBySourceFile -ErrorAction Stop } |
-            Should -Throw '*same per-source output file*'
+            Should-Throw '*same per-source output file*'
         }
 
         It 'rejects an output path whose parent directory does not exist' {
             $outputPath = Join-Path -Path (Join-Path -Path $TestDrive -ChildPath 'missing') -ChildPath 'matches.json'
 
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $outputPath } |
-            Should -Throw '*directory does not exist*'
+            Should-Throw '*directory does not exist*'
         }
 
         It 'rejects using the same explicit file as input and output' {
             { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '^Alice$' } -OutputPath $script:csvPath } |
-            Should -Throw '*cannot also be an explicit input file*'
+            Should-Throw '*cannot also be an explicit input file*'
         }
     }
 
     Context 'Validation and error handling' {
         It 'rejects empty criteria' {
-            { Search-DelimitedFile -Path $script:csvPath -Criteria @{} } | Should -Throw '*at least one*'
+            { Search-DelimitedFile -Path $script:csvPath -Criteria @{} } | Should-Throw '*at least one*'
         }
 
         It 'rejects invalid regular expressions' {
-            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '(unclosed' } } | Should -Throw '*Invalid regular expression*'
+            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = '(unclosed' } } | Should-Throw '*Invalid regular expression*'
         }
 
         It 'requires Literal when Exact is used' {
-            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = 'Alice' } -Exact } | Should -Throw '*requires Literal*'
+            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = 'Alice' } -Exact } | Should-Throw '*requires Literal*'
         }
 
         It 'rejects NoHeader combined with Header' {
-            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ 0 = 'Alice' } -NoHeader -Header Name, City, Status, Note } | Should -Throw '*cannot be used together*'
+            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ 0 = 'Alice' } -NoHeader -Header Name, City, Status, Note } | Should-Throw '*cannot be used together*'
         }
 
         It 'rejects unknown column names' {
-            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Missing = 'value' } -ErrorAction Stop } | Should -Throw '*was not found*'
+            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Missing = 'value' } -ErrorAction Stop } | Should-Throw '*was not found*'
         }
 
         It 'rejects out-of-range column indexes' {
-            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ 10 = 'value' } -ErrorAction Stop } | Should -Throw '*outside the valid range*'
+            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ 10 = 'value' } -ErrorAction Stop } | Should-Throw '*outside the valid range*'
         }
 
         It 'rejects a custom header with the wrong field count' {
             $path = Initialize-DelimitedTestFile -Name 'header-count.txt' -Content 'Alice,42,NY'
 
-            { Search-DelimitedFile -Path $path -Criteria @{ Name = 'Alice' } -Header Name, Age -ErrorAction Stop } | Should -Throw '*contains 3 fields*'
+            { Search-DelimitedFile -Path $path -Criteria @{ Name = 'Alice' } -Header Name, Age -ErrorAction Stop } | Should-Throw '*contains 3 fields*'
         }
 
         It 'rejects duplicate custom header names' {
-            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = 'Alice' } -Header Name, Name, Status, Note } | Should -Throw '*duplicate column name*'
+            { Search-DelimitedFile -Path $script:csvPath -Criteria @{ Name = 'Alice' } -Header Name, Name, Status, Note } | Should-Throw '*duplicate column name*'
         }
 
         It 'protects source metadata from input column collisions' {
             $path = Initialize-DelimitedTestFile -Name 'filename-column.csv' -Content "FileName,Value`noriginal.csv,one"
 
-            { Search-DelimitedFile -Path $path -Criteria @{ Value = 'one' } -IncludeFileName -ErrorAction Stop } | Should -Throw '*already contains a FileName column*'
+            { Search-DelimitedFile -Path $path -Criteria @{ Value = 'one' } -IncludeFileName -ErrorAction Stop } | Should-Throw '*already contains a FileName column*'
         }
 
         It 'reports missing paths' {
             $missingPath = Join-Path -Path $TestDrive -ChildPath 'missing.csv'
 
-            { Search-DelimitedFile -Path $missingPath -Criteria @{ Name = 'Alice' } -ErrorAction Stop } | Should -Throw
+            { Search-DelimitedFile -Path $missingPath -Criteria @{ Name = 'Alice' } -ErrorAction Stop } | Should-Throw
         }
     }
 }

--- a/Tests/Unit/Utilities/Search-FileContent.Tests.ps1
+++ b/Tests/Unit/Utilities/Search-FileContent.Tests.ps1
@@ -37,85 +37,85 @@ Describe 'Search-FileContent' {
         It 'Should have mandatory Pattern parameter' {
             $command = Get-Command Search-FileContent
             $patternParam = $command.Parameters['Pattern']
-            $patternParam.Attributes.Mandatory | Should -Contain $true
+            $patternParam.Attributes.Mandatory | Should-ContainCollection $true
         }
 
         It 'Should have optional Path parameter with default value' {
             $command = Get-Command Search-FileContent
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.Mandatory | Should -Not -Contain $true
+            $pathParam.Attributes.Mandatory | Should-NotContainCollection $true
         }
 
         It 'Should accept pipeline input for Path' {
             $command = Get-Command Search-FileContent
             $pathParam = $command.Parameters['Path']
-            $pathParam.Attributes.ValueFromPipeline | Should -Contain $true
+            $pathParam.Attributes.ValueFromPipeline | Should-ContainCollection $true
         }
 
         It 'Should have optional Recurse switch parameter' {
             $command = Get-Command Search-FileContent
-            $command.Parameters['Recurse'].SwitchParameter | Should -BeTrue
+            $command.Parameters['Recurse'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should validate Context parameter range' {
             $command = Get-Command Search-FileContent
             $contextParam = $command.Parameters['Context']
             $validateRange = $contextParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
-            $validateRange.MinRange | Should -Be 0
-            $validateRange.MaxRange | Should -Be 100
+            $validateRange.MinRange | Should-Be 0
+            $validateRange.MaxRange | Should-Be 100
         }
 
         It 'Should validate Before parameter range' {
             $command = Get-Command Search-FileContent
             $beforeParam = $command.Parameters['Before']
             $validateRange = $beforeParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
-            $validateRange.MinRange | Should -Be 0
-            $validateRange.MaxRange | Should -Be 100
+            $validateRange.MinRange | Should-Be 0
+            $validateRange.MaxRange | Should-Be 100
         }
 
         It 'Should validate After parameter range' {
             $command = Get-Command Search-FileContent
             $afterParam = $command.Parameters['After']
             $validateRange = $afterParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
-            $validateRange.MinRange | Should -Be 0
-            $validateRange.MaxRange | Should -Be 100
+            $validateRange.MinRange | Should-Be 0
+            $validateRange.MaxRange | Should-Be 100
         }
 
         It 'Should validate MaxDepth parameter range' {
             $command = Get-Command Search-FileContent
             $maxDepthParam = $command.Parameters['MaxDepth']
             $validateRange = $maxDepthParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
-            $validateRange.MinRange | Should -Be 1
-            $validateRange.MaxRange | Should -Be 100
+            $validateRange.MinRange | Should-Be 1
+            $validateRange.MaxRange | Should-Be 100
         }
 
         It 'Should validate MaxFileSizeMB parameter range' {
             $command = Get-Command Search-FileContent
             $maxSizeParam = $command.Parameters['MaxFileSizeMB']
             $validateRange = $maxSizeParam.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
-            $validateRange.MinRange | Should -Be 1
-            $validateRange.MaxRange | Should -Be 10240
+            $validateRange.MinRange | Should-Be 1
+            $validateRange.MaxRange | Should-Be 10240
         }
 
         It 'Should have Context alias C' {
             $command = Get-Command Search-FileContent
             $contextParam = $command.Parameters['Context']
             $aliases = $contextParam.Aliases
-            $aliases | Should -Contain 'C'
+            $aliases | Should-ContainCollection 'C'
         }
 
         It 'Should have Before alias B' {
             $command = Get-Command Search-FileContent
             $beforeParam = $command.Parameters['Before']
             $aliases = $beforeParam.Aliases
-            $aliases | Should -Contain 'B'
+            $aliases | Should-ContainCollection 'B'
         }
 
         It 'Should have After alias A' {
             $command = Get-Command Search-FileContent
             $afterParam = $command.Parameters['After']
             $aliases = $afterParam.Aliases
-            $aliases | Should -Contain 'A'
+            $aliases | Should-ContainCollection 'A'
         }
     }
 
@@ -155,34 +155,34 @@ No matches
         It 'Should find matches in files with Simple output' {
             $results = Search-FileContent -Pattern 'pattern' -Path $script:testDir -Simple -CaseInsensitive
             $results | Should -Not -BeNullOrEmpty
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should return correct line numbers' {
             $results = Search-FileContent -Pattern 'pattern' -Path $script:testDir -Simple -CaseInsensitive
-            $results[0].LineNumber | Should -Be 2
-            $results[1].LineNumber | Should -Be 4
+            $results[0].LineNumber | Should-Be 2
+            $results[1].LineNumber | Should-Be 4
         }
 
         It 'Should return correct line content' {
             $results = Search-FileContent -Pattern 'pattern' -Path $script:testDir -Simple -CaseInsensitive
-            $results[0].Line | Should -BeLike '*PATTERN*'
-            $results[1].Line | Should -BeLike '*pattern again*'
+            $results[0].Line | Should-BeLikeString '*PATTERN*'
+            $results[1].Line | Should-BeLikeString '*pattern again*'
         }
 
         It 'Should return correct match value' {
             $results = Search-FileContent -Pattern 'PATTERN' -Path $script:testDir -Simple
-            $results[0].Match | Should -Be 'PATTERN'
+            $results[0].Match | Should-Be 'PATTERN'
         }
 
         It 'Should respect case sensitivity by default' {
             $results = @(Search-FileContent -Pattern 'PATTERN' -Path $script:testDir -Simple)
-            $results.Count | Should -Be 1
+            $results.Count | Should-Be 1
         }
 
         It 'Should work with case insensitive flag' {
             $results = Search-FileContent -Pattern 'PATTERN' -Path $script:testDir -Simple -CaseInsensitive
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should find no matches when pattern does not exist' {
@@ -210,28 +210,28 @@ function Get-Item
 
         It 'Should treat pattern as literal when -Literal is used' {
             $results = @(Search-FileContent -Pattern 'test.file' -Path $script:testDir -Simple -Literal)
-            $results.Count | Should -Be 1
-            $results[0].Line | Should -Be 'test.file.name'
+            $results.Count | Should-Be 1
+            $results[0].Line | Should-Be 'test.file.name'
         }
 
         It 'Should treat pattern as regex by default' {
             $results = Search-FileContent -Pattern 'test.file' -Path $script:testDir -Simple
             # Regex . matches any character, so should match test*file and test[file] too
-            $results.Count | Should -BeGreaterThan 1
+            $results.Count | Should-BeGreaterThan 1
         }
 
         It 'Should support regex character classes' {
             $results = Search-FileContent -Pattern '\d+\.\d+\.\d+\.\d+' -Path $script:testDir -Simple
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should support regex word boundaries' {
             $results = Search-FileContent -Pattern '\bfunction\b' -Path $script:testDir -Simple
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should throw error for invalid regex pattern' {
-            { Search-FileContent -Pattern '(unclosed' -Path $script:testDir -Simple } | Should -Throw
+            { Search-FileContent -Pattern '(unclosed' -Path $script:testDir -Simple } | Should-Throw
         }
     }
 
@@ -256,7 +256,7 @@ Line 9
 
         It 'Should return matches without context by default' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
             # Each result should have no context or minimal context
         }
 
@@ -264,22 +264,22 @@ Line 9
             # Context parameter provides before and after context
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Context 1
             # Should find 2 matches
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should handle -Before parameter' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Before 2
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should handle -After parameter' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -After 2
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should handle both -Before and -After parameters' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Before 1 -After 1
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
     }
 
@@ -297,33 +297,33 @@ Line 9
 
         It 'Should search all files when no filter specified' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple
-            $results.Count | Should -Be 4
+            $results.Count | Should-Be 4
         }
 
         It 'Should filter files with -Include parameter' {
             $results = @(Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Include '*.txt')
-            $results.Count | Should -Be 1
-            $results[0].Path | Should -Match 'file1\.txt$'
+            $results.Count | Should-Be 1
+            $results[0].Path | Should-MatchString 'file1\.txt$'
         }
 
         It 'Should support multiple include patterns' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Include '*.txt', '*.ps1'
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should filter files with -Exclude parameter' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Exclude '*.log'
-            $results.Count | Should -Be 3
+            $results.Count | Should-Be 3
         }
 
         It 'Should support multiple exclude patterns' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Exclude '*.log', '*.md'
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should combine include and exclude filters' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Include '*.txt', '*.ps1', '*.log' -Exclude '*.log'
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
     }
 
@@ -352,28 +352,28 @@ Line 9
 
         It 'Should exclude .git directories by default' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse
-            $results.Path | Should -Not -BeLike '*.git*'
+            $results.Path | Should-NotBeLikeString '*.git*'
         }
 
         It 'Should exclude node_modules directories by default' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse
-            $results.Path | Should -Not -BeLike '*node_modules*'
+            $results.Path | Should-NotBeLikeString '*node_modules*'
         }
 
         It 'Should allow custom directory exclusions' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse -ExcludeDirectory 'src'
-            $results.Path | Should -Not -Match '[\\/]src[\\/]'
+            $results.Path | Should-NotMatchString '[\\/]src[\\/]'
         }
 
         It 'Should not exclude similarly named directories without wildcards' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse -ExcludeDirectory 'src'
-            $results.Path | Should -Contain (Join-Path -Path $script:testDir -ChildPath 'src-utils/helper.ps1')
+            $results.Path | Should-ContainCollection (Join-Path -Path $script:testDir -ChildPath 'src-utils/helper.ps1')
         }
 
         It 'Should support wildcard directory exclusions' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse -ExcludeDirectory 'src*'
-            $results.Path | Should -Not -Contain (Join-Path -Path $script:testDir -ChildPath 'src/main.ps1')
-            $results.Path | Should -Not -Contain (Join-Path -Path $script:testDir -ChildPath 'src-utils/helper.ps1')
+            $results.Path | Should-NotContainCollection (Join-Path -Path $script:testDir -ChildPath 'src/main.ps1')
+            $results.Path | Should-NotContainCollection (Join-Path -Path $script:testDir -ChildPath 'src-utils/helper.ps1')
         }
 
         It 'Should support multiple directory exclusions' {
@@ -398,26 +398,26 @@ Final line
 
         It 'Should output objects in Simple mode' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple
-            $results | Should -BeOfType [PSCustomObject]
-            $results[0].PSObject.Properties.Name | Should -Contain 'Path'
-            $results[0].PSObject.Properties.Name | Should -Contain 'LineNumber'
-            $results[0].PSObject.Properties.Name | Should -Contain 'Line'
-            $results[0].PSObject.Properties.Name | Should -Contain 'Match'
+            $results | Should-HaveType ([PSCustomObject])
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'Path'
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'LineNumber'
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'Line'
+            $results[0].PSObject.Properties.Name | Should-ContainCollection 'Match'
         }
 
         It 'Should output count with -CountOnly and -Simple' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -CountOnly -Simple
-            $results | Should -BeOfType [PSCustomObject]
-            $results.PSObject.Properties.Name | Should -Contain 'Path'
-            $results.PSObject.Properties.Name | Should -Contain 'MatchCount'
-            $results.MatchCount | Should -Be 2
+            $results | Should-HaveType ([PSCustomObject])
+            $results.PSObject.Properties.Name | Should-ContainCollection 'Path'
+            $results.PSObject.Properties.Name | Should-ContainCollection 'MatchCount'
+            $results.MatchCount | Should-Be 2
         }
 
         It 'Should output only file paths with -FilesOnly and -Simple' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -FilesOnly -Simple
-            $results | Should -BeOfType [PSCustomObject]
-            $results.PSObject.Properties.Name | Should -Contain 'Path'
-            $results.PSObject.Properties.Name | Should -Not -Contain 'LineNumber'
+            $results | Should-HaveType ([PSCustomObject])
+            $results.PSObject.Properties.Name | Should-ContainCollection 'Path'
+            $results.PSObject.Properties.Name | Should-NotContainCollection 'LineNumber'
         }
     }
 
@@ -443,18 +443,18 @@ Final line
 
         It 'Should search only the top-level directory by default after recursion became opt-in' {
             $results = @(Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple)
-            $results.Count | Should -Be 1
-            $results[0].Path | Should -Match 'root\.txt$'
+            $results.Count | Should-Be 1
+            $results[0].Path | Should-MatchString 'root\.txt$'
         }
 
         It 'Should search recursively with -Recurse' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse
-            $results.Count | Should -Be 4
+            $results.Count | Should-Be 4
         }
 
         It 'Should respect MaxDepth parameter' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse -MaxDepth 1
-            $results.Count | Should -BeLessOrEqual 2
+            $results.Count | Should-BeLessThanOrEqual 2
         }
     }
 
@@ -469,19 +469,19 @@ Final line
 
         It 'Should accept file objects from pipeline' {
             $results = Get-ChildItem $script:testDir -File | Search-FileContent -Pattern 'MATCH' -Simple
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should accept path strings from pipeline' {
             $results = (Get-ChildItem $script:testDir -File).FullName | Search-FileContent -Pattern 'MATCH' -Simple
-            $results.Count | Should -Be 2
+            $results.Count | Should-Be 2
         }
 
         It 'Should de-duplicate files from overlapping path inputs' {
             $singleFile = Join-Path -Path $script:testDir -ChildPath 'file1.txt'
             $results = Search-FileContent -Pattern 'MATCH' -Path @($script:testDir, $singleFile, $singleFile) -Simple
-            $results.Count | Should -Be 2
-            @($results | Where-Object { $_.Path -eq $singleFile }).Count | Should -Be 1
+            $results.Count | Should-Be 2
+            @($results | Where-Object { $_.Path -eq $singleFile }).Count | Should-Be 1
         }
     }
 
@@ -502,8 +502,8 @@ Final line
         It 'Should skip binary files' {
             $results = @(Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple)
             # Should only find the text file, not the binary file
-            $results.Count | Should -Be 1
-            $results[0].Path | Should -BeLike '*text.txt'
+            $results.Count | Should-Be 1
+            $results[0].Path | Should-BeLikeString '*text.txt'
         }
     }
 
@@ -517,7 +517,7 @@ Final line
         It 'Should throw error for invalid regex' {
             $testFile = Join-Path -Path $TestDrive -ChildPath 'test.txt'
             'test' | Set-Content -Path $testFile
-            { Search-FileContent -Pattern '[invalid' -Path $testFile -Simple } | Should -Throw
+            { Search-FileContent -Pattern '[invalid' -Path $testFile -Simple } | Should-Throw
         }
     }
 
@@ -555,81 +555,81 @@ USER-NAME = cssConstant
         }
 
         It 'Should throw error when IncludeCaseVariations used without CaseInsensitive' {
-            { Search-FileContent -Pattern 'username' -Path $script:testDir -IncludeCaseVariations } | Should -Throw '*IncludeCaseVariations requires CaseInsensitive*'
+            { Search-FileContent -Pattern 'username' -Path $script:testDir -IncludeCaseVariations } | Should-Throw '*IncludeCaseVariations requires CaseInsensitive*'
         }
 
         It 'Should throw error when IncludeCaseVariations used with CountOnly' {
-            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -CountOnly } | Should -Throw '*IncludeCaseVariations cannot be used with CountOnly*'
+            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -CountOnly } | Should-Throw '*IncludeCaseVariations cannot be used with CountOnly*'
         }
 
         It 'Should throw error when IncludeCaseVariations used with FilesOnly' {
-            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -FilesOnly } | Should -Throw '*IncludeCaseVariations cannot be used with FilesOnly*'
+            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -FilesOnly } | Should-Throw '*IncludeCaseVariations cannot be used with FilesOnly*'
         }
 
         It 'Should throw error when IncludeCaseVariations used with Context' {
-            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Context 2 } | Should -Throw '*IncludeCaseVariations cannot be used with Context*'
+            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Context 2 } | Should-Throw '*IncludeCaseVariations cannot be used with Context*'
         }
 
         It 'Should throw error when IncludeCaseVariations used with Before' {
-            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Before 2 } | Should -Throw '*IncludeCaseVariations cannot be used with*Before*'
+            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Before 2 } | Should-Throw '*IncludeCaseVariations cannot be used with*Before*'
         }
 
         It 'Should throw error when IncludeCaseVariations used with After' {
-            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -After 2 } | Should -Throw '*IncludeCaseVariations cannot be used with*After*'
+            { Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -After 2 } | Should-Throw '*IncludeCaseVariations cannot be used with*After*'
         }
 
         It 'Should detect all case variations in Simple mode' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $results | Should -Not -BeNullOrEmpty
-            $results.Count | Should -BeGreaterThan 0
+            $results.Count | Should-BeGreaterThan 0
             # Should find these variations (not separated patterns like user_name)
-            $results.Variation | Should -Contain 'userName'
-            $results.Variation | Should -Contain 'UserName'
-            $results.Variation | Should -Contain 'USERNAME'
-            $results.Variation | Should -Contain 'username'
-            $results.Variation | Should -Contain 'Username'
+            $results.Variation | Should-ContainCollection 'userName'
+            $results.Variation | Should-ContainCollection 'UserName'
+            $results.Variation | Should-ContainCollection 'USERNAME'
+            $results.Variation | Should-ContainCollection 'username'
+            $results.Variation | Should-ContainCollection 'Username'
         }
 
         It 'Should count occurrences correctly' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $userNameResult = $results | Where-Object { $_.Variation -ceq 'userName' }
-            $userNameResult.Count | Should -Be 2  # Once in code.js, once in code.py
+            $userNameResult.Count | Should-Be 2  # Once in code.js, once in code.py
         }
 
         It 'Should track files for each variation' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $usernameResult = $results | Where-Object { $_.Variation -ceq 'username' }
-            $usernameResult.Files | Should -Contain (Join-Path -Path $script:testDir -ChildPath 'code.js')
+            $usernameResult.Files | Should-ContainCollection (Join-Path -Path $script:testDir -ChildPath 'code.js')
         }
 
         It 'Should identify camelCase pattern' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $camelResult = $results | Where-Object { $_.Variation -ceq 'userName' }
-            $camelResult.CasePattern | Should -Be 'camelCase'
+            $camelResult.CasePattern | Should-Be 'camelCase'
         }
 
         It 'Should identify PascalCase pattern' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $pascalResult = $results | Where-Object { $_.Variation -ceq 'UserName' }
-            $pascalResult.CasePattern | Should -Be 'PascalCase'
+            $pascalResult.CasePattern | Should-Be 'PascalCase'
         }
 
         It 'Should identify UPPERCASE pattern' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $upperResult = $results | Where-Object { $_.Variation -ceq 'USERNAME' }
-            $upperResult.CasePattern | Should -Be 'UPPERCASE'
+            $upperResult.CasePattern | Should-Be 'UPPERCASE'
         }
 
         It 'Should identify lowercase pattern' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $lowerResult = $results | Where-Object { $_.Variation -ceq 'username' }
-            $lowerResult.CasePattern | Should -Be 'lowercase'
+            $lowerResult.CasePattern | Should-Be 'lowercase'
         }
 
         It 'Should identify First Capital pattern' {
             $results = Search-FileContent -Pattern 'username' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             $firstCapResult = $results | Where-Object { $_.Variation -ceq 'Username' }
-            $firstCapResult.CasePattern | Should -Be 'First Capital'
+            $firstCapResult.CasePattern | Should-Be 'First Capital'
         }
 
         It 'Should match separated patterns like user_name and user-name with separator-aware matching' {
@@ -637,9 +637,9 @@ USER-NAME = cssConstant
             # across different separators (underscores, hyphens, spaces) when pattern has word boundaries
             $results = Search-FileContent -Pattern 'userName' -Path $script:testDir -CaseInsensitive -IncludeCaseVariations -Simple
             # These SHOULD be in the results because the pattern is separator-aware
-            $results.Variation | Should -Contain 'user_name'
-            $results.Variation | Should -Contain 'USER_NAME'
-            $results.Variation | Should -Contain 'user-name'
+            $results.Variation | Should-ContainCollection 'user_name'
+            $results.Variation | Should-ContainCollection 'USER_NAME'
+            $results.Variation | Should-ContainCollection 'user-name'
         }
     }
 }

--- a/Tests/Unit/Utilities/Search-FileContent.Tests.ps1
+++ b/Tests/Unit/Utilities/Search-FileContent.Tests.ps1
@@ -352,17 +352,17 @@ Line 9
 
         It 'Should exclude .git directories by default' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse
-            $results.Path | Should-NotBeLikeString '*.git*'
+            $results.Path | ForEach-Object { $_ | Should-NotBeLikeString '*.git*' }
         }
 
         It 'Should exclude node_modules directories by default' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse
-            $results.Path | Should-NotBeLikeString '*node_modules*'
+            $results.Path | ForEach-Object { $_ | Should-NotBeLikeString '*node_modules*' }
         }
 
         It 'Should allow custom directory exclusions' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple -Recurse -ExcludeDirectory 'src'
-            $results.Path | Should-NotMatchString '[\\/]src[\\/]'
+            $results.Path | ForEach-Object { $_ | Should-NotMatchString '[\\/]src[\\/]' }
         }
 
         It 'Should not exclude similarly named directories without wildcards' {
@@ -398,7 +398,7 @@ Final line
 
         It 'Should output objects in Simple mode' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -Simple
-            $results | Should-HaveType ([PSCustomObject])
+            $results | ForEach-Object { $_ | Should-HaveType ([PSCustomObject]) }
             $results[0].PSObject.Properties.Name | Should-ContainCollection 'Path'
             $results[0].PSObject.Properties.Name | Should-ContainCollection 'LineNumber'
             $results[0].PSObject.Properties.Name | Should-ContainCollection 'Line'
@@ -407,7 +407,7 @@ Final line
 
         It 'Should output count with -CountOnly and -Simple' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -CountOnly -Simple
-            $results | Should-HaveType ([PSCustomObject])
+            $results | ForEach-Object { $_ | Should-HaveType ([PSCustomObject]) }
             $results.PSObject.Properties.Name | Should-ContainCollection 'Path'
             $results.PSObject.Properties.Name | Should-ContainCollection 'MatchCount'
             $results.MatchCount | Should-Be 2
@@ -415,7 +415,7 @@ Final line
 
         It 'Should output only file paths with -FilesOnly and -Simple' {
             $results = Search-FileContent -Pattern 'MATCH' -Path $script:testDir -FilesOnly -Simple
-            $results | Should-HaveType ([PSCustomObject])
+            $results | ForEach-Object { $_ | Should-HaveType ([PSCustomObject]) }
             $results.PSObject.Properties.Name | Should-ContainCollection 'Path'
             $results.PSObject.Properties.Name | Should-NotContainCollection 'LineNumber'
         }

--- a/Tests/Unit/Utilities/Set-FileEncoding.Tests.ps1
+++ b/Tests/Unit/Utilities/Set-FileEncoding.Tests.ps1
@@ -88,7 +88,7 @@ Describe 'Set-FileEncoding' -Tag 'Unit' {
         $result = Set-FileEncoding -Path $path -Encoding UTF8BOM -PassThru -WarningVariable warnings -WarningAction Continue
         $afterBytes = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($path))
 
-        $warnings | Should-MatchString 'binary'
+        ($warnings | Out-String) | Should-MatchString 'binary'
         $result | Should -BeNullOrEmpty
         $afterBytes | Should-Be $beforeBytes
     }

--- a/Tests/Unit/Utilities/Set-FileEncoding.Tests.ps1
+++ b/Tests/Unit/Utilities/Set-FileEncoding.Tests.ps1
@@ -21,18 +21,18 @@ Describe 'Set-FileEncoding' -Tag 'Unit' {
 
         $result = Set-FileEncoding -Path $path -Encoding UTF8BOM -PassThru
 
-        $result.Success | Should -BeTrue
-        $result.Skipped | Should -BeFalse
-        $result.EncodingChanged | Should -BeTrue
+        $result.Success | Should-BeTruthy
+        $result.Skipped | Should-BeFalsy
+        $result.EncodingChanged | Should-BeTruthy
 
         $bytes = [System.IO.File]::ReadAllBytes($path)
-        $bytes[0] | Should -Be 0xEF
-        $bytes[1] | Should -Be 0xBB
-        $bytes[2] | Should -Be 0xBF
+        $bytes[0] | Should-Be 0xEF
+        $bytes[1] | Should-Be 0xBB
+        $bytes[2] | Should-Be 0xBF
 
         $detected = Get-FileEncoding -FilePath $path
-        $detected.CodePage | Should -Be 65001
-        $detected.GetPreamble().Length | Should -Be 3
+        $detected.CodePage | Should-Be 65001
+        $detected.GetPreamble().Length | Should-Be 3
     }
 
     It 'Skips files that already have the requested encoding' {
@@ -43,10 +43,10 @@ Describe 'Set-FileEncoding' -Tag 'Unit' {
         $result = Set-FileEncoding -Path $path -Encoding UTF16LE -PassThru
         $afterBytes = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($path))
 
-        $result.Success | Should -BeTrue
-        $result.Skipped | Should -BeTrue
-        $result.EncodingChanged | Should -BeFalse
-        $afterBytes | Should -Be $beforeBytes
+        $result.Success | Should-BeTruthy
+        $result.Skipped | Should-BeTruthy
+        $result.EncodingChanged | Should-BeFalsy
+        $afterBytes | Should-Be $beforeBytes
     }
 
     It 'Rewrites matching encodings when Force is specified' {
@@ -60,11 +60,11 @@ Describe 'Set-FileEncoding' -Tag 'Unit' {
         $result = Set-FileEncoding -Path $path -Encoding UTF8BOM -Force -PassThru
         $afterWriteTime = (Get-Item -Path $path).LastWriteTimeUtc
 
-        $result.Success | Should -BeTrue
-        $result.Skipped | Should -BeFalse
-        $result.Forced | Should -BeTrue
-        $result.EncodingChanged | Should -BeFalse
-        $afterWriteTime | Should -BeGreaterThan $beforeWriteTime
+        $result.Success | Should-BeTruthy
+        $result.Skipped | Should-BeFalsy
+        $result.Forced | Should-BeTruthy
+        $result.EncodingChanged | Should-BeFalsy
+        $afterWriteTime | Should-BeGreaterThan $beforeWriteTime
     }
 
     It 'Accepts pipeline input by FullName' {
@@ -74,10 +74,10 @@ Describe 'Set-FileEncoding' -Tag 'Unit' {
         $result = Get-Item -Path $path | Set-FileEncoding -Encoding UTF8 -PassThru
         $detected = Get-FileEncoding -FilePath $path
 
-        $result.Success | Should -BeTrue
-        $result.Skipped | Should -BeFalse
-        $detected.CodePage | Should -Be 65001
-        $detected.GetPreamble().Length | Should -Be 0
+        $result.Success | Should-BeTruthy
+        $result.Skipped | Should-BeFalsy
+        $detected.CodePage | Should-Be 65001
+        $detected.GetPreamble().Length | Should-Be 0
     }
 
     It 'Warns and skips binary files' {
@@ -88,8 +88,8 @@ Describe 'Set-FileEncoding' -Tag 'Unit' {
         $result = Set-FileEncoding -Path $path -Encoding UTF8BOM -PassThru -WarningVariable warnings -WarningAction Continue
         $afterBytes = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($path))
 
-        $warnings | Should -Match 'binary'
+        $warnings | Should-MatchString 'binary'
         $result | Should -BeNullOrEmpty
-        $afterBytes | Should -Be $beforeBytes
+        $afterBytes | Should-Be $beforeBytes
     }
 }

--- a/Tests/Unit/Utilities/Sync-Directory.Tests.ps1
+++ b/Tests/Unit/Utilities/Sync-Directory.Tests.ps1
@@ -24,44 +24,44 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
     Context 'Parameter Validation' {
         It 'Should have mandatory Source parameter' {
-            (Get-Command Sync-Directory).Parameters['Source'].Attributes.Mandatory | Should -BeTrue
+            (Get-Command Sync-Directory).Parameters['Source'].Attributes.Mandatory | Should-BeTruthy
         }
 
         It 'Should have mandatory Destination parameter' {
-            (Get-Command Sync-Directory).Parameters['Destination'].Attributes.Mandatory | Should -BeTrue
+            (Get-Command Sync-Directory).Parameters['Destination'].Attributes.Mandatory | Should-BeTruthy
         }
 
         It 'Should have optional Delete switch' {
-            (Get-Command Sync-Directory).Parameters['Delete'].SwitchParameter | Should -BeTrue
+            (Get-Command Sync-Directory).Parameters['Delete'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should have optional DryRun switch' {
-            (Get-Command Sync-Directory).Parameters['DryRun'].SwitchParameter | Should -BeTrue
+            (Get-Command Sync-Directory).Parameters['DryRun'].SwitchParameter | Should-BeTruthy
         }
 
         It 'Should have optional ExcludeFiles parameter' {
-            (Get-Command Sync-Directory).Parameters['ExcludeFiles'].ParameterType | Should -Be ([String[]])
+            (Get-Command Sync-Directory).Parameters['ExcludeFiles'].ParameterType | Should-Be ([String[]])
         }
 
         It 'Should have optional ExcludeDirectories parameter' {
-            (Get-Command Sync-Directory).Parameters['ExcludeDirectories'].ParameterType | Should -Be ([String[]])
+            (Get-Command Sync-Directory).Parameters['ExcludeDirectories'].ParameterType | Should-Be ([String[]])
         }
 
         It 'Should have optional ExtraOptions parameter' {
-            (Get-Command Sync-Directory).Parameters['ExtraOptions'].ParameterType | Should -Be ([String[]])
+            (Get-Command Sync-Directory).Parameters['ExtraOptions'].ParameterType | Should-Be ([String[]])
         }
 
         It 'Should have optional ThreadCount parameter' {
-            (Get-Command Sync-Directory).Parameters['ThreadCount'].ParameterType | Should -Be ([Int32])
+            (Get-Command Sync-Directory).Parameters['ThreadCount'].ParameterType | Should-Be ([Int32])
         }
 
         It 'Should not have legacy Exclude parameter' {
-            (Get-Command Sync-Directory).Parameters.ContainsKey('Exclude') | Should -BeFalse
+            (Get-Command Sync-Directory).Parameters.ContainsKey('Exclude') | Should-BeFalsy
         }
 
         It 'Should support ShouldProcess' {
-            (Get-Command Sync-Directory).Parameters.ContainsKey('WhatIf') | Should -BeTrue
-            (Get-Command Sync-Directory).Parameters.ContainsKey('Confirm') | Should -BeTrue
+            (Get-Command Sync-Directory).Parameters.ContainsKey('WhatIf') | Should-BeTruthy
+            (Get-Command Sync-Directory).Parameters.ContainsKey('Confirm') | Should-BeTruthy
         }
     }
 
@@ -71,7 +71,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
             $TempDest = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
 
             { Sync-Directory -Source $NonExistentPath -Destination $TempDest -ErrorAction Stop } |
-            Should -Throw '*does not exist*'
+            Should-Throw '*does not exist*'
         }
 
         It 'Should accept tilde expansion in paths' {
@@ -90,7 +90,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
                 # Should return a result object
                 $Result | Should -Not -BeNullOrEmpty
-                $Result.Success | Should -BeTrue
+                $Result.Success | Should-BeTruthy
             }
             finally
             {
@@ -107,7 +107,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 New-Item -ItemType Directory -Path $TempPath -Force | Out-Null
 
                 { Sync-Directory -Source $TempPath -Destination $TempPath -DryRun -ErrorAction Stop } |
-                Should -Throw '*same directory*'
+                Should-Throw '*same directory*'
             }
             finally
             {
@@ -124,7 +124,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 New-Item -ItemType Directory -Path $TestSource -Force | Out-Null
 
                 { Sync-Directory -Source $TestSource -Destination $TestDest -DryRun -ErrorAction Stop } |
-                Should -Throw '*Destination cannot be inside source*'
+                Should-Throw '*Destination cannot be inside source*'
             }
             finally
             {
@@ -141,7 +141,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 New-Item -ItemType Directory -Path $TestSource -Force | Out-Null
 
                 { Sync-Directory -Source $TestSource -Destination $TestDest -Delete -DryRun -ErrorAction Stop } |
-                Should -Throw '*Source cannot be inside destination when -Delete is used*'
+                Should-Throw '*Source cannot be inside destination when -Delete is used*'
             }
             finally
             {
@@ -159,7 +159,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 'file destination' | Out-File -FilePath $TestDestFile
 
                 { Sync-Directory -Source $TestSource -Destination $TestDestFile -DryRun -ErrorAction Stop } |
-                Should -Throw '*exists as a file*'
+                Should-Throw '*exists as a file*'
             }
             finally
             {
@@ -183,13 +183,13 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
                 if ($IsWindowsPlatform)
                 {
-                    $Result.Platform | Should -Be 'Windows'
-                    $Result.Command | Should -Match 'robocopy'
+                    $Result.Platform | Should-Be 'Windows'
+                    $Result.Command | Should-MatchString 'robocopy'
                 }
                 else
                 {
-                    $Result.Platform | Should -Be 'macOS/Linux'
-                    $Result.Command | Should -Match 'rsync'
+                    $Result.Platform | Should-Be 'macOS/Linux'
+                    $Result.Command | Should-MatchString 'rsync'
                 }
             }
             finally
@@ -216,13 +216,13 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 $Result = Sync-Directory -Source $TestSource -Destination $TestDest -DryRun
 
                 # DryRun should still succeed
-                $Result.Success | Should -BeTrue
+                $Result.Success | Should-BeTruthy
 
                 # Destination should not be created or should be empty on Windows (robocopy creates dir)
                 if (Test-Path $TestDest)
                 {
                     # If created (robocopy), should be empty
-                    (Get-ChildItem -Path $TestDest -Recurse).Count | Should -Be 0
+                    (Get-ChildItem -Path $TestDest -Recurse).Count | Should-Be 0
                 }
             }
             finally
@@ -245,11 +245,11 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
                 if ($IsWindowsPlatform)
                 {
-                    $Result.Command | Should -Match '/L' # robocopy list-only mode
+                    $Result.Command | Should-MatchString '/L' # robocopy list-only mode
                 }
                 else
                 {
-                    $Result.Command | Should -Match '--dry-run' # rsync dry-run flag
+                    $Result.Command | Should-MatchString '--dry-run' # rsync dry-run flag
                 }
             }
             finally
@@ -270,9 +270,9 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
                 $Result = Sync-Directory -Source $TestSource -Destination $TestDest -WhatIf
 
-                $Result.Success | Should -BeTrue
-                $Result.ExitCode | Should -Be 0
-                $Result.Message | Should -Match 'skipped'
+                $Result.Success | Should-BeTruthy
+                $Result.ExitCode | Should-Be 0
+                $Result.Message | Should-MatchString 'skipped'
             }
             finally
             {
@@ -295,14 +295,14 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 $Result = Sync-Directory -Source $TestSource -Destination $TestDest -DryRun
 
                 $Result | Should -Not -BeNullOrEmpty
-                $Result.PSObject.Properties.Name | Should -Contain 'Platform'
-                $Result.PSObject.Properties.Name | Should -Contain 'Command'
-                $Result.PSObject.Properties.Name | Should -Contain 'ExitCode'
-                $Result.PSObject.Properties.Name | Should -Contain 'Success'
-                $Result.PSObject.Properties.Name | Should -Contain 'Message'
-                $Result.PSObject.Properties.Name | Should -Contain 'StartTime'
-                $Result.PSObject.Properties.Name | Should -Contain 'EndTime'
-                $Result.PSObject.Properties.Name | Should -Contain 'Duration'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'Platform'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'Command'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'ExitCode'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'Success'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'Message'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'StartTime'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'EndTime'
+                $Result.PSObject.Properties.Name | Should-ContainCollection 'Duration'
             }
             finally
             {
@@ -325,7 +325,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 $Result.StartTime | Should -Not -BeNullOrEmpty
                 $Result.EndTime | Should -Not -BeNullOrEmpty
                 $Result.Duration | Should -Not -BeNullOrEmpty
-                $Result.Duration | Should -BeOfType [TimeSpan]
+                $Result.Duration | Should-HaveType ([TimeSpan])
             }
             finally
             {
@@ -350,13 +350,13 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
                 if ($IsWindowsPlatform)
                 {
-                    $Result.Command | Should -Match '/XF'
-                    $Result.Command | Should -Match '\*.log'
+                    $Result.Command | Should-MatchString '/XF'
+                    $Result.Command | Should-MatchString '\*.log'
                 }
                 else
                 {
-                    $Result.Command | Should -Match '--exclude=\*.log'
-                    $Result.Command | Should -Match '--exclude=.git'
+                    $Result.Command | Should-MatchString '--exclude=\*.log'
+                    $Result.Command | Should-MatchString '--exclude=.git'
                 }
             }
             finally
@@ -381,15 +381,15 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
                 if ($IsWindowsPlatform)
                 {
-                    $Result.Command | Should -Match '/XF'
-                    $Result.Command | Should -Match '\*.log'
-                    $Result.Command | Should -Match '/XD'
-                    $Result.Command | Should -Match 'node_modules'
+                    $Result.Command | Should-MatchString '/XF'
+                    $Result.Command | Should-MatchString '\*.log'
+                    $Result.Command | Should-MatchString '/XD'
+                    $Result.Command | Should-MatchString 'node_modules'
                 }
                 else
                 {
-                    $Result.Command | Should -Match '--exclude=\*.log'
-                    $Result.Command | Should -Match '--exclude=node_modules'
+                    $Result.Command | Should-MatchString '--exclude=\*.log'
+                    $Result.Command | Should-MatchString '--exclude=node_modules'
                 }
             }
             finally
@@ -414,11 +414,11 @@ Describe 'Sync-Directory' -Tag 'Unit' {
 
                 if ($IsWindowsPlatform)
                 {
-                    $Result.Command | Should -Match '/MIR'
+                    $Result.Command | Should-MatchString '/MIR'
                 }
                 else
                 {
-                    $Result.Command | Should -Match '--delete'
+                    $Result.Command | Should-MatchString '--delete'
                 }
             }
             finally
@@ -443,15 +443,15 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 {
                     $ExtraOpts = @('/MT:8', '/R:2')
                     $Result = Sync-Directory -Source $TestSource -Destination $TestDest -ExtraOptions $ExtraOpts -DryRun
-                    $Result.Command | Should -Match '/MT:8'
-                    $Result.Command | Should -Match '/R:2'
+                    $Result.Command | Should-MatchString '/MT:8'
+                    $Result.Command | Should-MatchString '/R:2'
                 }
                 else
                 {
                     $ExtraOpts = @('--compress', '--links')
                     $Result = Sync-Directory -Source $TestSource -Destination $TestDest -ExtraOptions $ExtraOpts -DryRun
-                    $Result.Command | Should -Match '--compress'
-                    $Result.Command | Should -Match '--links'
+                    $Result.Command | Should-MatchString '--compress'
+                    $Result.Command | Should-MatchString '--links'
                 }
             }
             finally
@@ -471,7 +471,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 'test' | Out-File (Join-Path -Path $TestSource -ChildPath 'test.txt')
 
                 { Sync-Directory -Source $TestSource -Destination $TestDest -ThreadCount 0 -DryRun -ErrorAction Stop } |
-                Should -Throw
+                Should-Throw
             }
             finally
             {
@@ -496,7 +496,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 'test' | Out-File (Join-Path -Path $TestSource -ChildPath 'test.txt')
 
                 $Result = Sync-Directory -Source $TestSource -Destination $TestDest -ThreadCount 12 -DryRun
-                $Result.Command | Should -Match '/MT:12'
+                $Result.Command | Should-MatchString '/MT:12'
             }
             finally
             {
@@ -526,7 +526,7 @@ Describe 'Sync-Directory' -Tag 'Unit' {
                 }
 
                 $VerboseMessages | Should -Not -BeNullOrEmpty
-                $VerboseMessages -join ' ' | Should -Match 'Starting Sync-Directory'
+                $VerboseMessages -join ' ' | Should-MatchString 'Starting Sync-Directory'
             }
             finally
             {


### PR DESCRIPTION
## Summary

Implements the [Pester v6 Should migration](https://pester.dev/docs/migrations/v5-to-v6).

## Type of Change

- [ ] New function
- [ ] Bug fix
- [ ] Enhancement to existing function
- [x] Tests / CI
- [ ] Documentation

## Checklist

- [x] Follows `Verb-Noun.ps1` naming convention and standard function structure
- [x] Compatible with PowerShell Desktop 5.1 and Core 6.2+
- [x] No Windows-only APIs used (for example `Resolve-DnsName`) unless platform-gated
- [x] Files with Unicode characters are saved as UTF-8 with BOM
- [x] PSScriptAnalyzer passes with zero errors
- [x] Unit/integration tests added or updated
- [x] Tests include `$Global:ProgressPreference = 'SilentlyContinue'` in `BeforeAll`
